### PR TITLE
Update the FlyBase funding appeal to the March 2026 position

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -16,28 +16,23 @@ description = "Welcome to Virtual Fly Brain (VFB) - an interactive tool for neur
 	</a>
 	<p class="lead mt-5">A hub for Drosophila melanogaster neural anatomy, imaging data & connectomics.</p>
 
-			<div id="contributeBox" class="panel panel-info" style="background-color:#fe0; border:2px solid black; border-radius:5px; margin:1em auto; max-width:1000px;color: black;">
-
-                <div class="panel-body text-center">
-
-                  <p>
-                    <b style="color:red">
-                      <span> <a href="https://flybase.org/" target="_blank">Our colleagues at FlyBase need your help!</a> </span>
-                    </b>
-                  </p>
-                  <p>
-                    <b>
-					  Because of changes to US government funding, the foreign subaward of the NHGRI grant that supported the <a href="https://flybase.org/" target="_blank">FlyBase</a> curation team at the University of Cambridge has been terminated.
-					  They are now reaching out to the community to assist with funding. Please click here for more information and to contribute:
-					  <a href="https://wiki.flybase.org/wiki/FlyBase:Contribute_to_FlyBase" target="_blank">Contribute to FlyBase wiki page</a>
-                      Thank you in advance for your support in allowing FlyBase to continue serving the Drosophila research community.
-		      		  We remain grateful to Wellcome for their continued support of Virtual Fly Brain.
-                    </b>
-                  </p>
-
-                </div>
-
-              </div>
+			<div id="contributeBox" class="notice">
+				<i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+				<div>
+					<p>
+						<strong>Our colleagues at <a href="https://flybase.org/" target="_blank" rel="noopener">FlyBase</a> still need your help.</strong>
+						As of FlyBase's March 2026 update, NHGRI funding has been restored for the US-based FlyBase teams, but the
+						foreign subaward that supported the curation team at the University of Cambridge remains terminated.
+					</p>
+					<p>
+						That team now asks fly labs for an annual contribution — a suggested £/€200 or $250 per researcher — to keep
+						curating new data into FlyBase and the Alliance of Genome Resources. Without it, FlyBase freezes in its
+						current state. VFB depends on FlyBase for much of what it does, so we would ask you to contribute if you can:
+						<a href="https://wiki.flybase.org/wiki/FlyBase:Contribute_to_FlyBase" target="_blank" rel="noopener">how to contribute to FlyBase</a>.
+					</p>
+					<p>We remain grateful to Wellcome for their continued support of Virtual Fly Brain.</p>
+				</div>
+			</div>
 
 	{{< blocks/link-down color="info" >}}
 </div>

--- a/content/en/blog/news/FlyBase Funding.md
+++ b/content/en/blog/news/FlyBase Funding.md
@@ -1,15 +1,52 @@
 ---
-title: "FlyBase Emergency Funding"
+title: "FlyBase Funding"
 linkTitle: "FlyBase Funding"
-date: 2025-06-11
+date: 2026-03-01
+lastmod: 2026-08-15
+aliases:
+  - /blog/2025/06/11/flybase-funding/
 description: >
-    Please consider donating to support FlyBase
+    FlyBase's March 2026 update: US funding restored, the Cambridge curation team still unfunded
 ---
 
