### PR TITLE
Reserve nav space on .page, and rebuild the Data section on the content report

### DIFF
--- a/content/en/docs/Data/EM/_index.md
+++ b/content/en/docs/Data/EM/_index.md
@@ -9,6 +9,12 @@ description: >
 
 Virtual Fly Brain brings together data from multiple [electron microscopy (EM) resources](/docs/resources/), providing access to high-resolution neuroanatomical datasets. These datasets include complete EM volumes of Drosophila brains and ventral nerve cords, neuron reconstructions, connectivity information and neurotransmitter predictions. Data can be visualised using the web browser or accessed programmatically via [APIs](/docs/apis/).
 
+{{< vfb-figures set="em" >}}
+
+The synaptic connectivity derived from these datasets is described on its own page. See
+[Connectivity data](/docs/data/connectivity/) for what an edge means, which connectomes
+contribute one, and how to handle reconstructions that cover the same tissue.
+
 ## Comparison Table of Integrated Datasets
 
 The table below summarises EM datasets that have been integrated into VFB, including the portion of the organism covered (`Anatomy`), the resource(s) where the original data can be found, The level of reconstruction (sparse or dense) and the original publication for the dataset.

--- a/content/en/docs/Data/LM/_index.md
+++ b/content/en/docs/Data/LM/_index.md
@@ -2,10 +2,104 @@
 title: "Light Microscopy Data"
 linkTitle: "LM Data"
 weight: 5
+date: 2026-08-15
 description: >
     Light Microscopy Data available on Virtual Fly Brain.
 
 ---
 
-Virtual Fly Brain brings together data from multiple [Light Microscopy (LM) resources](/docs/resources/), providing access to visualisations of driver (including split) expression patterns.
+Light microscopy is the largest body of data on VFB by number of source studies. It
+answers a different question from EM: rather than what a neuron connects to, it tells
+you which genetic reagent will let you see or manipulate a cell type, and what else that
+reagent labels. VFB registers confocal image stacks from more than a hundred studies
+onto the [standard templates](/docs/data/templates/), classifies what they label with
+Drosophila Anatomy Ontology terms, and links each driver back to its FlyBase record and
+stock centre.
 
