### PR TITLE
Expression patterns and neuromeres

### DIFF
--- a/html/conf/vfb.xmi
+++ b/html/conf/vfb.xmi
@@ -98,10 +98,10 @@
         name="NBLAST"/>
     <types xsi:type="gep_1:SimpleType"
         id="Neuromere"
-        name="neuromere"/>
+        name="Neuromere"/>
     <types xsi:type="gep_1:SimpleType"
         id="Expression_pattern"
-        name="expression pattern"/>
+        name="Expression pattern"/>
   </libraries>
   <libraries
       id="vfbLibrary"

--- a/html/conf/vfb.xmi
+++ b/html/conf/vfb.xmi
@@ -96,6 +96,9 @@
     <types xsi:type="gep_1:SimpleType"
         id="NBLAST"
         name="NBLAST"/>
+    <types xsi:type="gep_1:SimpleType"
+        id="Neuromere"
+        name="neuromere"/>
   </libraries>
   <libraries
       id="vfbLibrary"
@@ -537,6 +540,8 @@
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
     <matchingCriteria
+        type="//@libraries.3/@types.1 //@libraries.3/@types.26"/>
+    <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.23"/>
   </queries>
   <queries xsi:type="gep_2:CompoundRefQuery"
@@ -546,6 +551,8 @@
       queryChain="//@dataSources.2/@queries.2 //@dataSources.2/@queries.5 //@dataSources.0/@queries.0">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
+    <matchingCriteria
+        type="//@libraries.3/@types.1 //@libraries.3/@types.26"/>
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.23"/>
   </queries>
@@ -557,6 +564,8 @@
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
     <matchingCriteria
+        type="//@libraries.3/@types.1 //@libraries.3/@types.26"/>
+    <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.23"/>
   </queries>
   <queries xsi:type="gep_2:CompoundRefQuery"
@@ -566,6 +575,8 @@
       queryChain="//@dataSources.2/@queries.4 //@dataSources.2/@queries.5 //@dataSources.0/@queries.0">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
+    <matchingCriteria
+        type="//@libraries.3/@types.1 //@libraries.3/@types.26"/>
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.23"/>
   </queries>

--- a/html/conf/vfb.xmi
+++ b/html/conf/vfb.xmi
@@ -99,6 +99,9 @@
     <types xsi:type="gep_1:SimpleType"
         id="Neuromere"
         name="neuromere"/>
+    <types xsi:type="gep_1:SimpleType"
+        id="Expression_pattern"
+        name="expression pattern"/>
   </libraries>
   <libraries
       id="vfbLibrary"
@@ -433,10 +436,19 @@
           type="//@libraries.3/@types.5 //@libraries.3/@types.1"/>
     </queries>
     <queries
+        xsi:type="gep_2:SimpleQuery"
+        id="Owlery_individual_parts"
+        name="Owlery individual parts"
+        description="Find individuals that are part of some X (useful for finding expression pattern parts)."
+        returnType="//@libraries.3/@types.0"
+        query="object=%3Chttp://purl.obolibrary.org/obo/BFO_0000050%3E%20some%20%3Chttp://purl.obolibrary.org/obo/$ID%3E&amp;direct=false&amp;includeDeprecated=false"
+        countQuery=""/>
+    <queries
         xsi:type="gep_2:ProcessQuery"
         id="owlPassIdListOnlyInstances"
         name="Owlery Pass id list only Instances"
         description="Keep nothing slimply pass ids"
+        returnType="//@libraries.3/@types.0"
         queryProcessorId="owleryIdOnlyQueryProcessor"/>
   </dataSources>
   <dataSources
@@ -515,7 +527,7 @@
       name="Images of neurons with some part here"
       description="Images of neurons with some part in $NAME"
       returnType="//@libraries.3/@types.2"
-      queryChain="//@dataSources.3/@queries.1 //@dataSources.3/@queries.2 //@dataSources.0/@queries.1">
+      queryChain="//@dataSources.3/@queries.1 //@dataSources.3/@queries.3 //@dataSources.0/@queries.1">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
     <matchingCriteria
@@ -526,7 +538,7 @@
       name="Images of neurons with some part here (clustered)"
       description="Images of neurons with some part in $NAME (clustered)"
       returnType="//@libraries.3/@types.22"
-      queryChain="//@dataSources.3/@queries.0 //@dataSources.3/@queries.2 //@dataSources.0/@queries.1">
+      queryChain="//@dataSources.3/@queries.0 //@dataSources.3/@queries.3 //@dataSources.0/@queries.1">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.5"/>
     <matchingCriteria
@@ -544,6 +556,10 @@
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.23"/>
   </queries>
+  <queries xsi:type="gep_2:CompoundRefQuery"
+      id="epFrag"
+      name="Images of expression pattern fragments"
+      description="Images of fragments of $NAME"/>
   <queries xsi:type="gep_2:CompoundRefQuery"
       id="neuronssynaptic"
       name="Neurons Synaptic"


### PR DESCRIPTION
Two distinct edits in this branch

1.  Add overlaps/synaptic terminals queries for neuromeres (Needed for VNS). 
2.  Add queries for images of expression pattern fragments to expression pattern nodes.  I have modelled this on existing image queries. 

(See commits for links to relevant tickets).