### PR TITLE
Fix invalid YAML front matter for terms with no tags

### DIFF
--- a/vfbterms.py
+++ b/vfbterms.py
@@ -497,11 +497,14 @@ def generate_page(term_data):
     url_slug = get_term_url(name, term_id)
 
     # Tags for front matter
-    tags_csv = ",".join(tags)
+    # Build a clean list and drop empties, otherwise a term with no Tags
+    # yields a leading comma (e.g. "[,VFB]") which is invalid YAML flow syntax
+    tag_list = list(tags)
     if "_" in term_id:
-        tags_csv += "," + term_id.split("_")[0]
+        tag_list.append(term_id.split("_")[0])
     elif term_id.startswith("FB"):
-        tags_csv += "," + term_id[0:4]
+        tag_list.append(term_id[0:4])
+    tags_csv = ",".join(t for t in tag_list if t)
 
     # Thumbnails
     thumbnails = get_thumbnails(term_data)


### PR DESCRIPTION
A term with an empty `Tags` list still had its ID-prefix tag appended onto an empty CSV string in `vfbterms.py`, producing `tags: [,VFB]`. The leading comma is an empty flow-sequence node, which go-yaml rejects ("did not find expected node content"), failing the Hugo build on `VFB_00017893_v8.md`.

Fix: build the tag list properly and drop empty entries before joining, so a leading/trailing comma can't be emitted for any input.

**Note for deploy:** existing `*_v8.md` already present in the build workspace are not regenerated by `save_terms` (it skips files that exist until the version bumps), so they must be swept separately:

```
grep -rlZ '^tags: \[,' --include='*_v8.md' content/en/blog/ontologies/ | xargs -0 sed -i 's/^tags: \[,/tags: [/'
```