### PR TITLE
Credit the hero body model, and lift the silhouette out of the background

### DIFF
--- a/themes/vfb-nova/assets/css/nav.css
+++ b/themes/vfb-nova/assets/css/nav.css
@@ -223,3 +223,14 @@
   color: var(--text-dim);
 }
 .footer__social a:hover { border-color: var(--brand); color: var(--text); background: var(--surface); }
+
+/* Attribution for the hero body model. Apache-2.0 requires the notice to be
+   distributed with the work, and an HTML comment is not that. Sits in the legal
+   row, sized down so it reads as a credit rather than navigation. */
+.footer__credit {
+  font-size: .78rem;
+  color: var(--muted);
+  flex: 1 1 22rem;
+  min-width: 0;
+}
+.footer__credit a { font-size: inherit; }

--- a/themes/vfb-nova/assets/js/connectome.js
+++ b/themes/vfb-nova/assets/js/connectome.js
@@ -292,9 +292,14 @@
       if (nodes[i].k !== 0) continue;
       const p = proj[i];
       const fade = 0.35 + 0.65 * (1 - (p.d + 1) / 2);
-      ctx.globalAlpha = (nodes[i].limb ? 0.05 + 0.10 * fade : 0.22 + 0.48 * fade);
+      /* Raised from 0.05/0.22 base. At the original values the silhouette read
+         as scattered dust rather than a fly, especially on the light theme where
+         the body colour is a muted blue-grey on near-white. Limbs stay dimmer
+         than the torso so the outline still recedes behind the CNS, which is
+         the subject. */
+      ctx.globalAlpha = (nodes[i].limb ? 0.11 + 0.19 * fade : 0.32 + 0.55 * fade);
       ctx.beginPath();
-      ctx.arc(p.x, p.y, nodes[i].r * p.p * (nodes[i].limb ? 0.95 : 1.35), 0, 6.283);
+      ctx.arc(p.x, p.y, nodes[i].r * p.p * (nodes[i].limb ? 1.05 : 1.45), 0, 6.283);
       ctx.fill();
     }
     ctx.globalAlpha = 1;

--- a/themes/vfb-nova/layouts/partials/footer.html
+++ b/themes/vfb-nova/layouts/partials/footer.html
@@ -54,6 +54,9 @@
 
     <div class="footer__legal">
       <span>© {{ now.Year }} {{ .Site.Params.copyright | default .Site.Title }}</span>
+      <span class="footer__credit">Hero body model from
+        <a href="https://doi.org/10.1101/2024.03.11.584515" rel="noopener">flybody</a>
+        (Vaxenburg et al. 2024), Apache-2.0. CNS from VFB JRC2018Unisex templates.</span>
       <span style="display:flex;gap:1.2rem;flex-wrap:wrap">
         <a href="/about/privacy/">Privacy</a>
         <a href="/about/cookies/">Cookies</a>


### PR DESCRIPTION
## What

Two small changes to the hero merged in #422.

**1. Credit the body model.** The `flybody` attribution existed only as an HTML
comment in `cover.html` and a field inside `hero-geometry.json`. Neither is
visible to a reader. Apache-2.0 requires the notice to travel with the work, so
it now appears in the footer legal row:

> Hero body model from **flybody** (Vaxenburg et al. 2024), Apache-2.0. CNS from
> VFB JRC2018Unisex templates.

Sized down so it reads as a credit rather than navigation, and it links to the
paper.

**2. Lift the body silhouette out of the background.**

| | before | after |
|---|---|---|
| torso opacity | `0.22 + 0.48 * fade` | `0.32 + 0.55 * fade` |
| limb opacity | `0.05 + 0.10 * fade` | `0.11 + 0.19 * fade` |
| point radius | 1.35 / 0.95 | 1.45 / 1.05 |

At the original values the silhouette read as scattered dust rather than a fly,
especially on the light theme where the body colour is a muted blue-grey against
near-white. Limbs stay dimmer than the torso, so the outline still recedes
behind the CNS, which remains the subject.

## Verified

Built and rendered headless at 1440x900 on this branch:

* 187 pages, no `WARN`, no `ERROR`
* footer credit renders in the legal row and wraps correctly
* no new external requests

## What this does not fix

⚠️ **The hero still does not read as a fly.** The silhouette is brighter but
remains diffuse, and on wide viewports the news card covers much of the body
area. Making it legible is a shape and composition problem rather than a
brightness one, and wants a separate design pass.

The credit should not wait for that.


