### PR TITLE
Pin the builder to Hugo 0.122.0, the last version that completes this build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,36 +3,74 @@
 #   docker build -t vfb-static-builder .
 #   docker run --rm -v "$PWD:/src" -v vfb_cache:/tmp vfb-static-builder
 #
-# v0.164.0 is the newest stable Hugo (released 2026-07-06) and the site builds
-# clean on it: 186 pages, no WARN, no ERROR. Pinned rather than :latest so
-# rebuilding this image cannot silently change the site.
+# Pinned to Hugo 0.122.0 rather than the newest release. That is a deliberate
+# step backwards and the reason is measured, not suspected.
 #
-# The theme's declared minimum is 0.128.0 (`[pagination] pagerSize`). It does
-# also build on 0.122.0, which is what rcourt/docsy-builder:Feb2023 carries, but
-# that image has no rsync and warns about the declared minimum.
+# The content tree is ~763k generated term pages, ~650k of them in a single
+# directory (content/en/blog/ontologies/vfb), reached over NFSv3 from a Synology
+# volume whose btrfs metadata sits on RAID5 spinning disks. Measured on that
+# volume: plain readdir runs at 5-29k entries/s, but readdir+stat runs at
+# 253/s — ~4ms per inode, a disk seek, nothing cached. NFSv3 uses READDIRPLUS,
+# so the server stats every entry it enumerates. Per-page filesystem cost is
+# therefore the dominant term in this build, far above template or render cost.
 #
-# Base is Alpine 3.22, so apk is correct. The upstream image already carries
-# git, Node, npm and Dart Sass. This site needs none of them — the theme ships
-# plain CSS concatenated by Hugo, so even the extended edition is optional — but
-# they come with the official image and are not worth stripping out.
+# Hugo's per-page filesystem cost rose at v0.123.0, which rewrote page assembly.
+# Counted with strace over an identical 25k-page corpus on local disk:
 #
-# bash and rsync are for deploy.sh, which stages the build and syncs it into the
-# served directory rather than writing there directly. findutils replaces
-# busybox find so the page-count gate behaves predictably.
-FROM ghcr.io/gohugoio/hugo:v0.164.0
+#     0.122.0    75,658 openat    76,997 newfstatat   3.06 stat/page
+#     0.128.0   100,788 openat   101,527 newfstatat   4.04 stat/page
+#     0.140.2   100,813 openat   101,485 newfstatat   4.03 stat/page
+#     0.164.0   100,844 openat   101,488 newfstatat   4.03 stat/page
+#
+# Flat from 0.128 onward, so this is one regression at 0.123, not a drift. At
+# 763k pages and 253 stat/s that extra stat per page is ~49 min on top of a
+# build already costing ~2.6h of pure metadata I/O.
+#
+# 0.122.0 is the last version known to complete this build: the live term pages
+# carry `generator: Hugo 0.122.0` and were written 2026-08-05 17:59. No 0.16x
+# build has ever finished — each ran 17h+ with one thread in uninterruptible
+# sleep on the vfb/ directory and not a single page written.
+#
+# This pin is a workaround. The fix is to stop holding 650k files in one
+# directory (shard vfbterms.py's output) and to pin the volume's btrfs metadata
+# to its SSD cache. When either lands, raise HUGO_VERSION — it is an ARG so that
+# is a one-line change.
+#
+# Debian rather than Alpine, and the tarball rather than ghcr.io/gohugoio/hugo:
+# that registry has no v0.122.0 tag (it begins around v0.140), and the extended
+# release binary is glibc-linked — `ldd` gives /lib64/ld-linux-x86-64.so.2 plus
+# libstdc++.so.6 — so musl with gcompat is not a safe host for it.
+#
+# Extended edition, matching the rcourt/docsy-builder:Feb2023 that produced the
+# last good site. The theme ships plain CSS and needs no Sass, so the standard
+# edition would also serve and is statically linked; keeping extended here
+# changes one variable at a time relative to the last build known to work.
+#
+# The theme declares min_version 0.128.0 for `[pagination] pagerSize`, so 0.122
+# emits one WARN and falls back to 10 items per page. Nothing on the site
+# paginates today, so that is latent rather than active.
+FROM debian:bookworm-slim
 
