### PR TITLE
Add a verified reference on Drosophila neuron counts, as page and as data

### DIFF
--- a/content/en/docs/Concepts/neuron-counts.md
+++ b/content/en/docs/Concepts/neuron-counts.md
@@ -1,0 +1,301 @@
+---
+title: "How many neurons are in the fly brain?"
+linkTitle: "Neuron counts"
+categories: ["overview","help"]
+tag: ["Connectome", "Neuron", "Counts", "FlyWire", "Hemibrain", "MANC", "BANC", "Optic lobe", "Larva"]
+description: >
+  Why there is no single neuron count for Drosophila, what each connectome
+  actually counted, and how to quote a figure defensibly.
+---
+
+*Every figure on this page was checked against its primary paper. Where a figure could
+not be verified from the original, it is marked. The machine-readable version of this
+page is published at [/data/fly-neuron-counts.json](/data/fly-neuron-counts.json).*
+
+## The short answer
+
+There isn't one number, and the reason is not evasion. Three things have to be pinned down before the
+question has an answer at all:
+
+**Which nervous system.** "Fly brain" can mean the cephalic brain alone, the brain plus the ventral
+nerve cord (the whole central nervous system), or a subset such as the central brain without the optic
+lobes. Published figures use all of these boundaries and rarely say which in the headline.
+
+**Which animal.** Every modern count comes from a connectome, and a connectome is one individual —
+one sex, one developmental stage, one specimen, at one moment in its life. None is a species average.
+
+**Counted how.** What a dataset calls a neuron is a decision recorded in its methods: whether
+boundary-truncated fragments count, whether unproofread segments count, whether glia are separated,
+and where proofreading was stopped. These decisions move the total by tens of thousands.
+
+If you need one number to quote and you must have one, the best-supported single figure for a whole
+adult brain is **139,255 neurons** (Dorkenwald et al. 2024) — an adult female, both optic lobes
+included, ventral nerve cord excluded. Everything below is why that sentence needs all of its
+qualifiers.
+
+---
+
+## 1. The connectome answers
+
+These are the datasets Virtual Fly Brain holds. Each row is one animal.
+
+| Dataset | Neurons | Scope | Specimen | Primary source |
+|---|---|---|---|---|
+| **FlyWire** (FAFB) | **139,255** | Whole brain, both optic lobes included. VNC excluded | Adult **female**, ssTEM | Dorkenwald et al. 2024, *Nature* 634:124–138 · PMID 39358518 · doi:10.1038/s41586-024-07558-y |
+| **Male CNS** v0.9 | **166,691** | **Whole CNS** — central brain + optic lobes + VNC, intact neck connective | Adult **male**, eFIB-SEM | Berg et al. 2025, bioRxiv · doi:10.1101/2025.10.09.680999 · **preprint** |
+| **BANC** v626 | **155,916** | Brain + VNC in one animal. **Lamina and ocellar ganglion absent** (~9,390 lamina neurons missing) | Adult **female**, ssTEM (GridTape) | Bates et al. 2026, *Nature* · PMID 42259917 · doi:10.1038/s41586-026-10735-w |
+| **Optic lobe** v1.0.1 | **~53,000** (732 cell types) | **Right optic lobe only.** Lamina incomplete; central brain not proofread | Adult **male**, FIB-SEM | Nern et al. 2025, *Nature* 641:1225–1237 · PMID 40140576 |
+| **MANC** v1.2.1 | **~23,000** ("roughly 23 thousand") | **Ventral nerve cord only**, plus the neck connective | 5-day **male**, FIB-SEM | Takemura et al. 2024, *eLife* 13:RP97769 · **reviewed preprint, no version of record, no PMID** |
+| **Hemibrain** v1.2.1 | **~25,000** | **A portion of the central brain** — see §2 | 5-day **female** Canton S, FIB-SEM | Scheffer et al. 2020, *eLife* 9:e57443 · PMID 32880371 |
+| **L1 CNS** | **3,016** | **Larval brain only**, inside a whole-CNS EM volume | 6-hour-old **female** first instar | Winding et al. 2023, *Science* 379:eadd9330 |
+| **FAFB** (CATMAID) | — | An EM *volume*, not a proofread census. FlyWire is the reconstruction of it | Adult female | Zheng et al. 2018, *Cell* 174:730 |
+
+### Two of these rows are the same fly
+
+The optic lobe connectome was traced from part of the male CNS volume, and the male CNS paper
+describes itself as extending the right optic lobe connectome. **Nern et al.'s ~53,000 optic lobe
+neurons are a subset of Berg et al.'s 166,691, not an addition to them.** That also explains why the
+optic lobe specimen is male. Adding the two would double-count one animal's visual system.
+
+### Aligned images are not neurons — the counts prove it
+
+It is tempting to use VFB's own `DatasetImages` count as a quick neuron proxy, since in a connectome
+dataset each reconstructed neuron has an image. It does not work, and the failure is not a constant
+factor that could be corrected for:
+
+| Dataset | VFB `DatasetImages` | Neurons per paper | Ratio |
+|---|---|---|---|
+| FlyWire | 208,210 | 139,255 | 1.50 |
+| Hemibrain v1.2.1 | 69,578 | ~25,000 | 2.78 |
+| Optic lobe v1.0.1 | 60,002 | ~53,000 | 1.13 |
+| Male CNS v0.9 | 315,430 | 166,691 | 1.89 |
+| **BANC v626** | **143,806** | **155,916** | **0.92** |
+
+The ratio ranges from 0.92 to 2.78 — and BANC has *fewer* images than the paper reports neurons, so
+the error does not even run in a consistent direction. Neurons are aligned to multiple template brains
+(one neuron can appear as several images), while other neurons in a release may have no aligned image
+at all. **An image count is a count of images.**
+
+One practical note for anyone querying this: `get_term_info` reports `count: -1` for `DatasetImages`,
+which is the unavailable sentinel and not zero. The real totals only come back from `run_query`.
+
+### Three consequences
+
+**Adding a brain count to a VNC count is not a CNS count.** FlyWire (139,255) is a female brain; MANC
+(~23,000) is a male VNC. Summing them produces a number for an animal that does not exist. If you want
+a whole-CNS figure from one animal, the male CNS dataset (166,691) and BANC (155,916) are the datasets
+that provide it — and they disagree by about 11,000, in different sexes, with BANC missing its lamina.
+
+**The larval figure is a different order of magnitude and a different structure.** 3,016 is the larval
+*brain*; the ventral nerve cord of that animal was imaged but not reconstructed as part of that count.
+
+**Two of the six adult figures are preprints.** The male CNS paper and MANC have no peer-reviewed
+version of record. That does not make them wrong; it does mean a submitted manuscript should say so.
+
+---
+
+## 2. The hemibrain is not a brain
+
+This is the most commonly misused number in the field, and the misuse is understandable: "~25,000
+neurons in the fly brain" is a memorable sentence and the hemibrain paper is the most-cited source of
+it. But the hemibrain is roughly half a cephalic brain — slightly over half, and irregularly so.
+
+Scheffer et al. describe the volume as a portion of the central brain: most of the right hemisphere,
+excluding the optic lobe, the periesophageal neuropils and the gnathal ganglia, plus part of the left
+hemisphere. They quantify it — about 36% of all synaptic neuropil by volume, and 54% of the central
+brain neuropils. The lamina is not in the volume at all. Many regions appear only fractionally, which
+is why the paper reports a per-region inclusion percentage rather than a simple region list.
+
+So ~25,000 is the count of reconstructed bodies in a bit over half of one hemisphere's central brain,
+in a volume with no optic lobe and no ventral nerve cord, with an arbitrary cut through the left side.
+It is not half of 139,255, and it should never be scaled up to estimate a whole brain.
+
+The paper is also explicit that its own inclusion criterion is soft. Neurons are classed as traced,
+uncropped or cropped depending on how much of the cell is inside the volume, the authors note the
+cropped definition is somewhat subjective, and they record that some small fragments are known to be
+distinct neurons. "≈25K" is the authors' own simplification, and they say so.
+
+---
+
+## 3. What the connectomes do not tell you
+
+### Dense and sparse reconstruction
+
+The distinction matters for what a count means, and the clearest definition in the fly literature is
+in the hemibrain paper: earlier work was either *dense* in small volumes or *sparse* in large ones. A
+dense reconstruction attempts every object in the volume; a sparse one traces selected neurons of
+interest through it.
+
+Worth noting for anyone comparing datasets: Scheffer et al. classify Zheng et al. 2018 — the FAFB
+volume — as sparse. FlyWire is the dense proofreading of that volume, carried out later. Hemibrain,
+MANC and the larval L1 brain describe their own reconstructions as dense. FlyWire's papers do not use
+the dense/sparse vocabulary about themselves at all, so attributing a "dense reconstruction"
+self-description to Dorkenwald et al. would be putting words in their mouths.
+
+### Flood-filling and automated segmentation still miss things
+
+The Janelia datasets use flood-filling networks; FlyWire uses a different automated segmentation
+followed by proofreading. Both leave residue, and the papers quantify it.
+
+Hemibrain reports its automated segmentation performance before human proofreading: the base
+segmentation achieved an expected run length of 163 µm at a 0.25% false-merge rate, and aggressive
+agglomeration raised run length to 585 µm at a **27.6% false-merge rate**. That figure is
+pre-proofreading — quoting it as a residual error rate would be wrong — but it shows the scale of what
+human proofreading is there to repair.
+
+The stopping point is explicitly resource-bounded. Scheffer et al. record that proofreading every
+small segment was prohibitive, that they aimed for a basic level of completeness with extra effort in
+regions of biological interest, and that the final pass was done to reach the highest completeness
+achievable *in the time allotted*.
+
+The most telling numbers are the synapse attachment rates. In FlyWire's published whole brain, about
+93.7% of presynapses are attached to a neuron — but only about **44.7% of postsynapses**, because
+postsynapses sit predominantly on fine twigs that received less proofreading. In the larval brain,
+reconstructed manually rather than automatically, more than 99% of neurons were traced to completion
+but only 75% of annotated synaptic sites could be linked to a neuron, the remainder being mostly small
+dendritic fragments.
+
+Two very different methods, the same failure mode: thin distal neurites are where completeness goes.
+
+### Counts move between versions — sometimes by a lot
+
+This is the single most useful thing to know when quoting any connectome figure.
+
+- **FlyWire's own count changed by more than 11,000 between preprint and publication** — 127,978 in the
+  bioRxiv version, 139,255 in *Nature*. Same authors, same dataset, more proofreading. (The preprint
+  notes a public release missing roughly 8,000 retinula cells.)
+- **Shiu et al.'s model, built on FlyWire materialisation v630, used 127,400 neurons** — the same brain,
+  a different materialisation, ~12,000 fewer neurons.
+- **BANC's preprint reports 142,719 proofread neurons at v821; the *Nature* version reports 155,916**
+  proofread plus roughly-proofread. The paper's analyses are performed on v626 — the version VFB holds
+  — but no neuron total is ever published for v626 specifically.
+- **The optic lobe cell-type count went from 727 to 732** between preprint (v1.0) and version of record
+  (v1.1). VFB holds v1.0.1, which neither citation documents.
+- **MANC's companion papers disagree with each other** by a handful of neurons per class, and Marin et
+  al. warn that annotations changed substantially between v1.0 and v1.2.1.
+
+A neuron count from a connectome is a property of a *release*, not of a fly.
+
+### One animal, and what stereotypy does and does not buy you
+
+Both major groups address this directly, and neither is complacent.
+
+Scheffer et al. argue the single-animal design is a feature as well as a limit — circuitry depends on
+nutritional history, age and circadian phase, and a single animal holds those constant — while
+acknowledging that establishing stereotypy will eventually require more connectomes.
+
+Dorkenwald et al. argue that variability between individuals and reconstruction noise are both modest
+enough that a single wiring diagram is useful for wild-type flies generally, while flagging known
+sex differences and high variability in mushroom body principal neurons.
+
+The FlyWire companion paper (Schlegel et al. 2024) tests this quantitatively, and the result is
+sobering. Comparing FlyWire and hemibrain hemispheres, over half the connectome graph's edges are not
+reproducible between brains; the edges that survive a strong-connection criterion are 7–16% of edges
+but 50–70% of synapses. Cell *numbers* per type are much more stable — a mean difference of 0.3 cells
+within a brain and 0.7 across brains — with a striking exception: Kenyon cells are about 30% more
+numerous per hemisphere in FlyWire than in hemibrain. Their recommendation is three or more hemispheres
+before defining a cell type.
+
+For counting purposes the encouraging finding is that cell numbers are among the *more* stereotyped
+properties. The caution is that the exception is a well-studied, functionally central cell class.
+
+---
+
+## 4. What people said before connectomics
+
+This is where the article gets uncomfortable, because the most-quoted number has no source.
+
+### "About 100,000 neurons" — no primary measurement found
+
+We could not trace this figure to any original measurement. It appears without citation in the papers
+that popularised it, including work from the FlyCircuit group (Lee et al. 2012, *PLoS Comput Biol*
+8:e1002658), in the FAFB paper's abstract (Zheng et al. 2018), and in the hemibrain paper's lay
+summary. Where a modern paper does attach citations to a range, they resolve to reviews or to
+measurements that give different numbers: Jiao et al. 2022 cite a 100,000–199,000 range to five
+sources, of which only one is an actual measurement — and it reports 199,000.
+
+The honest description is that ~100,000 is an order-of-magnitude convention that became canonical by
+repetition. It is not wrong so much as unsourced.
+
+### The three real non-connectome measurements disagree by 2.5×
+
+| Figure | Method | Source |
+|---|---|---|
+| ~88,300 cells (~92,500 by confocal) | Isotropic fractionator | Godfrey et al. 2021, *Proc R Soc B* 288:20210199 ⚠️ **unverified — see below** |
+| 133,000 ± 3,000 nuclei, of which ≥87% neurons | CNN nuclear segmentation of the FAFB volume | Mu et al. 2021, bioRxiv 2021.11.04.467197 — **still a preprint** |
+| 217,000 ± 4,000 cells; **199,380 ± 3,400 neurons** | Isotropic fractionator with elav/repo immunostaining | Raji & Potter 2021, *PLoS ONE* 16:e0250381 |
+
+Two studies using nominally the same technique — isotropic fractionation — differ by a factor of about
+2.5. That is arguably the most interesting fact in the pre-connectome literature, and it is rarely
+mentioned. Mu et al. observe that their nuclear count lands within 3% of the geometric mean of the two.
+
+Raji & Potter's figure is brain only (optic lobes plus central brain, VNC excluded), which matters
+because it is frequently misquoted as a CNS number. They also report the glia fraction directly:
+neurons are 91.8% of brain cells, with roughly 18,000 non-neuronal cells.
+
+Note what this means against the connectome answer: **199,380 (isotropic fractionator, brain) versus
+139,255 (FlyWire, brain)** — a 43% discrepancy between the two best-documented adult brain figures,
+using entirely different methods on different animals. Neither is obviously wrong. This is an open
+question, not a settled one.
+
+⚠️ **Verification gap.** The Godfrey et al. figures above are quoted from Mu et al. citing them; the
+original was not retrievable in this session (publisher and repository blocks). Verify against the
+original before publishing.
+
+### Glia are not a rounding error
+
+The conventional "glia ≈ 10% of neurons" holds up for the adult brain (Raji & Potter: 8.2% of cells).
+It does not hold in the larva: Jiao et al. 2022 (*eLife* 11:e74968), counting nuclei in intact
+third-instar CNS by light-sheet microscopy, report glia at about 37% of neuron number — roughly four
+times the received figure — alongside 10,312 neurons in the female third-instar CNS and 9,396 in the
+male, a sexual dimorphism in cell number at the larval stage.
+
+---
+
+## 5. How to answer the question properly
+
+If someone asks how many neurons are in the fly brain, a good answer does four things.
+
+1. **Names the scope.** Brain or CNS; adult or larva; with or without optic lobes.
+2. **Names the animal.** One specimen, its sex, its stage.
+3. **Names the release.** A connectome count belongs to a version, not to a species.
+4. **Points at the methods.** The inclusion rules are in the paper, and they are where the number
+   actually comes from.
+
+And it keeps two kinds of number strictly apart:
+
+- **A biological count** from a connectome or a cell-counting study — a property of one animal,
+  measured a particular way.
+- **A Virtual Fly Brain annotation count** — for example, 15,214 neuron *types* with some part in the
+  adult central nervous system. This is a curated count over an ontology spanning many datasets, sexes
+  and stages. It is not a census of cells in any animal, and it must never be added to or compared with
+  the figures above.
+
+---
+
+## Sources
+
+**Connectomes**
+
+- Dorkenwald S et al. (2024) Neuronal wiring diagram of an adult brain. *Nature* 634(8032):124–138. PMID 39358518. doi:10.1038/s41586-024-07558-y
+- Schlegel P et al. (2024) Whole-brain annotation and multi-connectome cell typing of *Drosophila*. *Nature*. doi:10.1038/s41586-024-07686-5
+- Scheffer LK et al. (2020) A connectome and analysis of the adult *Drosophila* central brain. *eLife* 9:e57443. PMID 32880371. doi:10.7554/eLife.57443
+- Nern A et al. (2025) Connectome-driven neural inventory of a complete visual system. *Nature* 641(8065):1225–1237. PMID 40140576. doi:10.1038/s41586-025-08746-0
+- Takemura S et al. (2024) A connectome of the male *Drosophila* ventral nerve cord. *eLife* 13:RP97769. doi:10.7554/eLife.97769.1 — reviewed preprint
+- Marin EC et al. (2024) Systematic annotation of a complete adult male *Drosophila* nerve cord connectome. *eLife* 13:RP97766. doi:10.7554/eLife.97766.1 — reviewed preprint
+- Berg S et al. (2025) Sexual dimorphism in the complete connectome of the *Drosophila* male central nervous system. bioRxiv. doi:10.1101/2025.10.09.680999 — preprint
+- Bates AS et al. (2026) Distributed control circuits across a brain-and-cord connectome. *Nature*. PMID 42259917. doi:10.1038/s41586-026-10735-w
+- Winding M et al. (2023) The connectome of an insect brain. *Science* 379(6636):eadd9330
+- Zheng Z et al. (2018) A complete electron microscopy volume of the brain of adult *Drosophila melanogaster*. *Cell* 174(3):730–743
+
+**Cell counting, non-connectome**
+
+- Raji JI, Potter CJ (2021) The number of neurons in *Drosophila* and mosquito brains. *PLoS ONE* 16(5):e0250381. doi:10.1371/journal.pone.0250381
+- Mu S et al. (2021) 3D reconstruction of cell nuclei in a full *Drosophila* brain. bioRxiv 2021.11.04.467197 — preprint
+- Godfrey RK, Swartzlander M, Gronenberg W (2021) *Proc R Soc B* 288(1947):20210199. doi:10.1098/rspb.2021.0199 ⚠️ figures unverified
+- Jiao W et al. (2022) Intact *Drosophila* central nervous system cellular quantitation reveals sexual dimorphism. *eLife* 11:e74968
+- Kremer MC et al. (2017) The glia of the adult *Drosophila* nervous system. *Glia* 65(4):606–638. PMID 28133822 ⚠️ not retrieved
+
+**Miscitation traced in this review**
+
+- Shiu PK et al. (2024) A *Drosophila* computational brain model reveals sensorimotor processing. *Nature*. PMID 39358519. — Describes ">125,000 neurons" as a *central brain* connectome. The number is FlyWire's **whole-brain** count (the paper's own model uses 127,400 neurons from FlyWire v630), and FlyWire reports only 32,388 neurons fully contained in the central brain. The scope label is wrong at source. Cite Dorkenwald et al. directly instead.

