### PR TITLE
Update contributors.md

### DIFF
--- a/content/en/about/contributors.md
+++ b/content/en/about/contributors.md
@@ -10,7 +10,8 @@ We would like to thank the following contributors for their help with this proje
 
 <style>
 img {
-  max-width: 100px !important;
+  width: 100px !important;
+  height: 100px ! important;
 }
 </style>
 


### PR DESCRIPTION
profile images smaller than 100px width mess up the grid. If we force 100x100 px it should work? (assuming images are all square)