-VFB works closely with the FlyBase team and we rely on their hard work to provide many of our features. Due to the current funding situation at [FlyBase](https://flybase.org/), we encourage our users to donate and help maintain this essential resource.
+VFB works closely with the FlyBase team and depends on their work for many of its
+features. FlyBase's funding position changed in March 2026, and not entirely for the
+better.
 
-Because of recent NIH impediments to international collaboration, FlyBase has divided forces:
-- European labs can contribute via this crowdfunding [link](https://www.philanthropy.cam.ac.uk/give-to-cambridge/physiology-development-and-neuroscience/drosophila-genetic-database), where you can also request to make a donation from a grant.
-- the FlyBase U.S. fee system will be set up soon.
+NHGRI funding has been **restored for the US-based FlyBase teams**. The foreign
+subaward that supported the curation team at the University of Cambridge has
+**not** been restored, and remains terminated. In FlyBase's own words:
 
-We are grateful to the Wellcome Trust for their continued funding of VFB.
+> The NHGRI funding for FlyBase has been restored for US-based FlyBase teams but the
+> foreign subaward that supported the essential curation team at the University of
+> Cambridge UK has been terminated. Therefore, the Cambridge UK team now requests annual
+> contributions from fly labs to support curation of new data into FlyBase and the
+> Alliance of Genome Resources. Without these annual contributions, FlyBase will become
+> frozen in its current state and become progressively less useful.
+
+## How to contribute
+
+The two-route arrangement described in our earlier post — a European crowdfunding page
+and a US fee system still to be set up — has been replaced by a single annual
+contribution, open to labs anywhere. The suggested amount is **£/€200 or $250 per fly
+researcher per year**.
+
+- **By card**, through the University of Cambridge online store, which needs no invoice:
+  [annual contribution to fund biocuration at the FlyBase knowledgebase](https://onlinesales.admin.cam.ac.uk/product-catalogue/products/schools-faculties-departments-and-institutions/physiology-development-neuroscience/pdn-annual-contribution-to-fund-biocuration-at-the-flybase-knowledgebase).
+  Payments are accepted in GBP, Euro and USD.
+- **By purchase order**, if your institution requires an invoice: email
+  `flybase-finance@pdn.cam.ac.uk`.
+
+Current details are on the
+[Contribute to FlyBase](https://wiki.flybase.org/wiki/FlyBase:Contribute_to_FlyBase)
+wiki page.
+
+## Why it matters to VFB
+
+Curation is the part at risk, and curation is what VFB consumes. FlyBase supplies the
+gene, allele, transgene and stock records behind VFB's driver-line and reagent queries,
+and the [scRNAseq datasets](/docs/data/scrnaseq/) VFB integrates come to us through
+FlyBase from the Single Cell Expression Atlas. A FlyBase frozen at its current state
+means new *Drosophila* nervous-system data stops reaching VFB by that route.
+
+We remain grateful to Wellcome for their continued funding of Virtual Fly Brain.

--- a/themes/vfb-nova/assets/css/content-hooks.css
+++ b/themes/vfb-nova/assets/css/content-hooks.css
@@ -37,21 +37,17 @@
 .btn-secondary { background: var(--surface-2); color: var(--text); }
 a.btn { text-decoration: none; }
 
-/* The FlyBase appeal box is hard-styled inline in content/en/_index.html.
-   Neutralise the yellow block and re-cast it as the theme's notice band. */
+/* The FlyBase appeal box. It used to be a Docsy panel hard-styled inline
+   (#fe0 background, black border, red heading) and this rule neutralised it.
+   It is now written as the theme's .notice band directly, so all that is left
+   is the hero placement: margin, and the paragraph rhythm inside the band.
+   The heading is a <strong> rather than coloured text — --signal is #ffe406 in
+   both themes, which is unreadable on the light background. */
 #contributeBox {
-  background: linear-gradient(120deg, rgba(255,228,6,.10), rgba(255,107,154,.07)) !important;
-  border: 1px solid rgba(255,228,6,.35) !important;
-  border-radius: var(--r-lg) !important;
-  color: var(--text-dim) !important;
-  margin: var(--sp-4) 0 0 !important;
-  max-width: none !important;
+  margin: var(--sp-4) 0 0;
   font-size: .88rem;
 }
-#contributeBox .panel-body { padding: var(--sp-4) var(--sp-5); text-align: left !important; }
-#contributeBox b, #contributeBox strong { font-weight: 550; color: var(--text-dim); }
-#contributeBox b[style*="red"] { color: var(--signal) !important; font-weight: 650; }
-#contributeBox b[style*="red"] a { color: var(--signal); }
+#contributeBox p { margin-bottom: .6rem; }
 #contributeBox p:last-child { margin-bottom: 0; }
 
 /* link-down chevron */


### PR DESCRIPTION
FlyBase's March 2026 update restored NHGRI funding for the US-based teams; the foreign
subaward supporting the Cambridge curation team was not restored. Both the home page
notice and the news article still described the mid-2025 position, and the article still
pointed at a two-route arrangement that no longer exists — a European crowdfunding page
and a US fee system "to be set up soon". There is now one annual contribution, open to
labs anywhere, at a suggested £/€200 or $250 per researcher. The old crowdfunding URL on
`philanthropy.cam.ac.uk` redirects to a login page, so it is replaced by the Cambridge
online store and the purchase-order address, both from the Contribute to FlyBase wiki
page.

The article's date moves to the date of the FlyBase update rather than today, so the
post is not passed off as newer than the news it carries; an alias keeps the old
`/blog/2025/06/11/flybase-funding/` URL working.

The home page notice was a Docsy panel hard-styled inline — `#fe0` background, black
border, red heading — which `content-hooks.css` then overrode. In light mode the heading
resolved to `--signal` (`#ffe406`) on white and could not be read. It is now the theme's
own `.notice` band, so the override shrinks to placement and both colour schemes work.

The article also gains a short section on why this matters to VFB specifically: FlyBase
supplies the gene, allele, transgene and stock records behind VFB's driver-line and
reagent queries, and the scRNAseq datasets reach VFB through FlyBase from the Single
Cell Expression Atlas.

## Testing

Hugo v0.164.0, `hugo --noBuildLock --gc --minify` on current `master` (so after #422 and
#423): 189 pages, no WARN or ERROR. The `/blog/2025/06/11/flybase-funding/` alias is
emitted, the notice renders as `.notice` and is screenshot-checked in both colour
schemes, and the hero stat tiles from #423 are unaffected.

## Note

This was written as a fourth commit on the #423 branch but landed after that PR merged,
so it is split out here on a fresh branch off `master`.