--- a/static/data/fly-neuron-counts.json
+++ b/static/data/fly-neuron-counts.json
@@ -1,0 +1,401 @@
+{
+  "$comment": "Curated fundamentals for Drosophila neuron counts. Every figure verified against its primary paper on 2026-08-11 unless verified=false. This is DATA, not chat logic: it is intended to be readable by VFBchat, the VFB2 wrapper site, and the MCP alike. Do not hard-code any of these numbers into application source.",
+  "id": "fly-neuron-counts",
+  "title": "How many neurons are in the fly brain?",
+  "compiled": "2026-08-11",
+  "article": "/docs/concepts/neuron-counts/",
+  "review_status": "draft-for-curator-review",
+  "answer_rules": [
+    "There is no single species-level neuron count. Do not give one.",
+    "Every count belongs to ONE specimen: state sex, stage and dataset.",
+    "Every connectome count belongs to a RELEASE, not to a fly. State the version.",
+    "Never add a brain count to a VNC count from a different animal.",
+    "The hemibrain is a portion of one hemisphere's central brain, NOT half a brain to be doubled.",
+    "Keep VFB annotation counts strictly separate from biological counts; never add or compare them.",
+    "Point the user at the paper's methods for what was counted as a neuron.",
+    "If asked for 'the' number for a whole adult brain, Dorkenwald et al. 2024 (139,255) is the best-supported single figure, with its qualifiers."
+  ],
+  "disambiguation_prompt": {
+    "trigger": "An unscoped question such as 'how many neurons are in the fly brain?'",
+    "ask": "Which do you mean?",
+    "options": [
+      {
+        "label": "Whole adult brain (cephalic, both optic lobes)",
+        "resolves_to": "flywire"
+      },
+      {
+        "label": "Whole adult CNS (brain + ventral nerve cord)",
+        "resolves_to": [
+          "male_cns",
+          "banc"
+        ]
+      },
+      {
+        "label": "Adult central brain only (no optic lobes)",
+        "resolves_to": "flywire_central_brain_subcount"
+      },
+      {
+        "label": "Ventral nerve cord only",
+        "resolves_to": "manc"
+      },
+      {
+        "label": "Larval CNS",
+        "resolves_to": "l1_brain"
+      },
+      {
+        "label": "What VFB has annotated (not a biological count)",
+        "resolves_to": "vfb_annotation"
+      }
+    ]
+  },
+  "connectomes": [
+    {
+      "key": "flywire",
+      "vfb_dataset": "Dorkenwald2023",
+      "vfb_label": "FlyWire connectome neurons",
+      "neurons": 139255,
+      "exact": true,
+      "verified": true,
+      "scope": "Whole adult brain, both optic lobes and ocellar ganglia included. Ventral nerve cord NOT included; neurons crossing the neck connective are truncated at the brain boundary.",
+      "specimen": {
+        "sex": "female",
+        "stage": "adult",
+        "n": 1,
+        "technique": "serial-section TEM",
+        "volume": "FAFB (Zheng et al. 2018)"
+      },
+      "version": "v783",
+      "subcounts": {
+        "intrinsic_to_brain": 118501,
+        "fully_in_central_brain": 32388,
+        "fully_in_optic_lobes_and_ocellar_ganglia": 77536,
+        "visual_projection_neurons": 8053,
+        "central_brain_to_optic_lobe": 524,
+        "non_visual_sensory": 5375,
+        "photoreceptors_compound_eye": 11118,
+        "photoreceptors_ocelli": 273,
+        "descending_through_neck": 1303,
+        "ascending_through_neck": 2362,
+        "motor_neurons": 106
+      },
+      "counting_notes": "Count is of PROOFREAD neurons. Glia excluded; the paper estimates 13% of cell bodies in the volume are non-neuronal or glial. Afferent neurons with somata outside the brain ARE included.",
+      "version_drift": "bioRxiv preprint reported 127,978. Published Nature figure is 139,255 — same dataset, more proofreading. Shiu et al.'s model used 127,400 from materialisation v630.",
+      "completeness": "~93.7% of presynapses attached to a neuron; only ~44.7% of postsynapses attached.",
+      "citation": "Dorkenwald S et al. (2024) Nature 634(8032):124-138",
+      "pmid": "39358518",
+      "doi": "10.1038/s41586-024-07558-y",
+      "peer_reviewed": true,
+      "vfb_dataset_images_count": 208210,
+      "$images_warning": "DatasetImages is a count of ALIGNED IMAGES, not neurons. Never use as a neuron proxy."
+    },
+    {
+      "key": "male_cns",
+      "vfb_dataset": "Berg2025",
+      "vfb_label": "Male CNS version 0.9 connectome neurons",
+      "neurons": 166691,
+      "exact": true,
+      "verified": true,
+      "scope": "WHOLE CNS: central brain + optic lobes + ventral nerve cord, one continuous volume with intact neck connective. Sensory axons included.",
+      "specimen": {
+        "sex": "male",
+        "stage": "adult",
+        "n": 1,
+        "technique": "eFIB-SEM, 8x8x8 nm isotropic"
+      },
+      "version": "VFB holds v0.9; Janelia has since released v1.0 (2026-06-08) with further proofreading.",
+      "subcounts": {
+        "connectome_graph_neurons": 166391,
+        "neuron_associated_nuclei": 141780,
+        "cell_types": 11691
+      },
+      "counting_notes": "All segmentation fragments with >100 synaptic connections were proofread. Whether glia are excluded is not stated in the preprint main text.",
+      "version_drift": "The paper states no version number. 166,691 is the preprint figure and must NOT be presented as a v0.9-specific or v1.0 number.",
+      "completeness": "94% presynaptic / 42% postsynaptic completion in neuropils; 40.1% of connections have both partners proofread.",
+      "citation": "Berg S et al. (2025) bioRxiv",
+      "doi": "10.1101/2025.10.09.680999",
+      "peer_reviewed": false,
+      "caution": "Preprint. No peer-reviewed version of record as of 2026-08-11. The optic lobe connectome (Nern et al.) is part of this same volume; do not add the two.",
+      "vfb_dataset_images_count": 315430,
+      "$images_warning": "DatasetImages is a count of ALIGNED IMAGES, not neurons. Never use as a neuron proxy.",
+      "same_animal_as": "optic_lobe"
+    },
+    {
+      "key": "banc",
+      "vfb_dataset": "Bates2025",
+      "vfb_label": "Brain and Nerve Cord (BANC) version 626 connectome neurons",
+      "neurons": 155916,
+      "exact": true,
+      "verified": true,
+      "scope": "Brain + ventral nerve cord from ONE animal. NOT a complete CNS: the lamina and ocellar ganglion are absent, so ~9,390 lamina neurons (R1-R6 photoreceptors and Lai) are missing.",
+      "specimen": {
+        "sex": "female",
+        "stage": "adult",
+        "n": 1,
+        "technique": "serial-section TEM via GridTape, 4x4x45 nm"
+      },
+      "version": "VFB holds v626. The paper's analyses use v626, but it publishes NO neuron total labelled v626.",
+      "subcounts": {
+        "ascending_neurons": 1839,
+        "descending_neurons": 1313,
+        "cell_type_labelled": 147846
+      },
+      "counting_notes": "155,916 = proofread + 'roughly proofread' neurons. Excludes glia, trachea, and fragments too small to cell-type. Preprint reports 142,719 PROOFREAD-only neurons at v821.",
+      "version_drift": "Preprint (v821): 142,719 proofread. Nature: 155,916 proofread + roughly proofread, no version label.",
+      "completeness": "72% of presynaptic and 23% of postsynaptic links attached to identified cells; 17% of synapses identified on both sides.",
+      "citation": "Bates AS et al. (2026) Nature",
+      "pmid": "42259917",
+      "doi": "10.1038/s41586-026-10735-w",
+      "peer_reviewed": true,
+      "caution": "VFB labels this 'Bates et al. (2025)', which is the preprint. The version of record is 2026 and its figures differ.",
+      "vfb_dataset_images_count": 143806,
+      "$images_warning": "DatasetImages is a count of ALIGNED IMAGES, not neurons. Never use as a neuron proxy."
+    },
+    {
+      "key": "optic_lobe",
+      "vfb_dataset": "Nern2024",
+      "vfb_label": "Optic Lobe connectome neurons from optic_lobe:v1.0.1",
+      "neurons": 53000,
+      "exact": false,
+      "verified": true,
+      "scope": "RIGHT OPTIC LOBE ONLY. All optic lobe neuropils complete EXCEPT the lamina. Central brain not proofread.",
+      "specimen": {
+        "sex": "male",
+        "stage": "adult",
+        "n": 1,
+        "technique": "FIB-SEM"
+      },
+      "version": "VFB holds optic_lobe:v1.0.1 — documented by NEITHER the preprint (v1.0) nor the version of record (v1.1).",
+      "subcounts": {
+        "cell_types_version_of_record": 732,
+        "cell_types_preprint": 727,
+        "visual_projection_neurons": 4500,
+        "vpn_types": 352
+      },
+      "counting_notes": "No exact total is stated; the paper says 'approximately 53,000' throughout. Undercounts an estimated 2,777 lamina cells and 459 R7/R8 photoreceptors.",
+      "version_drift": "Cell types went 727 (preprint, v1.0) to 732 (version of record, v1.1).",
+      "citation": "Nern A et al. (2025) Nature 641(8065):1225-1237",
+      "pmid": "40140576",
+      "doi": "10.1038/s41586-025-08746-0",
+      "peer_reviewed": true,
+      "caution": "VFB labels this 'Nern et al., 2024', which is the preprint year; the version of record is 2025. TRACED FROM PART OF THE MALE CNS EM VOLUME - the same animal as Berg et al. ~53,000 is a SUBSET of the male CNS 166,691, never an addition to it.",
+      "vfb_dataset_images_count": 60002,
+      "$images_warning": "DatasetImages is a count of ALIGNED IMAGES, not neurons. Never use as a neuron proxy.",
+      "same_animal_as": "male_cns"
+    },
+    {
+      "key": "manc",
+      "vfb_dataset": null,
+      "vfb_label": "Neuprint web interface - MANC:v1.2.1",
+      "neurons": 23000,
+      "exact": false,
+      "verified": true,
+      "scope": "VENTRAL NERVE CORD ONLY, plus the neck connective. Brain was dissected with the sample but not imaged.",
+      "specimen": {
+        "sex": "male",
+        "stage": "adult, 5 days post-eclosion",
+        "n": 1,
+        "technique": "FIB-SEM"
+      },
+      "version": "v1.2.1",
+      "subcounts": {
+        "intrinsic": 13060,
+        "sensory": 5927,
+        "ascending": 1865,
+        "descending": 1328,
+        "motor": 737,
+        "sensory_ascending": 535,
+        "efferent": 93,
+        "efferent_ascending": 8,
+        "$note": "From Marin et al. (v1.2.1-aligned). Companion papers disagree by a handful per class."
+      },
+      "counting_notes": "Primary paper states only 'roughly 23 thousand traced neurons'. Any exact integer must be sourced to Marin et al. or the live neuPrint release, NOT to Takemura et al. Glia not systematically reconstructed.",
+      "version_drift": "Annotations changed substantially between manc:v1.0 and manc:v1.2.1.",
+      "citation": "Takemura S et al. (2024) eLife 13:RP97769",
+      "doi": "10.7554/eLife.97769.1",
+      "peer_reviewed": false,
+      "caution": "Reviewed preprint. No version of record and no PMID as of 2026-08-11."
+    },
+    {
+      "key": "hemibrain",
+      "vfb_dataset": "Xu2020NeuronsV1point2point1",
+      "vfb_label": "JRC_FlyEM_Hemibrain neurons Version 1.2.1",
+      "neurons": 25000,
+      "exact": false,
+      "verified": true,
+      "scope": "A PORTION OF THE CENTRAL BRAIN — roughly half a cephalic brain, slightly over and irregularly so. Most of the right hemisphere excluding optic lobe, periesophageal neuropils and gnathal ganglia, plus part of the left. About 36% of all synaptic neuropil by volume and 54% of central brain neuropils. Lamina absent. No ventral nerve cord.",
+      "specimen": {
+        "sex": "female",
+        "stage": "adult, 5 days old",
+        "strain": "Canton S G1 x w1118",
+        "n": 1,
+        "technique": "FIB-SEM"
+      },
+      "version": "VFB holds v1.2.1; the paper describes v1.1 and predates v1.2.1.",
+      "counting_notes": "Neurons classed traced / uncropped / cropped by how much of the cell is in the volume. The authors call the cropped definition subjective and note some small fragments are known to be distinct neurons. '~25K' is the authors' own simplification. No numeric size or synapse threshold is stated.",
+      "citation": "Scheffer LK et al. (2020) eLife 9:e57443",
+      "pmid": "32880371",
+      "doi": "10.7554/eLife.57443",
+      "peer_reviewed": true,
+      "caution": "MOST MISUSED FIGURE IN THE FIELD. Never present ~25,000 as a whole-brain count and never double it to estimate one.",
+      "vfb_dataset_images_count": 69578,
+      "$images_warning": "DatasetImages is a count of ALIGNED IMAGES, not neurons. Never use as a neuron proxy."
+    },
+    {
+      "key": "l1_brain",
+      "vfb_dataset": null,
+      "vfb_label": "VFB CATMAID L1 CNS",
+      "neurons": 3016,
+      "exact": true,
+      "verified": true,
+      "scope": "LARVAL BRAIN ONLY, reconstructed inside a whole-CNS EM volume. VNC and SEZ neurons were not reconstructed; ascending neurons enter as input axons.",
+      "specimen": {
+        "sex": "female",
+        "stage": "first instar, 6 hours old",
+        "strain": "Canton S G1[iso] x w1118[iso] 5905",
+        "n": 1,
+        "technique": "EM, 4841 sections at 3.8x3.8x50 nm"
+      },
+      "subcounts": {
+        "input_neurons": 480,
+        "differentiated_brain_neurons": 2536,
+        "synapses": 548000
+      },
+      "counting_notes": "Complete census by seeding every brain cell body. >99% of neurons reconstructed to completion; 75% of annotated synaptic sites linked to a neuron.",
+      "version_drift": "bioRxiv preprint reported 3,013 neurons and ~544,000 synapses; published Science figures are 3,016 and ~548,000.",
+      "citation": "Winding M et al. (2023) Science 379(6636):eadd9330",
+      "peer_reviewed": true,
+      "caution": "The paper does not name VFB's l1em dataset; equivalence must be verified against VFB's own dataset record."
+    },
+    {
+      "key": "fafb_volume",
+      "vfb_dataset": null,
+      "vfb_label": "VFB CATMAID Adult Brain (FAFB)",
+      "neurons": null,
+      "verified": true,
+      "scope": "An EM VOLUME, not a proofread neuron census. FlyWire is the dense reconstruction of this volume.",
+      "specimen": {
+        "sex": "female",
+        "stage": "adult",
+        "n": 1,
+        "technique": "serial-section TEM"
+      },
+      "counting_notes": "Do not quote a neuron count for this dataset. Refer to FlyWire.",
+      "citation": "Zheng Z et al. (2018) Cell 174(3):730-743",
+      "peer_reviewed": true
+    }
+  ],
+  "non_connectome_estimates": [
+    {
+      "figure": 199380,
+      "uncertainty": 3400,
+      "unit": "neurons",
+      "scope": "Whole adult brain (optic lobes + central brain). VNC excluded.",
+      "method": "Isotropic fractionator with elav/repo immunostaining",
+      "specimen": "4-6 days post-eclosion, both sexes, no significant sexual dimorphism found",
+      "also": {
+        "total_cells": 217000,
+        "neuron_fraction_percent": 91.8,
+        "non_neuronal_cells": 18000
+      },
+      "citation": "Raji JI, Potter CJ (2021) PLoS ONE 16(5):e0250381",
+      "doi": "10.1371/journal.pone.0250381",
+      "verified": true,
+      "caution": "Frequently misquoted as a CNS figure. It is brain only."
+    },
+    {
+      "figure": 133000,
+      "uncertainty": 3000,
+      "unit": "nuclei",
+      "scope": "Whole adult brain (the FAFB volume)",
+      "method": "CNN nuclear segmentation — a morphological census, not a connectome",
+      "also": {
+        "neuron_fraction_percent_min": 87
+      },
+      "citation": "Mu S et al. (2021) bioRxiv 2021.11.04.467197",
+      "verified": true,
+      "peer_reviewed": false
+    },
+    {
+      "figure": 88300,
+      "unit": "cells",
+      "scope": "Whole adult brain",
+      "method": "Isotropic fractionator (92,500 by confocal imaging)",
+      "citation": "Godfrey RK, Swartzlander M, Gronenberg W (2021) Proc R Soc B 288(1947):20210199",
+      "doi": "10.1098/rspb.2021.0199",
+      "verified": false,
+      "caution": "NOT VERIFIED against the original — figures taken from Mu et al. citing it. Verify before publishing."
+    },
+    {
+      "figure": 100000,
+      "unit": "neurons",
+      "scope": "'The fly brain', unscoped",
+      "method": null,
+      "citation": null,
+      "verified": false,
+      "caution": "NO PRIMARY SOURCE FOUND. Appears uncited in Lee et al. 2012, Zheng et al. 2018 and the Scheffer et al. lay summary. An order-of-magnitude convention that became canonical by repetition. Do not present it as a measurement."
+    },
+    {
+      "figure": 10312,
+      "unit": "neurons",
+      "scope": "Third-instar larval CNS, female (male: 9,396)",
+      "method": "Light-sheet nuclear counting of intact CNS",
+      "also": {
+        "glia_female": 3860,
+        "glia_male": 4015,
+        "glia_as_percent_of_neurons": 37
+      },
+      "citation": "Jiao W et al. (2022) eLife 11:e74968",
+      "verified": true,
+      "caution": "Glia at ~37% of neuron number, roughly 4x the conventional 10% figure."
+    }
+  ],
+  "vfb_annotation_counts": {
+    "$comment": "NOT biological counts. Curated annotation over an ontology spanning many datasets, sexes and stages. Never add to or compare with the figures above.",
+    "adult_central_nervous_system": {
+      "term": "FBbt_00003623",
+      "NeuronsPartHere": 15214,
+      "NeuronsSynaptic": 14077,
+      "NeuronsPresynapticHere": 12153
+    }
+  },
+  "known_miscitations": [
+    {
+      "claim": "The adult Drosophila CENTRAL BRAIN connectome contains more than 125,000 neurons",
+      "cited_to": "Shiu PK et al. (2024) Nature, PMID 39358519",
+      "problem": "The scope label is wrong at source. The number is FlyWire's WHOLE-BRAIN count; Shiu's own model uses 127,400 neurons from FlyWire materialisation v630. FlyWire reports only 32,388 neurons fully contained in the central brain. Shiu et al. performed no reconstruction; the sentence is background citing Dorkenwald et al. and Schlegel et al.",
+      "fix": "Cite Dorkenwald et al. 2024 directly for the whole brain (139,255), or cite Shiu's model explicitly as 127,400 FlyWire v630 neurons."
+    }
+  ],
+  "methodology_notes": {
+    "dense_vs_sparse": "Scheffer et al. define the contrast: earlier work was dense in small volumes or sparse in large ones. They classify Zheng et al. 2018 (FAFB) as SPARSE — FlyWire is the later dense proofreading of that volume. Hemibrain, MANC and the larval L1 brain describe their own reconstructions as dense. FlyWire's papers do not use this vocabulary about themselves.",
+    "flood_filling_limits": "Hemibrain reports pre-proofreading segmentation performance: expected run length 163 um at 0.25% false-merge, rising to 585 um at a 27.6% false-merge rate after aggressive agglomeration. Human proofreading exists to repair this and was explicitly stopped when time ran out.",
+    "orphan_synapses": "FlyWire: ~93.7% of presynapses attached, only ~44.7% of postsynapses. Larval L1 (manual reconstruction): >99% of neurons complete but only 75% of synaptic sites linked. Both methods lose completeness on thin distal neurites.",
+    "one_animal": "Schlegel et al. 2024 found over half of connectome graph edges are not reproducible between FlyWire and hemibrain hemispheres; strong edges are 7-16% of edges but 50-70% of synapses. Cell NUMBERS per type are far more stable (mean difference 0.3 within a brain, 0.7 across brains) — with Kenyon cells a notable exception at ~30% more per hemisphere in FlyWire. They recommend three or more hemispheres before defining a cell type."
+  },
+  "dataset_images_are_not_neurons": {
+    "$comment": "Empirical disproof of the 'aligned images ~= neurons' shortcut, measured 2026-08-11.",
+    "ratios": {
+      "flywire": 1.5,
+      "hemibrain": 2.78,
+      "optic_lobe": 1.13,
+      "male_cns": 1.89,
+      "banc": 0.92
+    },
+    "finding": "Ratio of DatasetImages to published neuron count ranges 0.92-2.78 and does not run in a consistent direction: BANC has FEWER images than neurons. There is no correction factor. Neurons align to multiple templates; some neurons have no aligned image.",
+    "api_note": "get_term_info reports count:-1 for DatasetImages (the 'unavailable' sentinel, NOT zero). Only run_query returns the true totals."
+  },
+  "vfb_kb_metadata_review": {
+    "$comment": "State of VFB knowledge-base dataset records as at 2026-08-11. Curation items, not code items.",
+    "correct": {
+      "Nern2024": "Publications already cites the VERSION OF RECORD (Nern et al., 2025, Nature 641(8065):1225-1237, FBrf0262545, PMID 40140576). Only the dataset id/Name/Description strings still read '2024'. No citation fix needed.",
+      "Dorkenwald2023": "Cites Dorkenwald et al., 2024, Nature 634(8032):124-138, FBrf0260546, PMID 39358518. Correct.",
+      "Xu2020NeuronsV1point2point1": "Cites Scheffer et al., 2020, eLife 9:e57443, FBrf0246888, PMID 32880371. Correct.",
+      "Berg2025": "Cites the bioRxiv preprint, which is correct - no peer-reviewed version exists yet."
+    },
+    "needs_update": {
+      "Bates2025": "Publications cites ONLY the preprint (doi 10.1101/2025.07.31.667571); no FBrf, no PubMed link. The version of record is Nature (2026), PMID 42259917, doi 10.1038/s41586-026-10735-w. The preprint DOI is also embedded in Meta.Description, so both fields need changing.",
+      "Berg2025_technique": "Technique reads 'serial block face SEM (SBFSEM)'. The paper describes enhanced focused ion beam SEM (eFIB-SEM), 8x8x8 nm isotropic. Likely a metadata error."
+    }
+  },
+  "canonical_url": "https://www.virtualflybrain.org/data/fly-neuron-counts.json"
+}