-# Deliberately root, unlike the upstream image's hugo:hugo. The published tree
-# on the NFS volume is owned by root from the klakegg-era builds, so an
-# unprivileged rsync could not overwrite it.
+ARG HUGO_VERSION=0.122.0
+
+# bash and find are already in the base image. rsync is for deploy.sh, which
+# stages the build and syncs it into the served directory rather than writing
+# there directly. libstdc++6 is what the extended Hugo binary links against.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends rsync ca-certificates libstdc++6 \
+ && rm -rf /var/lib/apt/lists/*
+
+ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz /tmp/hugo.tgz
+RUN tar xzf /tmp/hugo.tgz -C /usr/local/bin hugo \
+ && rm -f /tmp/hugo.tgz \
+ && hugo version
+
+# Deliberately root. The published tree on the NFS volume is owned by root from
+# the klakegg-era builds, so an unprivileged rsync could not overwrite it.
 USER root
-RUN apk add --no-cache bash rsync findutils
 
-# The upstream image sets HUGO_CACHEDIR=/cache and WORKDIR /project. Both are
-# wrong here and neither can be left to deploy.sh's defaults: the script uses
-# ${HUGO_CACHEDIR:-/tmp/hugo_cache}, which never fires while the image has the
-# variable set, so the cache would land in the container's writable layer
-# instead of the volume mounted at /tmp — discarded every run, and growing host
-# disk in between. Rancher mounts the workspace at /src and the cache at /tmp.
+# deploy.sh uses ${HUGO_CACHEDIR:-/tmp/hugo_cache}, so this must be set
+# explicitly: Rancher mounts the workspace at /src and the cache volume at /tmp.
 ENV HUGO_CACHEDIR=/tmp/hugo_cache
 WORKDIR /src
 


### PR DESCRIPTION
## What this does

Pins `virtualflybrain/vfb-static-builder` to **Hugo 0.122.0**. One file changes.

## Why

The site has not published since 3 August. Hugo 0.164.0 has never completed a
build of the full term corpus — two runs, on two different machines, each sat
for 17h+ with:

* one thread in uninterruptible sleep on `content/en/blog/ontologies/vfb`
* ~500 MB RSS, against the 1.70 GB a *187-page* build of this site needs
* 66 files and 16 MB in the staging tree — the static files, nothing else
* no error, because `HUGO_TIMEOUT` never fires in the phase where it stalls

Meanwhile the live term pages carry `generator: Hugo 0.122.0`, written
2026-08-05 17:59. 0.122.0 is the last version demonstrably able to finish.

## The build is metadata-bound

Measured on the Synology volume itself, with NFS out of the picture:

| operation | rate |
|---|---:|
| readdir, `go/` (14k entries) | 20,191/s |
| readdir, `vfb/` first 20k | 29,000/s |
| readdir, `vfb/` 300k to 400k | ~5,076/s |
| **readdir + stat** | **253/s** |

253 stats/s is ~4 ms per inode — one disk seek, nothing cached. 187 GiB of
btrfs metadata on RAID5 spinning disks. NFSv3 uses READDIRPLUS, so the server
stats every entry it enumerates. Filesystem cost dominates this build.

## The regression

`strace`, identical 25k-page corpus, local disk:

| Hugo | `openat` | `newfstatat` | stat/page |
|---|---:|---:|---:|
| **0.122.0** | 75,658 | 76,997 | **3.06** |
| 0.128.0 | 100,788 | 101,527 | 4.04 |
| 0.140.2 | 100,813 | 101,485 | 4.03 |
| 0.164.0 | 100,844 | 101,488 | 4.03 |

One extra stat and open per page, arriving at v0.123.0's page-assembly rewrite
and flat afterwards. Across 763k pages at 253 stat/s that is ~49 minutes on top
of a build already costing ~2.6 h of pure metadata I/O.

**This does not fully explain the hang** — 33% more syscalls does not turn a
build that finishes into one that never does — so this pin is an unblock, not a
diagnosis closed. Expect ~2.6 h, not a fast build.

## Implementation notes

* Debian, not Alpine: the extended release binary is glibc-linked (`ldd` gives
  `/lib64/ld-linux-x86-64.so.2` and `libstdc++.so.6`), so musl + gcompat is not
  a safe host for it.
* Release tarball, not `ghcr.io/gohugoio/hugo`: that registry has no `v0.122.0`
  (it starts around `v0.140`).
* Extended edition, matching the `docsy-builder:Feb2023` that built the last
  good site — changing one variable at a time.
* `HUGO_VERSION` is an `ARG`, so raising it again is a one-line change.
* The existing workflow smoke test passes unchanged: bash, rsync, find,
  `HUGO_CACHEDIR`, `/src`, uid 0.

> [!WARNING]
> 0.122 emits one WARN — the theme declares `min_version = "0.128.0"` for
> `[pagination] pagerSize`, which silently falls back to 10 per page. Nothing on
> the site paginates, so it is latent.

> [!NOTE]
> This image could not be built in the sandbox (no Docker daemon), so the
> Dockerfile is unverified beyond the tarball URL resolving and the binary's
> linkage matching the base. The workflow smoke test is the first real check.

## Real fixes, not in this PR

1. **Shard `vfb/`** by ID prefix in `vfbterms.py`. `go/` at 14k entries reads at
   20,191/s; `vfb/` at 650k collapses to 5,076/s and 253 stat/s.
2. **Pin btrfs metadata to the SSD cache** — 374 GiB raw metadata, 447 GB cache
   device. Would take stat from ~4 ms to sub-0.1 ms.
3. **Fix the Jenkins gate.** It greps `build.log` for `rror` and reports SUCCESS
   when it finds none, so a build producing zero pages goes green. That is why
   this went unnoticed for nine days.
