### PR TITLE
Correct FlyBase notice wording to clarify the VFB–FlyBase position

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -27,10 +27,13 @@ description = "Welcome to Virtual Fly Brain (VFB) - an interactive tool for neur
 					<p>
 						That team now asks fly labs for an annual contribution — a suggested £/€200 or $250 per researcher — to keep
 						curating new data into FlyBase and the Alliance of Genome Resources. Without it, FlyBase freezes in its
-						current state. VFB depends on FlyBase for much of what it does, so we would ask you to contribute if you can:
+						current state. VFB and FlyBase are long-standing partners: we maintain the <em>Drosophila</em> anatomy, cell
+						type and developmental ontologies the community works with, and FlyBase curates the genetic reagents and
+						literature that turn those data into experiments. Losing that curation would slow work right across the fly
+						community, so please contribute if you can:
 						<a href="https://wiki.flybase.org/wiki/FlyBase:Contribute_to_FlyBase" target="_blank" rel="noopener">how to contribute to FlyBase</a>.
 					</p>
-					<p>We remain grateful to Wellcome for their continued support of Virtual Fly Brain.</p>
+					<p>Virtual Fly Brain's own funding is unaffected, and we remain grateful to Wellcome for their continued support.</p>
 				</div>
 			</div>
 


### PR DESCRIPTION
A correction to the FlyBase contribution notice on the homepage.

The text stated that "VFB depends on FlyBase for much of what it does". That misstates the position and reads as though VFB is at risk if FlyBase curation stops.

VFB maintains the *Drosophila* anatomy, cell type and developmental ontologies itself — they are hosted on FlyBase's GitHub, but VFB edits them. FlyBase curates the genetic reagents and literature. The notice now describes that relationship accurately, makes the case for contributing on behalf of the fly community rather than on behalf of VFB, and confirms that VFB's own funding is unaffected.

Copy only — one file, `content/en/_index.html`, no markup or layout change beyond an `<em>` on the species name.

To check: `hugo server` and read the notice on the landing page.