### PR DESCRIPTION
A reviewer asked VFBchat how many neurons are in the fly brain and it could not answer. The resolution bug is fixed separately (VFBchat `fix/neuron-count-resolution-and-sourcing`); this addresses the harder half — the question has no single answer and we had nowhere authoritative to point.

Two artefacts, one source of truth. `content/en/docs/Concepts/neuron-counts.md` is the article: why the question is under-specified, what each connectome VFB holds actually counted, dense versus sparse reconstruction, what flood-filling and proofreading still miss, and what was quoted before connectomics. `static/data/fly-neuron-counts.json` is the same facts machine-readable, published at `/data/fly-neuron-counts.json`, so VFBchat and the MCP can read the figures rather than each hard-coding them.

Every figure was checked against its primary paper. Two that could not be retrieved from the original are flagged `verified: false` rather than quietly included.

Findings worth curator attention:

- **"~100,000 neurons" has no traceable primary measurement.** It appears uncited in the papers that popularised it.
- The three real non-connectome measurements disagree by 2.5x, two of them using the same technique.
- FlyWire's own count moved 127,978 to 139,255 between preprint and *Nature*. A connectome count is a property of a release, not of a fly.
- Nern et al. traced the optic lobe from part of the male CNS volume, so those two datasets are **the same animal** and must never be summed.
- **VFB `DatasetImages` counts are not neuron counts.** The ratio to the published figure runs 0.92 to 2.78 across our five datasets and does not err in a consistent direction, so there is no correction factor. Also note `get_term_info` reports `count: -1` for `DatasetImages` — the unavailable sentinel, not zero. Only `run_query` returns the real totals.

Two knowledge-base curation items are recorded in the JSON: `Bates2025` still cites only the preprint DOI in both `Publications` and `Meta.Description` (the version of record is now Nature 2026, PMID 42259917), and `Berg2025`'s `Technique` reads SBFSEM where the paper describes eFIB-SEM. `Nern2024` needs no citation fix — its `Publications` field already carries the 2025 version of record; only the dataset id and label strings still read 2024.

The data file is in `static/` rather than `data/` so it publishes at a stable URL with no change to `hugo.toml`. Hugo was not available in the environment this was prepared in, so nothing here alters the build configuration — if you would rather it live in `data/` for `.Site.Data` access, that is a one-line output-format addition you can test and I cannot.