+{{< vfb-figures set="lm" >}}
+
+## Kinds of LM data
+
+The distinction that matters when searching is between an image of a *whole expression
+pattern* — everything a driver labels — and an image of a *single neuron* or small
+clone picked out of that pattern.
+
+| Kind | What one image is | Typical use |
+|---|---|---|
+| Driver expression pattern | The full pattern of a GAL4 or LexA line in a CNS | Find a reagent that covers your region of interest, and see what else it hits |
+| Split-GAL4 combination | The pattern of an AD/DBD hemidriver pair | Find a reagent specific enough to target one cell type |
+| Expression pattern fragment | A segmented part of a driver's pattern | Compare a driver against a neuron or region without the rest of the pattern in the way |
+| Single neuron | One neuron isolated by stochastic labelling (MCFO, FLP-out) or by single-cell clonal analysis | Get a morphology to compare against EM or by [NBLAST](/docs/website-features/) |
+| Clone or lineage | A neuroblast clone or a *fru*-positive clone | Work with developmental units rather than single cells |
+| Painted domain | A neuropil region drawn onto a template | Anatomical reference; see [Templates](/docs/data/templates/) |
+
+Every one of these is registered to a template, so a single-neuron image from one study
+can be compared directly against an EM reconstruction from another, and a driver's
+pattern can be scored for overlap against any region or neuron.
+
+## Major collections
+
+Collections are grouped here by what they contain. VFB holds around 120 LM datasets in
+total, most of them the per-paper split-GAL4 sets described below; the full list is
+reachable from any template's `All datasets` query.
+
+| Collection | Anatomy / stage | What the images show | VFB dataset | Publication |
+|---|---|---|---|---|
+| FlyLight Gen1 GAL4/LexA | Adult brain and VNC | Whole expression patterns of the GMR enhancer-fragment collection | [FlyLightGen1Set2019](http://virtualflybrain.org/reports/FlyLightGen1Set2019) | [Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011) |
+| FlyLight Gen1 MCFO | Adult brain and VNC | Single neurons stochastically labelled within Gen1 lines | [Gen1MCFOJenett2012](http://virtualflybrain.org/reports/Gen1MCFOJenett2012) and four further sets | [Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011) |
+| VT collection (Dickson lab) | Adult brain | Whole expression patterns of the VT GAL4, LexA and split lines, imaged at VDRC | [Dickson_VT](http://virtualflybrain.org/reports/Dickson_VT) | [Tirian and Dickson, 2017](https://doi.org/10.1101/198648) |
+| FlyCircuit 1.0 | Adult brain | Single neurons from the Chiang lab collection, one neuron per image | [Chiang2010](http://virtualflybrain.org/reports/Chiang2010) | [Chiang et al., 2011](https://doi.org/10.1016/j.cub.2010.11.056) |
+| *fru* clones | Adult brain | Clonal units of the *fruitless*-positive circuitry | [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | [Cachero et al., 2010](https://doi.org/10.1016/j.cub.2010.07.045) |
+| Per-paper split-GAL4 sets | Mostly adult brain and VNC | Split combinations characterised in one publication each — around 70 sets, from Aso and Rubin's dopaminergic lines through to Nern, Wolff, Zhao and Zung in 2025 | Search `Split` in datasets | Per dataset page |
+| Truman larval flip-out | Larval CNS | Single neurons and small clones in the larval CNS | [TrumanWood2018](http://virtualflybrain.org/reports/TrumanWood2018) | Per dataset page |
+| Lineage and clone sets | Adult brain | Neuroblast lineage clones from the Ito, Yu and Lee collections | [Ito2013](http://virtualflybrain.org/reports/Ito2013), [Yu2013](http://virtualflybrain.org/reports/Yu2013), [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | Per dataset page |
+| BrainTrap | Adult brain | Protein-trap expression patterns | [Knowles_Barley2010](http://virtualflybrain.org/reports/Knowles_Barley2010) | Per dataset page |
+
+Where the Publication column says *per dataset page*, the citation is recorded on the
+dataset's own page on VFB rather than repeated here, so that it stays correct if the
+record is updated. Cite the original study, not VFB, when you use the images.
+
+## Expression annotations
+
+Registration puts an image in the right place; annotation is what makes it queryable.
+VFB curators and pipelines record, for each driver, which anatomical structures it is
+expressed in, as ontology-classified assertions rather than free text. That is what
+lets a query for a cell type return the drivers that label it, and a query for a driver
+return everything it is known to hit.
+
+These annotations come from two sources: curation of the published literature, and
+computed overlap between a registered expression pattern and the painted domains or
+neuron images in the same template space. They are annotations of what has been
+observed and recorded — a driver with no recorded expression in a region has not been
+shown to be absent there.
+
+## Finding LM data
+
+- **From a cell type.** Open any neuron class and run the expression queries on its
+  Term Info pane to get the drivers reported to label it.
+- **From a region.** Open a neuropil and ask for the expression patterns that overlap
+  it.
+- **From an image.** Run [NBLAST](/docs/website-features/) from a single-neuron image
+  to find morphologically similar neurons, LM or EM, across every registered dataset.
+- **From a reagent name.** Search the line directly — `R81G11`, `VT061192`, `SS04495` —
+  or the FlyBase identifier.
+- **Programmatically.** `VFB_connect` exposes the same queries; see the
+  [APIs](/docs/apis/) page.
+
+Adult LM images are registered to
+[JRC2018Unisex or JRC2018UnisexVNC](/docs/data/templates/) unless the study predates
+them, in which case the older JFRC2 or Court2018 VNS template may be the only alignment
+available. Check the template shown on the image's Term Info page before comparing
+coordinates across studies.
+
+## Data VFB does not hold
+
+VFB indexes and registers LM images, and links out to the original collections for the
+raw, unregistered data. For adult FlyLight material that means
+[flweb.janelia.org](https://flweb.janelia.org/),
+[gen1mcfo.janelia.org](https://gen1mcfo.janelia.org/) and
+[splitgal4.janelia.org](https://splitgal4.janelia.org/); VFB hosts the raw larval
+FlyLight images itself, at
+[raw.larval.flylight.virtualflybrain.org](https://raw.larval.flylight.virtualflybrain.org/).
+See [FlyLight](/docs/data/lm/flylight/) and the
+[external resources](/docs/resources/) page.

--- a/content/en/docs/Data/_index.md
+++ b/content/en/docs/Data/_index.md
@@ -2,7 +2,7 @@
 title: "Data on VFB"
 linkTitle: "Data"
 weight: 9
-date: 2026-01-19
+date: 2026-08-15
 description: >
   Types of data and datasets that are available on Virtual Fly Brain.
 cascade:
@@ -11,4 +11,51 @@ cascade:
     path: "/**"
 ---
 
-VFB hosts a range of datatypes, including electron microscopy (EM) and light microscopy (LM) datasets with images annotated using the same cell type ontology terms and aligned to common standard templates. We also host single cell RNA sequencing (scRNAseq) gene expression data.
+Virtual Fly Brain integrates *Drosophila melanogaster* nervous system data from many
+laboratories into one queryable resource. Two things make that integration work, and
+both apply to every datatype below: images are registered onto a small set of
+[standard templates](/docs/data/templates/) so that data from different studies can be
+compared in the same coordinate space, and everything is classified with terms from the
+Drosophila Anatomy Ontology (DAO) so that a query for a cell type returns data from
+every study that reported it, whatever that study called it.
+
+{{< vfb-figures set="overview" >}}
+
+The figures above come from the [content report](/blog/2022/01/01/vfb-content-report/),
+which is regenerated against the production knowledge base after every data release.
+
+## What is here
+
+| Datatype | What it covers | Page |
+|---|---|---|
+| Electron microscopy | Dense and sparse EM reconstructions of the adult brain, VNC and larval CNS, with neuron morphology and synaptic connectivity | [EM data](/docs/data/em/) |
+| Connectivity | Neuron-to-neuron and neuron-to-region synaptic connections derived from the EM datasets | [Connectivity data](/docs/data/connectivity/) |
+| Light microscopy | Driver line expression patterns, split-GAL4 combinations, single-neuron and clonal images from confocal microscopy | [LM data](/docs/data/lm/) |
+| Single-cell transcriptomics | Cell clusters and their gene expression from scRNAseq and snRNAseq studies | [scRNAseq data](/docs/data/scrnaseq/) |
+| Templates and regions | The reference brains and VNCs everything is registered to, and the painted neuropil domains in each | [Templates](/docs/data/templates/) |
+
+VFB also hosts the public [CATMAID instances](/hosted/) for several community EM
+datasets, in some cases as the only remaining public copy after the original host went
+offline.
+
+## Where the data comes from, and where it goes
+
+Most data on VFB is published data that VFB has registered, classified and indexed —
+VFB is an integrator, not usually the originator. Every dataset therefore carries its
+original publication, and every image links back to the resource it came from. Cite the
+original study when you use the data, and cite
+[Court et al. (2023)](https://doi.org/10.3389/fphys.2023.1076533) for VFB itself.
+
+Data can be reached three ways: through the
+[3D browser](https://v2.virtualflybrain.org/org.geppetto.frontend/geppetto),
+programmatically through the [APIs](/docs/apis/) — `VFB_connect` for Python, the
+knowledge graph, and the MCP server — and by download of individual images from their
+[Term Info](/docs/website-features/terminfo/#data) pages, in NRRD, Woolz, OBJ and SWC as
+available.
+
+## Licences
+
+Licence terms differ per dataset and are set by the original producer, not by VFB. Where
+a dataset carries a licence it is shown on its Term Info page. Some older datasets
+predate the practice and carry none recorded; absence of a stated licence on VFB is not
+a grant of permission, so check with the original resource before redistributing.

--- a/content/en/docs/Data/connectivity.md
+++ b/content/en/docs/Data/connectivity.md
@@ -1,0 +1,96 @@
+---
+title: "Connectivity Data"
+linkTitle: "Connectivity"
+weight: 3
+date: 2026-08-15
+tags: ["connectome","EM","connectivity"]
+description: >-
+    Synaptic connectivity on Virtual Fly Brain — what an edge is, which connectomes
+    contribute one, and how to query across them.
+---
+
+Connectivity is derived data: it comes out of the [EM datasets](/docs/data/em/), but VFB
+holds and queries it separately from the images. Loading it into one knowledge graph,
+with both ends of every edge classified against the Drosophila Anatomy Ontology, is what
+makes it possible to ask a question once and have it answered across every connectome
+at the same time, rather than once per resource in each resource's own vocabulary.
+
+{{< vfb-figures set="connectivity" >}}
+
+## What an edge means
+
+A VFB connectivity edge records that a reconstruction reported synapses between two
+neurons, and how many. It is evidence from one dataset, not a biological fact: two
+neurons may be connected in the animal and unconnected in a partial reconstruction, and
+a weak edge may be a segmentation artefact. Treat every count as attributable to the
+connectome it came from.
+
+VFB holds four kinds of connection:
+
+| From | To | What it is |
+|---|---|---|
+| Neuron (individual) | Neuron (individual) | The connectome proper — one reconstructed neuron synapsing onto another |
+| Neuron (individual) | Region (individual) | Synapses a neuron makes within a named neuropil, used for region-level input and output profiles |
+| Neuron (class) | Muscle (class) | Curated motor innervation, from the literature rather than from EM |
+| Neuron (class) | Sense organ (class) | Curated sensory innervation, likewise |
+
+The first two are per-individual and come from EM. The last two are per-class and come
+from curation, so they carry no synapse counts and cover far fewer entities. The
+[content report](/blog/2022/01/01/vfb-content-report/) gives the current size of each.
+
+## Which connectomes contribute
+
+| Dataset | VFB symbol | Coverage |
+|---|---|---|
+| BANC v626 | `BANC` | Full CNS, adult female |
+| FlyWire v783 (FAFB) | `fw` | Full brain, adult female |
+| male-CNS v0.9 | `mc` | Full CNS, adult male |
+| MANC v1.2.1 | `mv` | Full VNC, adult male |
+| Optic-lobe v1.0.1 | `ol` | Optic lobe, adult male |
+| hemibrain v1.2.1 | `hb` | Partial brain, adult female |
+| FAFB (CATMAID) | `fafb` | Full brain, adult female — sparse reconstruction |
+| L1 CNS (CATMAID) | `l1em` | Full CNS, first-instar larva |
+
+Versions matter: a connectome is re-released as proofreading progresses, neuron
+identifiers do not always survive between versions, and VFB states the version it holds.
+See [EM dataset versioning](/docs/data/em/versioning/).
+
+### Overlapping reconstructions
+
+Several of these reconstruct the *same tissue*. The hemibrain, the sparse FAFB CATMAID
+reconstruction and FlyWire all cover adult female brain, and a connection present in
+more than one of them is one biological connection reported several times, not several
+connections. Summing partner counts across all datasets therefore inflates them.
+
+The convention VFB and `VFB_connect` follow is to exclude `hb` and `fafb` from
+cross-dataset connectivity queries by default, leaving FlyWire as the adult female brain
+source. Change that when the question calls for it — comparing reconstructions against
+each other, for instance — but change it deliberately.
+
+## Querying it
+
+Connectivity queries are available from the Term Info pane of any neuron or region, and
+programmatically through [`VFB_connect`](/docs/apis/) and the MCP server.
+
+- **Partners of one neuron type.** Ask for its inputs or outputs. The default weight
+  threshold is 5 synapses; lower it only if you are prepared to look at the weak edges
+  individually.
+- **Between two neuron types.** A pairwise query returns the edges between them in each
+  contributing dataset separately, which is usually what you want to see.
+- **For a region.** Regions take a different set of queries from neurons. Ask a
+  neuropil for the neurons presynaptic or postsynaptic in it, not for its connectivity
+  partners.
+
+Direction is easy to invert, so it is worth stating plainly: neurons *presynaptic in* a
+region have their presynaptic terminals there and are providing input to it; neurons
+*postsynaptic in* a region receive there. A query for the inputs to a region returns the
+presynaptic set.
+
+## What the numbers do and do not say
+
+The neuron counts above are the neurons VFB holds connectivity for, which is not the
+number of neurons in a fly. Absence is likewise not evidence: a cell type with no
+connectivity on VFB may simply not be reconstructed in any dataset VFB has loaded, or
+may not yet be matched between the connectome's own naming and the ontology. Where a
+connectome's identifiers have not been mapped onto ontology classes, the neurons are
+still present and queryable individually.

--- a/content/en/docs/Data/scRNAseq/_index.md
+++ b/content/en/docs/Data/scRNAseq/_index.md
@@ -2,23 +2,78 @@
 title: "Single Cell RNA Sequencing Data"
 linkTitle: "scRNAseq Data"
 weight: 15
+date: 2026-08-15
 description: >
     scRNAseq Data available on Virtual Fly Brain.
 
 ---
 
-Virtual Fly Brain incorporates scRNAseq data from multiple studies, including the [Fly Cell Atlas](https://flycellatlas.org/), [Aging Fly Cell Atlas](https://hongjielilab.org/afca/) and other datasets that identify nervous system cell types - full list [here](https://github.com/VirtualFlyBrain/VFB_reporting_results/blob/master/scRNAseq_DataSets.tsv). These datasets can be found by searching for 'scRNAseq' and filtering to 'Dataset'.
+VFB integrates single-cell and single-nucleus RNA sequencing data by connecting it to
+anatomy: each cluster from a published study is annotated with the Drosophila Anatomy
+Ontology term for the cell type it corresponds to, so that a query for a cell type
+returns its transcriptomic clusters alongside its images and connectivity. The
+sequencing itself is not VFB's; the anatomical annotation and the cross-linking are.
 
-Clusters can be found for particular cell types via the `Single cell transcriptomics data for..` query on the cell type Term Info pane.
+{{< vfb-figures set="scrnaseq" >}}
+
+Data comes from [FlyBase](https://flybase.org/), which takes it from the
+[Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home). The studies include
+the [Fly Cell Atlas](https://flycellatlas.org/) and the
+[Aging Fly Cell Atlas](https://hongjielilab.org/afca/).
+
+## Finding clusters and genes
+
+Clusters for a cell type are reached through the `Single cell transcriptomics data for…`
+query on that cell type's Term Info pane. Datasets themselves are found by searching for
+`scRNAseq` and filtering to `Dataset`.
 
 ![transcriptomics_query](https://www.virtualflybrain.org/images/scRNAseq/cluster_query.png)
 
-Genes for a particular cluster can be filtered by function and sorted by expression level and extent (proportion of cells in cluster expressing the gene). As with other VFB search results, these can be exported as a csv.
+Genes in a cluster can be filtered by function and sorted by expression level and by
+extent — the proportion of cells in the cluster expressing the gene. As with other VFB
+result tables, the list exports as CSV.
 
-_Note that we currently only include genes that have extent > 0.2 in a cluster._
+_Only genes with extent > 0.2 in a cluster are included._
 
 ![cluster_genes](https://www.virtualflybrain.org/images/scRNAseq/gene_expression.png)
 
-Data can also be retrieved using [VFB_connect](https://vfb-connect.readthedocs.io/en/stable/API_reference.html#transcriptomics-queries).
+The same queries are available through
+[VFB_connect](https://vfb-connect.readthedocs.io/en/stable/API_reference.html#transcriptomics-queries).
 
-We pull scRNAseq data from [FlyBase](https://flybase.org/), which takes it from the [Single Cell Expression Atlas](https://www.ebi.ac.uk/gxa/sc/home).
+## Datasets
+
+Gene counts are after the extent filter above, so they are lower than the gene count
+reported by the original study. Ordered by cluster count.
+
+| Dataset | Study | Clusters | Genes |
+|---|---|---|---|
+| [scRNAseq_2022_FCA_MIXED](https://flybase.org/reports/FBlc0004785) | Single-nucleus RNA-seq on cells from 5-days old female and male flies | 497 | 11,079 |
+| [scRNAseq_2022_FCA_MALE](https://flybase.org/reports/FBlc0004307) | Single-nucleus RNA-seq on cells from 5-days old male flies | 422 | 10,978 |
+| [scRNAseq_2022_FCA_FEMALE](https://flybase.org/reports/FBlc0003846) | Single-nucleus RNA-seq on cells from 5-days old female flies | 411 | 8,169 |
+| [scRNAseq_2022_Calderon](https://flybase.org/reports/FBlc0007797) | The continuum of Drosophila embryonic development at single-cell resolution | 274 | 2,166 |
+| [scRNAseq_2023_AFCA_D30_FEMALE](https://flybase.org/reports/FBlc0006424) | Single-nucleus RNA-seq on cells from 30-days old female flies | 179 | 4,987 |
+| [scRNAseq_2023_AFCA_D70_FEMALE](https://flybase.org/reports/FBlc0007348) | Single-nucleus RNA-seq on cells from 70-days old female flies | 176 | 5,458 |
+| [scRNAseq_2023_AFCA_D50_FEMALE](https://flybase.org/reports/FBlc0006888) | Single-nucleus RNA-seq on cells from 50-days old female flies | 175 | 4,595 |
+| [scRNAseq_2023_AFCA_D50_MALE](https://flybase.org/reports/FBlc0007071) | Single-nucleus RNA-seq on cells from 50-days old male flies | 172 | 4,878 |
+| [scRNAseq_2023_AFCA_D30_MALE](https://flybase.org/reports/FBlc0006611) | Single-nucleus RNA-seq on cells from 30-days old male flies | 168 | 4,857 |
+| [scRNAseq_2023_AFCA_D70_MALE](https://flybase.org/reports/FBlc0007532) | Single-nucleus RNA-seq on cells from 70-days old male flies | 161 | 4,835 |
+| [scRNAseq_2023_AFCA_D30](https://flybase.org/reports/FBlc0006423) | Single-nucleus RNA-seq on cells from 30-days old flies | 99 | 5,312 |
+| [scRNAseq_2023_AFCA_D70](https://flybase.org/reports/FBlc0007347) | Single-nucleus RNA-seq on cells from 70-days old flies | 95 | 5,592 |
+| [scRNAseq_2023_AFCA_D50](https://flybase.org/reports/FBlc0006887) | Single-nucleus RNA-seq on cells from 50-days old flies | 95 | 5,015 |
+| [scRNAseq_2021_Ozel](https://flybase.org/reports/FBlc0005659) | Single-cell RNA-seq study of pupal and adult optic lobes | 66 | 4,770 |
+| [scRNAseq_2020_Kurmangaliyev](https://flybase.org/reports/FBlc0006237) | Single-cell RNA-seq study of the pupal optic lobe | 62 | 5,975 |
+| [scRNAseq_2018_Davie](https://flybase.org/reports/FBlc0006090) | Single-cell RNA-seq study of the aging brain | 59 | 6,111 |
+| [scRNAseq_2020_Hormann](https://flybase.org/reports/FBlc0006305) | Single-cell RNA-seq study of visual motion-sensing neurons | 40 | 4,014 |
+| [scRNAseq_2021_Mokashi_CTRL](https://flybase.org/reports/FBlc0005420) | Single-cell RNA-seq study of adult brain without alcohol exposure | 39 | 3,097 |
+| [scRNAseq_2021_Baker_CTRL](https://flybase.org/reports/FBlc0005515) | Single-cell RNA-seq study of adult brain without cocaine exposure | 36 | 3,329 |
+| [scRNAseq_2020_Allen](https://flybase.org/reports/FBlc0005603) | Single-cell RNA-seq study of adult ventral nerve cords | 20 | 3,085 |
+| [scRNAseq_2022_Konstantinides](https://flybase.org/reports/FBlc0006404) | Single-cell RNA-seq study of larval optic lobes | 14 | 5,530 |
+| [scRNAseq_2023_Saavedra](https://flybase.org/reports/FBlc0006361) | Single-cell RNA-seq study of the adult thorax | 11 | 1,726 |
+| [scRNAseq_2019_Avalos](https://flybase.org/reports/FBlc0005362) | Single-cell RNA-seq study of first instar larval brains upon starvation | 10 | 6,463 |
+| [scRNAseq_2021_IngSimmons](https://flybase.org/reports/FBlc0006191) | Single-cell RNA-seq study of gastrulating embryos | 9 | 6,423 |
+
+Not every cluster carries an anatomical annotation: many are non-neural or were not
+resolved to a cell type in the source study. Counts here are of what VFB holds, and are
+regenerated with the [content report](/blog/2022/01/01/vfb-content-report/) after each
+data release; the machine-readable version is
+[scRNAseq_DataSets.tsv](https://github.com/VirtualFlyBrain/VFB_reporting_results/blob/master/scRNAseq_DataSets.tsv).

--- a/themes/vfb-nova/assets/css/content-hooks.css
+++ b/themes/vfb-nova/assets/css/content-hooks.css
@@ -164,3 +164,14 @@ a.btn { text-decoration: none; }
   color: var(--muted);
 }
 .pagination .btn[aria-disabled="true"] { opacity: .4; pointer-events: none; }
+
+/* --- figure strip inside a documentation page ---------------------------- */
+/* The hero's .stats grid, scaled down for use in prose by the vfb-figures
+   shortcode. Sits between paragraphs rather than under a page title, so it
+   needs its own vertical rhythm and a lighter number. */
+.vfb-figures {
+  margin: var(--sp-5) 0;
+  padding-top: var(--sp-4);
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+.vfb-figures .stat__num { font-size: var(--step-1); }

--- a/themes/vfb-nova/assets/css/docs.css
+++ b/themes/vfb-nova/assets/css/docs.css
@@ -113,6 +113,24 @@
 .doc__header { margin-bottom: var(--sp-6); }
 .doc__header h1 { font-size: var(--step-3); margin-bottom: var(--sp-3); }
 .doc__header .lede { font-size: var(--step-1); }
+
+/* --- standalone page shell ---------------------------------------------- */
+/* Everything outside the docs shell renders through .page: blog posts, news,
+   releases, the generated term pages, and the taxonomy and tag lists. The
+   class was used by five layouts but had no rule, so those pages carried no
+   offset for the fixed nav and their breadcrumb rendered underneath it. Only
+   .hero and .doc reserved the space. */
+.page {
+  position: relative;
+  z-index: 1;
+  padding-top: calc(var(--nav-h) + var(--sp-6));
+  padding-bottom: var(--sp-8);
+}
+
+.page__header { margin-bottom: var(--sp-6); }
+.page__header h1 { font-size: var(--step-3); margin-bottom: var(--sp-3); }
+.page__header .lede { font-size: var(--step-1); }
+
 .doc__meta {
   margin-top: var(--sp-4);
   display: flex;

--- a/themes/vfb-nova/layouts/partials/content-stats.html
+++ b/themes/vfb-nova/layouts/partials/content-stats.html
@@ -1,0 +1,54 @@
+{{- /* ---------------------------------------------------------------------------
+     content-stats — the headline figures for the home page hero.
+
+     Source is the VFB content report, not the size of this site. The report is
+     regenerated against pdb.virtualflybrain.org after every data release and
+     injected into /blog/releases by the reporting pipeline, so it is the only
+     figure source in the built tree that tracks the knowledge base. It is not
+     in this repository, which is why the caller must handle an empty result:
+     a local checkout has no such page and must not print a constant that would
+     go stale the next time data lands.
+
+     Returns a dict. Absent keys mean the report was not found or its wording
+     changed; the caller falls back rather than guessing.
+     --------------------------------------------------------------------------- */ -}}
+
+{{- $raw := "" -}}
+{{- with site.GetPage "/blog/releases" -}}
+  {{- range .RegularPages -}}
+    {{- if and (eq $raw "") (in (lower .Title) "content report") -}}
+      {{- $raw = .RawContent -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $s := dict -}}
+{{- if $raw -}}
+
+  {{- /* "**608512** total images from **136** datasets" */ -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* total images from \*\*([0-9]+)\*\* datasets` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "images" (int (index $m 1)) "datasets" (int (index $m 2))) -}}
+  {{- end -}}
+
+  {{- /* First row of the connectivity table: neuron-to-neuron individuals.
+         "|Any neuron (individuals)|488111|Any neuron (individuals)|488111|34715655|" */ -}}
+  {{- with first 1 (findRESubmatch `\|Any neuron \(individuals\)\|([0-9]+)\|Any neuron \(individuals\)\|[0-9]+\|([0-9]+)\|` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "connected_neurons" (int (index $m 1)) "connections" (int (index $m 2))) -}}
+  {{- end -}}
+
+  {{- /* Ontology content table: "|All Terms|28772|2224|" */ -}}
+  {{- with first 1 (findRESubmatch `\|All Terms\|([0-9]+)\|` $raw 1) -}}
+    {{- $s = merge $s (dict "anatomy_terms" (int (index (index . 0) 1))) -}}
+  {{- end -}}
+
+  {{- /* "**3290** clusters from **24** datasets" */ -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* clusters from \*\*([0-9]+)\*\* datasets` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "sc_clusters" (int (index $m 1)) "sc_datasets" (int (index $m 2))) -}}
+  {{- end -}}
+
+{{- end -}}
+
+{{- return $s -}}

--- a/themes/vfb-nova/layouts/partials/content-stats.html
+++ b/themes/vfb-nova/layouts/partials/content-stats.html
@@ -42,11 +42,45 @@
   {{- with first 1 (findRESubmatch `\|All Terms\|([0-9]+)\|` $raw 1) -}}
     {{- $s = merge $s (dict "anatomy_terms" (int (index (index . 0) 1))) -}}
   {{- end -}}
+  {{- with first 1 (findRESubmatch `\|All Neurons\|([0-9]+)\|` $raw 1) -}}
+    {{- $s = merge $s (dict "neuron_classes" (int (index (index . 0) 1))) -}}
+  {{- end -}}
+  {{- with first 1 (findRESubmatch `\|All Nervous System Parts\|([0-9]+)\|` $raw 1) -}}
+    {{- $s = merge $s (dict "ns_parts" (int (index (index . 0) 1))) -}}
+  {{- end -}}
+
+  {{- /* Image content, one line per image class. */ -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* single neuron images of \*\*([0-9]+)\*\* cell types` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "single_neuron_images" (int (index $m 1)) "cell_types" (int (index $m 2))) -}}
+  {{- end -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* images of expression patterns of \*\*([0-9]+)\*\* drivers` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "ep_images" (int (index $m 1)) "drivers" (int (index $m 2))) -}}
+  {{- end -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* images of expression patterns of \*\*([0-9]+)\*\* split combinations` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "split_images" (int (index $m 1)) "splits" (int (index $m 2))) -}}
+  {{- end -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* images of expression pattern fragments of \*\*([0-9]+)\*\* drivers` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "fragment_images" (int (index $m 1)) "fragment_drivers" (int (index $m 2))) -}}
+  {{- end -}}
+
+  {{- /* "**93820** annotations recording **3291** types of anatomical structure
+         that **12889** specific driver lines are expressed in." */ -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* annotations recording \*\*[0-9]+\*\* types of anatomical structure that \*\*([0-9]+)\*\* specific driver lines` $raw 1) -}}
+    {{- $m := index . 0 -}}
+    {{- $s = merge $s (dict "expression_annotations" (int (index $m 1)) "annotated_drivers" (int (index $m 2))) -}}
+  {{- end -}}
 
   {{- /* "**3290** clusters from **24** datasets" */ -}}
   {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* clusters from \*\*([0-9]+)\*\* datasets` $raw 1) -}}
     {{- $m := index . 0 -}}
     {{- $s = merge $s (dict "sc_clusters" (int (index $m 1)) "sc_datasets" (int (index $m 2))) -}}
+  {{- end -}}
+  {{- with first 1 (findRESubmatch `\*\*([0-9]+)\*\* distinct genes expressed across all clusters` $raw 1) -}}
+    {{- $s = merge $s (dict "sc_genes" (int (index (index . 0) 1))) -}}
   {{- end -}}
 
 {{- end -}}

--- a/themes/vfb-nova/layouts/shortcodes/blocks/cover.html
+++ b/themes/vfb-nova/layouts/shortcodes/blocks/cover.html
@@ -15,11 +15,13 @@
 {{ with .Site.GetPage "/blog/news" }}{{ $latest = first 3 (sort .RegularPages "Date" "desc") }}{{ end }}
 {{ $docs := 0 }}{{ with .Site.GetPage "/docs" }}{{ $docs = len .RegularPagesRecursive }}{{ end }}
 {{ $hosted := 0 }}{{ with .Site.GetPage "/hosted" }}{{ $hosted = len .RegularPages }}{{ end }}
-{{ $onto := 0 }}{{ $terms := 0 }}
-{{ with .Site.GetPage "/blog/ontologies" }}
-  {{ $onto = len .Sections }}
-  {{ $terms = len .RegularPagesRecursive }}
-{{ end }}
+{{ $onto := 0 }}
+{{ with .Site.GetPage "/blog/ontologies" }}{{ $onto = len .Sections }}{{ end }}
+
+{{/* Headline figures come from the content report, which is regenerated
+     against the production knowledge base after every data release. See
+     partials/content-stats.html. */}}
+{{ $c := partial "content-stats.html" . }}
 
 <section class="hero">
   <canvas id="connectome" aria-hidden="true"></canvas>
@@ -33,13 +35,50 @@
         </div>
 
         <div class="stats">
-          {{/* The term corpus is only present in a full build (Jenkins runs vfbterms.py
-               into this tree first); below 1000 it is a local checkout, so the stat is
-               a scale claim that would read as false. */}}
-          {{ if gt $terms 1000 }}<div class="stat"><div class="stat__num">{{ lang.FormatNumberCustom 0 $terms }}</div><div class="stat__label">indexed anatomy terms</div></div>{{ end }}
-          {{ with $docs }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">documentation &amp; tutorial pages</div></div>{{ end }}
-          {{ with $hosted }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">hosted community datasets</div></div>{{ end }}
-          {{ with $onto }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">ontologies integrated</div></div>{{ end }}
+          {{/* Every figure here is a count of data in the knowledge base, taken from
+               the content report. The previous version counted pages in this site:
+               the largest tile read "indexed anatomy terms" but was the size of the
+               generated term corpus across all 22 integrated ontologies, most of
+               which is NCBITaxon and none of which is a count of anatomy.
+
+               A checkout without the report built into the tree gets the site-shape
+               tiles instead — fewer figures, but none of them wrong. */}}
+          {{ if $c }}
+            {{ with $c.images }}
+              <div class="stat">
+                <div class="stat__num">{{ lang.FormatNumberCustom 0 . }}</div>
+                <div class="stat__label">registered 3D images{{ with $c.datasets }} from {{ . }} datasets{{ end }}</div>
+              </div>
+            {{ end }}
+            {{ with $c.connected_neurons }}
+              <div class="stat">
+                <div class="stat__num">{{ lang.FormatNumberCustom 0 . }}</div>
+                <div class="stat__label">neurons with connectomics</div>
+              </div>
+            {{ end }}
+            {{ with $c.connections }}
+              <div class="stat">
+                <div class="stat__num">{{ if ge . 1000000 }}{{ lang.FormatNumberCustom 1 (div (float .) 1000000) }} M{{ else }}{{ lang.FormatNumberCustom 0 . }}{{ end }}</div>
+                <div class="stat__label">synaptic connections</div>
+              </div>
+            {{ end }}
+            {{ with $c.anatomy_terms }}
+              <div class="stat">
+                <div class="stat__num">{{ lang.FormatNumberCustom 0 . }}</div>
+                <div class="stat__label">anatomy ontology terms</div>
+              </div>
+            {{ end }}
+            {{ with $c.sc_clusters }}
+              <div class="stat">
+                <div class="stat__num">{{ lang.FormatNumberCustom 0 . }}</div>
+                <div class="stat__label">single-cell clusters{{ with $c.sc_datasets }} from {{ . }} datasets{{ end }}</div>
+              </div>
+            {{ end }}
+          {{ else }}
+            {{ with $onto }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">ontologies integrated</div></div>{{ end }}
+            {{ with $hosted }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">community services hosted</div></div>{{ end }}
+            {{ with $docs }}<div class="stat"><div class="stat__num">{{ . }}</div><div class="stat__label">documentation &amp; tutorial pages</div></div>{{ end }}
+          {{ end }}
         </div>
       </div>
 

--- a/themes/vfb-nova/layouts/shortcodes/vfb-figures.html
+++ b/themes/vfb-nova/layouts/shortcodes/vfb-figures.html
@@ -1,0 +1,63 @@
+{{- /* ---------------------------------------------------------------------------
+     vfb-figures — a small figure strip for a documentation page, taking its
+     numbers from the content report rather than from prose someone has to
+     remember to update. See partials/content-stats.html for the source.
+
+         {{< vfb-figures set="lm" >}}
+
+     Sets: overview, em, lm, connectivity, scrnaseq, ontology.
+
+     Renders nothing at all when the report is not in the tree, which is the
+     case in any checkout without a pipeline run. A page that uses this must
+     therefore still read correctly with the strip absent — put the figures
+     here and the meaning in the prose, never the other way round.
+     --------------------------------------------------------------------------- */ -}}
+{{- $c := partial "content-stats.html" . -}}
+{{- $set := .Get "set" | default "overview" -}}
+
+{{- $rows := slice -}}
+
+{{- if eq $set "overview" -}}
+  {{- with $c.images }}{{ $rows = $rows | append (dict "n" . "l" "registered 3D images") }}{{ end -}}
+  {{- with $c.datasets }}{{ $rows = $rows | append (dict "n" . "l" "imaging datasets") }}{{ end -}}
+  {{- with $c.connections }}{{ $rows = $rows | append (dict "n" . "l" "synaptic connections") }}{{ end -}}
+  {{- with $c.sc_clusters }}{{ $rows = $rows | append (dict "n" . "l" "single-cell clusters") }}{{ end -}}
+  {{- with $c.anatomy_terms }}{{ $rows = $rows | append (dict "n" . "l" "anatomy ontology terms") }}{{ end -}}
+
+{{- else if eq $set "em" -}}
+  {{- with $c.connected_neurons }}{{ $rows = $rows | append (dict "n" . "l" "neurons with connectivity") }}{{ end -}}
+  {{- with $c.connections }}{{ $rows = $rows | append (dict "n" . "l" "synaptic connections") }}{{ end -}}
+  {{- with $c.cell_types }}{{ $rows = $rows | append (dict "n" . "l" "cell types with neuron images") }}{{ end -}}
+
+{{- else if eq $set "lm" -}}
+  {{- with $c.ep_images }}{{ $rows = $rows | append (dict "n" . "l" "expression pattern images") }}{{ end -}}
+  {{- with $c.drivers }}{{ $rows = $rows | append (dict "n" . "l" "driver lines imaged") }}{{ end -}}
+  {{- with $c.split_images }}{{ $rows = $rows | append (dict "n" . "l" "split combination images") }}{{ end -}}
+  {{- with $c.fragment_images }}{{ $rows = $rows | append (dict "n" . "l" "expression fragment images") }}{{ end -}}
+  {{- with $c.expression_annotations }}{{ $rows = $rows | append (dict "n" . "l" "expression annotations") }}{{ end -}}
+
+{{- else if eq $set "connectivity" -}}
+  {{- with $c.connected_neurons }}{{ $rows = $rows | append (dict "n" . "l" "neurons with connectivity") }}{{ end -}}
+  {{- with $c.connections }}{{ $rows = $rows | append (dict "n" . "l" "neuron-to-neuron connections") }}{{ end -}}
+
+{{- else if eq $set "scrnaseq" -}}
+  {{- with $c.sc_clusters }}{{ $rows = $rows | append (dict "n" . "l" "clusters") }}{{ end -}}
+  {{- with $c.sc_datasets }}{{ $rows = $rows | append (dict "n" . "l" "datasets") }}{{ end -}}
+  {{- with $c.sc_genes }}{{ $rows = $rows | append (dict "n" . "l" "distinct genes expressed") }}{{ end -}}
+
+{{- else if eq $set "ontology" -}}
+  {{- with $c.anatomy_terms }}{{ $rows = $rows | append (dict "n" . "l" "anatomy classes") }}{{ end -}}
+  {{- with $c.ns_parts }}{{ $rows = $rows | append (dict "n" . "l" "nervous system parts") }}{{ end -}}
+  {{- with $c.neuron_classes }}{{ $rows = $rows | append (dict "n" . "l" "neuron classes") }}{{ end -}}
+{{- end -}}
+
+{{- with $rows }}
+<div class="stats vfb-figures">
+  {{- range . }}
+  <div class="stat">
+    <div class="stat__num">{{ if ge .n 1000000 }}{{ lang.FormatNumberCustom 1 (div (float .n) 1000000) }} M{{ else }}{{ lang.FormatNumberCustom 0 .n }}{{ end }}</div>
+    <div class="stat__label">{{ .l }}</div>
+  </div>
+  {{- end }}
+</div>
+{{- end -}}


### PR DESCRIPTION
Two theme fixes and a Data-section rewrite, all visible on the live site.

## 1. The nav overlaps every page outside the docs shell

`single.html`, `list.html`, `taxonomy.html` and `term.html` wrap their content in
`<div class="page">`, but the theme has no `.page` rule — confirmed absent from the live
bundle `/css/nova.min.c5b9a6a9d7c1eb3d146d41e30734391485815307f3ad85292418dce82bdc6ea3.css`.
Only `.hero` and `.doc` carry `padding-top: calc(var(--nav-h) + …)`, so everything else
renders under the 68 px fixed header: all of `/blog/**` (news, releases, ontologies),
every generated ontology term page, and the taxonomy and tag lists. That is the large
majority of the site's pages.

Adds `.page` and `.page__header` alongside the existing `.doc__header` rules, matching
the docs shell's spacing.

## 2. The hero figures counted pages, not data

`763,268 indexed anatomy terms` was `len .RegularPagesRecursive` over `/blog/ontologies`
— the generated term corpus across all 22 integrated ontologies. Most of it is
NCBITaxon, and none of it is a count of anatomy. The real figure from the content report
is 28,772. The remaining tiles were documentation page count and hosted-service count,
so the front page said nothing at all about imaging, connectomics or transcriptomics.

New `partials/content-stats.html` reads the figures out of the content report page in
`/blog/releases`, which the reporting pipeline regenerates against
`pdb.virtualflybrain.org` after every data release. The hero now reads:

| | |
|---|---|
| 608,512 | registered 3D images from 136 datasets |
| 488,111 | neurons with connectomics |
| 34.7 M | synaptic connections |
| 28,772 | anatomy ontology terms |
| 3,290 | single-cell clusters from 24 datasets |

The report is not in this repository, so a checkout without it falls back to the
site-shape tiles (ontologies integrated, community services hosted, documentation pages)
rather than printing a constant that would go stale at the next data release.

## 3. The Data section described the smallest datatypes best

`Data/_index.md` was three sentences and no figures. `Data/LM/_index.md` was one
sentence and a single FlyLight child page, although light microscopy is around 120 of
the 210 datasets in the knowledge base. `Data/scRNAseq` linked to a TSV on GitHub for
its dataset list. There was no connectivity page at all, though connectivity is what
most users arrive for. `templates.md` and the EM comparison table were already good and
are left alone apart from adding figures.

- **`vfb-figures` shortcode** over the same content-report partial, so each page opens
  with the counts for its own modality and they track the data release rather than going
  stale in prose. Sets: `overview`, `em`, `lm`, `connectivity`, `scrnaseq`, `ontology`.
- **`Data/_index`** — what integration means here, a routing table over the datatypes,
  provenance and citation, and the licence position.
- **`Data/LM`** — the distinction between whole-pattern and single-neuron images, a
  collection table to match the EM one, how expression annotations are made and what
  they do not assert, and five routes in.
- **`Data/connectivity`** (new) — what an edge is and is not, the four kinds VFB holds,
  the eight contributing connectomes, why `hb` and `fafb` are excluded by default, and
  direction semantics stated explicitly.
- **`Data/scRNAseq`** — all 24 datasets rendered as a table with cluster and gene counts.
- **`Data/EM`** — figures, and a pointer to the new connectivity page.

Publications are cited only where the citation was read back from the knowledge base;
elsewhere the table links the dataset's own VFB page rather than carrying a reference
that could drift.

## Testing

Hugo v0.164.0 (as pinned in `Dockerfile` and `netlify.toml`),
`hugo --noBuildLock --gc --minify`: 189 pages, no WARN or ERROR, and no broken internal
links under `/docs/data`. Verified with the content report present in the tree (figures
above, from `VFB_reporting_results@master`, report date 2026-08-15) and absent — absent,
the hero falls back to the site-shape tiles and the in-page figure strips render nothing
rather than empty boxes. `.page{…padding-top:calc(var(--nav-h) + var(--sp-6))…}` is
present in the minified output, and the breadcrumb clears the header in a rendered
screenshot.

## Follow-ups, not in this PR

Dataset label defects found while inventorying the 210 dataset records — ten pairs of
duplicate labels, `SplitDavis2017` carrying the Turner-Evans label, four
label/short_form year-or-author disagreements, and the short_form rendered twice on
every VFB-hosted dataset. These are curation-side and are written up separately.
