### PR TITLE
List all LM datasets grouped by data provider

### DIFF
--- a/content/en/docs/Data/LM/_index.md
+++ b/content/en/docs/Data/LM/_index.md
@@ -40,28 +40,27 @@ pattern can be scored for overlap against any region or neuron.
 ## Data providers
 
 VFB holds 125 light microscopy datasets. Each is grouped below by where its images were
-produced, which VFB records either through the source cross-references carried by the
-images or in the dataset's own description. Follow a provider for the full list of its
-datasets.
+produced. For the large collections that is recorded in VFB, through the source
+cross-references carried by the images or the dataset's own description; for the
+directly-deposited sets it was established by reading the cited paper.
 
 | Provider | What it contributes | Datasets | Records in VFB |
 |---|---|---|---|
-| [Janelia FlyLight](/docs/data/lm/flylight/) | The Generation 1 GMR GAL4/LexA collection, its MCFO single-neuron derivatives, the Truman larval flip-out collection, and the per-paper split-GAL4 sets | 59 | 72,325 |
+| [Janelia FlyLight](/docs/data/lm/flylight/) | The Generation 1 GMR GAL4/LexA collection, its MCFO single-neuron derivatives, the Truman larval flip-out collection, and the per-paper split-GAL4 sets | 62 | 72,357 |
 | [VDRC](/docs/data/lm/vdrc/) | The Dickson lab VT enhancer-fragment collection, imaged at VDRC and re-imaged at Janelia | 3 | 23,395 |
 | [FlyCircuit](/docs/data/lm/flycircuit/) | Single neurons from the Chiang lab collection, one neuron per image | 1 | 16,127 |
+| [Contributing laboratories](/docs/data/lm/labs/) | Lineage clone sets, *fru* clones and single-study collections deposited directly by the lab that produced them | 12 | 1,048 |
 | [BrainTrap](/docs/data/lm/braintrap/) | Protein-trap expression patterns in the adult brain | 1 | 501 |
-| [Source not recorded](/docs/data/lm/other/) | Lineage and clone sets, direct lab deposits, and the per-paper split-GAL4 sets with no images loaded | 52 | 1,080 |
+| [No images loaded](/docs/data/lm/other/) | Dataset records whose split combinations are searchable but whose imagery is not held by VFB | 37 | none |
 | [Templates and painted domains](/docs/data/templates/) | Reference templates and the neuropil domains drawn onto them | 9 | 865 |
 
 Records are the individuals VFB holds from a dataset — expression patterns, fragments,
 single neurons or painted domains. They count what VFB has loaded, not what a collection
 contains at source.
 
-The 52 datasets under *Source not recorded* hold only 1,080 records between them. That
-grouping reflects a gap in VFB's own metadata rather than anything about the images: a
-dataset lands there when neither its images nor its description name a source, which
-includes every dataset whose record exists but whose images have not been loaded. Those
-are flagged individually on that page.
+Every dataset that holds images has an attributed source. The 37 under *No images loaded*
+are dataset records without imagery: their split combinations are recorded as FlyBase
+features and are searchable, but there is no image data to attribute.
 
 Citations are recorded on each dataset's own page on VFB rather than repeated here, so
 that they stay correct if a record is updated. Cite the original study, not VFB, when you

--- a/content/en/docs/Data/LM/_index.md
+++ b/content/en/docs/Data/LM/_index.md
@@ -37,27 +37,35 @@ Every one of these is registered to a template, so a single-neuron image from on
 can be compared directly against an EM reconstruction from another, and a driver's
 pattern can be scored for overlap against any region or neuron.
 
-## Major collections
+## Data providers
 
-Collections are grouped here by what they contain. VFB holds around 120 LM datasets in
-total, most of them the per-paper split-GAL4 sets described below; the full list is
-reachable from any template's `All datasets` query.
+VFB holds 125 light microscopy datasets. Each is grouped below by where its images were
+produced, which VFB records either through the source cross-references carried by the
+images or in the dataset's own description. Follow a provider for the full list of its
+datasets.
 
-| Collection | Anatomy / stage | What the images show | VFB dataset | Publication |
-|---|---|---|---|---|
-| FlyLight Gen1 GAL4/LexA | Adult brain and VNC | Whole expression patterns of the GMR enhancer-fragment collection | [FlyLightGen1Set2019](http://virtualflybrain.org/reports/FlyLightGen1Set2019) | [Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011) |
-| FlyLight Gen1 MCFO | Adult brain and VNC | Single neurons stochastically labelled within Gen1 lines | [Gen1MCFOJenett2012](http://virtualflybrain.org/reports/Gen1MCFOJenett2012) and four further sets | [Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011) |
-| VT collection (Dickson lab) | Adult brain | Whole expression patterns of the VT GAL4, LexA and split lines, imaged at VDRC | [Dickson_VT](http://virtualflybrain.org/reports/Dickson_VT) | [Tirian and Dickson, 2017](https://doi.org/10.1101/198648) |
-| FlyCircuit 1.0 | Adult brain | Single neurons from the Chiang lab collection, one neuron per image | [Chiang2010](http://virtualflybrain.org/reports/Chiang2010) | [Chiang et al., 2011](https://doi.org/10.1016/j.cub.2010.11.056) |
-| *fru* clones | Adult brain | Clonal units of the *fruitless*-positive circuitry | [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | [Cachero et al., 2010](https://doi.org/10.1016/j.cub.2010.07.045) |
-| Per-paper split-GAL4 sets | Mostly adult brain and VNC | Split combinations characterised in one publication each — around 70 sets, from Aso and Rubin's dopaminergic lines through to Nern, Wolff, Zhao and Zung in 2025 | Search `Split` in datasets | Per dataset page |
-| Truman larval flip-out | Larval CNS | Single neurons and small clones in the larval CNS | [TrumanWood2018](http://virtualflybrain.org/reports/TrumanWood2018) | Per dataset page |
-| Lineage and clone sets | Adult brain | Neuroblast lineage clones from the Ito, Yu and Lee collections | [Ito2013](http://virtualflybrain.org/reports/Ito2013), [Yu2013](http://virtualflybrain.org/reports/Yu2013), [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | Per dataset page |
-| BrainTrap | Adult brain | Protein-trap expression patterns | [Knowles_Barley2010](http://virtualflybrain.org/reports/Knowles_Barley2010) | Per dataset page |
+| Provider | What it contributes | Datasets | Records in VFB |
+|---|---|---|---|
+| [Janelia FlyLight](/docs/data/lm/flylight/) | The Generation 1 GMR GAL4/LexA collection, its MCFO single-neuron derivatives, the Truman larval flip-out collection, and the per-paper split-GAL4 sets | 59 | 72,325 |
+| [VDRC](/docs/data/lm/vdrc/) | The Dickson lab VT enhancer-fragment collection, imaged at VDRC and re-imaged at Janelia | 3 | 23,395 |
+| [FlyCircuit](/docs/data/lm/flycircuit/) | Single neurons from the Chiang lab collection, one neuron per image | 1 | 16,127 |
+| [BrainTrap](/docs/data/lm/braintrap/) | Protein-trap expression patterns in the adult brain | 1 | 501 |
+| [Source not recorded](/docs/data/lm/other/) | Lineage and clone sets, direct lab deposits, and the per-paper split-GAL4 sets with no images loaded | 52 | 1,080 |
+| [Templates and painted domains](/docs/data/templates/) | Reference templates and the neuropil domains drawn onto them | 9 | 865 |
 
-Where the Publication column says *per dataset page*, the citation is recorded on the
-dataset's own page on VFB rather than repeated here, so that it stays correct if the
-record is updated. Cite the original study, not VFB, when you use the images.
+Records are the individuals VFB holds from a dataset — expression patterns, fragments,
+single neurons or painted domains. They count what VFB has loaded, not what a collection
+contains at source.
+
+The 52 datasets under *Source not recorded* hold only 1,080 records between them. That
+grouping reflects a gap in VFB's own metadata rather than anything about the images: a
+dataset lands there when neither its images nor its description name a source, which
+includes every dataset whose record exists but whose images have not been loaded. Those
+are flagged individually on that page.
+
+Citations are recorded on each dataset's own page on VFB rather than repeated here, so
+that they stay correct if a record is updated. Cite the original study, not VFB, when you
+use the images.
 
 ## Expression annotations
 

--- a/content/en/docs/Data/LM/braintrap/index.md
+++ b/content/en/docs/Data/LM/braintrap/index.md
@@ -1,0 +1,27 @@
+---
+title: "BrainTrap"
+linkTitle: "BrainTrap"
+weight: 50
+tags: ["BrainTrap","protein_trap","expression_pattern"]
+description: >
+    Protein-trap expression patterns in the adult brain, from the BrainTrap collection.
+---
+
+## Introduction
+
+BrainTrap is a collection of protein-trap lines imaged in the adult brain. Unlike an
+enhancer-fragment driver, a protein trap reports the expression of the gene it is inserted
+into, so these patterns speak to endogenous gene expression rather than to a fragment's
+activity.
+
+The original collection is browsable at
+[braintrap.virtualflybrain.org](https://braintrap.virtualflybrain.org/), which VFB hosts.
+
+## Datasets
+
+| Dataset | Contents | Records in VFB |
+|---|---|---|
+| [Knowles_Barley2010](http://virtualflybrain.org/reports/Knowles_Barley2010) | BrainTrap lines (Knowles-Barley2010) | 501 |
+
+Records are the individuals VFB holds from each dataset. Citations are on each dataset's
+own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/LM/flycircuit/index.md
+++ b/content/en/docs/Data/LM/flycircuit/index.md
@@ -1,0 +1,28 @@
+---
+title: "FlyCircuit — Chiang lab"
+linkTitle: "FlyCircuit"
+weight: 40
+tags: ["FlyCircuit","single_neuron","Chiang","NBLAST"]
+description: >
+    Single-neuron images from the FlyCircuit collection, produced in the Chiang lab.
+---
+
+## Introduction
+
+FlyCircuit is a single-neuron image collection built in the Chiang lab from stochastic
+labelling of GAL4 lines, with one segmented neuron per image. It is the largest body of
+single-neuron light microscopy VFB holds outside the FlyLight MCFO sets, and it is what
+[NBLAST](/docs/website-features/) was originally developed against, so it remains a dense
+reference for morphology search in the adult brain.
+
+Each image links back to its record on [flycircuit.tw](http://www.flycircuit.tw/), where
+the raw and unsegmented data live.
+
+## Datasets
+
+| Dataset | Contents | Records in VFB |
+|---|---|---|
+| [Chiang2010](http://virtualflybrain.org/reports/Chiang2010) | FlyCircuit 1.0 - single neurons (Chiang2010) | 16,127 |
+
+Records are the individuals VFB holds from each dataset. Citations are on each dataset's
+own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/LM/flylight/index.md
+++ b/content/en/docs/Data/LM/flylight/index.md
@@ -33,11 +33,12 @@ Also see [FlyLight Imaging Tile Documentation](/docs/concepts/flylight_tiles/).
 
 ## Datasets
 
-These are the datasets whose images carry a FlyLight or Janelia source cross-reference in
-VFB, or whose description names Janelia as the source. They fall into three kinds: the
-Generation 1 GMR enhancer-fragment collection with its MCFO single-neuron derivatives, the
-per-paper split-GAL4 sets characterised in individual publications, and larval material
-from the Truman flip-out collection.
+These are the datasets produced through the FlyLight project or otherwise sourced at
+Janelia, identified from the FlyLight and Janelia source cross-references carried by their
+images, from the dataset description, or from the release paper. They fall into three
+kinds: the Generation 1 GMR enhancer-fragment collection with its MCFO single-neuron
+derivatives, the per-paper split-GAL4 sets characterised in individual publications, and
+larval material from the Truman flip-out collection.
 
 | Dataset | Contents | Records in VFB |
 |---|---|---|
@@ -63,6 +64,7 @@ from the Truman flip-out collection.
 | [SplitSchretter2020](http://virtualflybrain.org/reports/SplitSchretter2020) | Split-GAL4 lines from Schretter et al., 2020 | 61 |
 | [SplitBogovic2020](http://virtualflybrain.org/reports/SplitBogovic2020) | Split-GAL4 lines from Bogovic et al., 2020 | 52 |
 | [SplitEhrhardt2023](http://virtualflybrain.org/reports/SplitEhrhardt2023) | Split-GAL4 lines from Ehrhardt et al., 2023 | 33 |
+| [FlyLight2019Strother2017](http://virtualflybrain.org/reports/FlyLight2019Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 32 |
 | [AsoRubin2016](http://virtualflybrain.org/reports/AsoRubin2016) | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 30 |
 | [FlyLight2019Wolff2018](http://virtualflybrain.org/reports/FlyLight2019Wolff2018) | Splits targetting CX neurons, Wolff2018 | 21 |
 | [SplitVogt2016](http://virtualflybrain.org/reports/SplitVogt2016) | Split-GAL4 lines from Vogt et al., 2016 | 21 |
@@ -99,11 +101,17 @@ from the Truman flip-out collection.
 | [FlyLight2019Klapoetke2017](http://virtualflybrain.org/reports/FlyLight2019Klapoetke2017) | Split-GAL4 lines from Klapoetke et al. 2017 | 1 |
 | [FlyLight2019Robie2017](http://virtualflybrain.org/reports/FlyLight2019Robie2017) | split-GAL4 lines for EB neurons (Robie2017) | 1 |
 | [SplitTurner_Evans2017](http://virtualflybrain.org/reports/SplitTurner_Evans2017) | Split-GAL4 lines from Turner-Evans et al., 2017 | 1 |
+| [FlyLight2019Hampel2015](http://virtualflybrain.org/reports/FlyLight2019Hampel2015) | Grooming neurons and drivers (Hampel 2015) | none loaded |
+| [Gen1MCFOJovanic2019](http://virtualflybrain.org/reports/Gen1MCFOJovanic2019) | MCFO images of GMR-GAL4 lines from Jovanic et al., 2019 | none loaded |
 | [LateralHorn2019](http://virtualflybrain.org/reports/LateralHorn2019) | FlyLight split-GAL4 lines for Lateral Horn | none loaded |
 
 Records are the individuals VFB holds from each dataset — whole expression patterns,
 fragments and single neurons. Where a row reads *none loaded*, the dataset record exists
 and is linkable but no images have been loaded into VFB.
+
+Datasets from Janelia laboratories that were deposited directly rather than through the
+FlyLight project are listed under
+[Contributing laboratories](/docs/data/lm/labs/).
 
 VT lines are listed under [VDRC](/docs/data/lm/vdrc/), including the subset re-imaged
 through the FlyLight pipeline.

--- a/content/en/docs/Data/LM/flylight/index.md
+++ b/content/en/docs/Data/LM/flylight/index.md
@@ -30,3 +30,83 @@ FlyLight data is integrated and indexed on [VFB](https://v2.virtualflybrain.org/
 Light and EM neurons can also be searched for on [NeuronBridge](https://neuronbridge.janelia.org/)
 
 Also see [FlyLight Imaging Tile Documentation](/docs/concepts/flylight_tiles/).
+
+## Datasets
+
+These are the datasets whose images carry a FlyLight or Janelia source cross-reference in
+VFB, or whose description names Janelia as the source. They fall into three kinds: the
+Generation 1 GMR enhancer-fragment collection with its MCFO single-neuron derivatives, the
+per-paper split-GAL4 sets characterised in individual publications, and larval material
+from the Truman flip-out collection.
+
+| Dataset | Contents | Records in VFB |
+|---|---|---|
+| [Gen1MCFOTirian2017](http://virtualflybrain.org/reports/Gen1MCFOTirian2017) | MCFO images of VT-GAL4 lines from Tirian et al., 2017 | 16,965 |
+| [Gen1MCFOJenett2012](http://virtualflybrain.org/reports/Gen1MCFOJenett2012) | MCFO images of GMR-GAL4 lines from Jenett et al., 2012 | 15,861 |
+| [FlyLightGen1Set2019](http://virtualflybrain.org/reports/FlyLightGen1Set2019) | FlyLight - Gen1 GAL4/LexA collection (exported 2019) | 13,587 |
+| [TrumanWood2018](http://virtualflybrain.org/reports/TrumanWood2018) | Truman Larval Flip-Out Collection | 12,238 |
+| [Jenett2012](http://virtualflybrain.org/reports/Jenett2012) | FlyLight - GMR GAL4 collection (Jenett2012) | 3,469 |
+| [SplitShuai2023](http://virtualflybrain.org/reports/SplitShuai2023) | Split-GAL4 lines from Shuai et al., 2023 | 2,819 |
+| [Aso2014](http://virtualflybrain.org/reports/Aso2014) | MBONs and split-GAL4 lines that target them (Aso2014) | 2,685 |
+| [SplitSterne2021](http://virtualflybrain.org/reports/SplitSterne2021) | Split-GAL4 lines from Sterne et al., 2021 | 1,490 |
+| [SplitMeissner2024](http://virtualflybrain.org/reports/SplitMeissner2024) | Split-GAL4 lines from Meissner et al., 2024 | 864 |
+| [Namiki2018](http://virtualflybrain.org/reports/Namiki2018) | split-GAL4 lines for descending neurons (Namiki2018) | 390 |
+| [Wu2016](http://virtualflybrain.org/reports/Wu2016) | split-GAL4 lines for LC VPNs (Wu2016) | 334 |
+| [Dolan2019](http://virtualflybrain.org/reports/Dolan2019) | GAL4 Split expression patterns from Dolan et al. 2019 | 308 |
+| [Wolff2018](http://virtualflybrain.org/reports/Wolff2018) | Splits targetting CX neurons, Wolff2018 | 213 |
+| [Gen1MCFODionne2018](http://virtualflybrain.org/reports/Gen1MCFODionne2018) | MCFO images of GMR-GAL4 lines from Dionne et al., 2018 | 151 |
+| [FlyLight2019LateralHorn2019](http://virtualflybrain.org/reports/FlyLight2019LateralHorn2019) | FlyLight split-GAL4 lines for Lateral Horn | 131 |
+| [FlyLight2019Namiki2018](http://virtualflybrain.org/reports/FlyLight2019Namiki2018) | split-GAL4 lines for descending neurons (Namiki2018) | 128 |
+| [SplitDavis2020](http://virtualflybrain.org/reports/SplitDavis2020) | Split-GAL4 lines from Davis et al., 2020 | 100 |
+| [Robie2017](http://virtualflybrain.org/reports/Robie2017) | split-GAL4 lines for  EB neurons (Robie2017) | 82 |
+| [SplitWang2020a](http://virtualflybrain.org/reports/SplitWang2020a) | Split-GAL4 lines from Wang et al., 2020a | 70 |
+| [SplitSchretter2020](http://virtualflybrain.org/reports/SplitSchretter2020) | Split-GAL4 lines from Schretter et al., 2020 | 61 |
+| [SplitBogovic2020](http://virtualflybrain.org/reports/SplitBogovic2020) | Split-GAL4 lines from Bogovic et al., 2020 | 52 |
+| [SplitEhrhardt2023](http://virtualflybrain.org/reports/SplitEhrhardt2023) | Split-GAL4 lines from Ehrhardt et al., 2023 | 33 |
+| [AsoRubin2016](http://virtualflybrain.org/reports/AsoRubin2016) | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 30 |
+| [FlyLight2019Wolff2018](http://virtualflybrain.org/reports/FlyLight2019Wolff2018) | Splits targetting CX neurons, Wolff2018 | 21 |
+| [SplitVogt2016](http://virtualflybrain.org/reports/SplitVogt2016) | Split-GAL4 lines from Vogt et al., 2016 | 21 |
+| [Strother2017](http://virtualflybrain.org/reports/Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 20 |
+| [Klapoetke2017](http://virtualflybrain.org/reports/Klapoetke2017) | Split-GAL4 lines from Klapoetke et al. 2017 | 17 |
+| [SplitMinegishi2023](http://virtualflybrain.org/reports/SplitMinegishi2023) | Split-GAL4 lines from Minegishi et al., 2023 | 16 |
+| [SplitMontague2019](http://virtualflybrain.org/reports/SplitMontague2019) | Split-GAL4 lines from Montague et al., 2019 | 15 |
+| [SplitSitaraman2015](http://virtualflybrain.org/reports/SplitSitaraman2015) | Split-GAL4 lines from Sitaraman et al., 2015 | 14 |
+| [FlyLight2019Wu2016](http://virtualflybrain.org/reports/FlyLight2019Wu2016) | split-GAL4 lines for LC VPNs (Wu2016) | 13 |
+| [SplitCheong2023](http://virtualflybrain.org/reports/SplitCheong2023) | Split-GAL4 lines from Cheong et al., 2023 | 10 |
+| [SplitFeng2020](http://virtualflybrain.org/reports/SplitFeng2020) | Split-GAL4 lines from Feng et al., 2020 | 10 |
+| [SplitTurner_Evans2020](http://virtualflybrain.org/reports/SplitTurner_Evans2020) | Split-GAL4 lines from Turner-Evans et al., 2020 | 9 |
+| [SplitBaker2022](http://virtualflybrain.org/reports/SplitBaker2022) | Split-GAL4 lines from Baker et al., 2022 | 8 |
+| [SplitJovanic2019](http://virtualflybrain.org/reports/SplitJovanic2019) | Split-GAL4 lines from Jovanic et al., 2019 | 8 |
+| [SplitRubin2024](http://virtualflybrain.org/reports/SplitRubin2024) | Split-GAL4 lines from Rubin et al., 2024 | 8 |
+| [SplitMorimoto2020](http://virtualflybrain.org/reports/SplitMorimoto2020) | Split-GAL4 lines from Morimoto et al., 2020 | 7 |
+| [SplitNamiki2022](http://virtualflybrain.org/reports/SplitNamiki2022) | Split-GAL4 lines from Namiki et al., 2022 | 7 |
+| [Hampel2015](http://virtualflybrain.org/reports/Hampel2015) | Grooming neurons and drivers (Hampel 2015) | 6 |
+| [SplitKind2021](http://virtualflybrain.org/reports/SplitKind2021) | Split-GAL4 lines from Kind et al., 2021 | 6 |
+| [SplitIsaacson2023](http://virtualflybrain.org/reports/SplitIsaacson2023) | Split-GAL4 lines from Isaacson et al., 2023 | 5 |
+| [SplitWang2020b](http://virtualflybrain.org/reports/SplitWang2020b) | Split-GAL4 lines from Wang et al., 2020b | 5 |
+| [Gen1MCFOPfeiffer2010](http://virtualflybrain.org/reports/Gen1MCFOPfeiffer2010) | MCFO images of GMR-GAL4 lines from Pfeiffer et al., 2010 | 4 |
+| [SplitGao2019](http://virtualflybrain.org/reports/SplitGao2019) | Split-GAL4 lines from Gao et al., 2019 | 4 |
+| [SplitKlapoetke2022](http://virtualflybrain.org/reports/SplitKlapoetke2022) | Split-GAL4 lines from Klapoetke et al., 2022 | 4 |
+| [SplitZhao2023](http://virtualflybrain.org/reports/SplitZhao2023) | Split-GAL4 lines from Zhao et al., 2023 | 4 |
+| [SplitGiraldo2018](http://virtualflybrain.org/reports/SplitGiraldo2018) | Split-GAL4 lines from Giraldo et al., 2018 | 3 |
+| [SplitMasek2015](http://virtualflybrain.org/reports/SplitMasek2015) | Split-GAL4 lines from Masek et al., 2015 | 3 |
+| [SplitXie2021](http://virtualflybrain.org/reports/SplitXie2021) | Split-GAL4 lines from Xie et al., 2021 | 3 |
+| [SplitYamagata2015](http://virtualflybrain.org/reports/SplitYamagata2015) | Split-GAL4 lines from Yamagata et al., 2015 | 3 |
+| [SplitLongden2023](http://virtualflybrain.org/reports/SplitLongden2023) | Split-GAL4 lines from Longden et al., 2023 | 2 |
+| [SplitSchlichting2019](http://virtualflybrain.org/reports/SplitSchlichting2019) | Split-GAL4 lines from Schlichting et al., 2019 | 2 |
+| [TrumanWood2018public](http://virtualflybrain.org/reports/TrumanWood2018public) | Truman Larval Flip-Out Collection | 2 |
+| [FlyLight2019AsoRubin2016](http://virtualflybrain.org/reports/FlyLight2019AsoRubin2016) | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 1 |
+| [FlyLight2019Klapoetke2017](http://virtualflybrain.org/reports/FlyLight2019Klapoetke2017) | Split-GAL4 lines from Klapoetke et al. 2017 | 1 |
+| [FlyLight2019Robie2017](http://virtualflybrain.org/reports/FlyLight2019Robie2017) | split-GAL4 lines for EB neurons (Robie2017) | 1 |
+| [SplitTurner_Evans2017](http://virtualflybrain.org/reports/SplitTurner_Evans2017) | Split-GAL4 lines from Turner-Evans et al., 2017 | 1 |
+| [LateralHorn2019](http://virtualflybrain.org/reports/LateralHorn2019) | FlyLight split-GAL4 lines for Lateral Horn | none loaded |
+
+Records are the individuals VFB holds from each dataset — whole expression patterns,
+fragments and single neurons. Where a row reads *none loaded*, the dataset record exists
+and is linkable but no images have been loaded into VFB.
+
+VT lines are listed under [VDRC](/docs/data/lm/vdrc/), including the subset re-imaged
+through the FlyLight pipeline.
+
+Citations are on each dataset's own page on VFB; cite the original study rather than VFB
+when you use the images.

--- a/content/en/docs/Data/LM/labs/index.md
+++ b/content/en/docs/Data/LM/labs/index.md
@@ -1,0 +1,64 @@
+---
+title: "Contributing laboratories"
+linkTitle: "Contributing labs"
+weight: 55
+tags: ["Expression_pattern","single_neuron","clone","lineage","dataset"]
+description: >
+    Light microscopy datasets deposited directly by the laboratory that produced them, rather than through an imaging facility.
+---
+
+## Introduction
+
+These datasets did not come to VFB through one of the large imaging projects. Each was
+produced by the laboratory that published it and deposited directly, so VFB carries no
+site cross-reference for the images. The imaging source below was established by reading
+each dataset's cited paper — the methods, author affiliations and acknowledgements — not
+from VFB metadata.
+
+Entries marked † are inferred from affiliations and funding because the paper does not
+name an imaging facility outright. Everything else is stated in the paper.
+
+## Datasets
+
+| Dataset | Contents | Imaging source | Records |
+|---|---|---|---|
+| [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | Tzumin Lee lab, Janelia Research Campus | 462 |
+| [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge † | 119 |
+| [Kohl2013](http://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | 111 |
+| [Ito2013](http://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | Kei Ito lab, Institute of Molecular and Cellular Biosciences, University of Tokyo | 96 |
+| [Yu2013](http://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | Tzumin Lee lab, Janelia Research Campus | 95 |
+| [Xie2018](http://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | Mark Wu lab, Johns Hopkins University School of Medicine | 78 |
+| [Matsuo2016](http://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | Kamikouchi lab, Nagoya University, with the Ito lab, University of Tokyo † | 41 |
+| [HeadMusclesMcKellar2020](http://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | 18 |
+| [Nojima2021](http://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | Goodwin lab, Centre for Neural Circuits and Behaviour, University of Oxford † | 15 |
+| [SplitNallasivan2025](http://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | Soller lab, University of Birmingham † | 6 |
+| [McKellar2020](http://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | 5 |
+| [Lillvis2018](http://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | Stern and Dickson labs, Janelia Research Campus | 2 |
+
+Records are the individuals VFB holds from each dataset.
+
+## How each attribution was established
+
+| Dataset | Paper | Basis |
+|---|---|---|
+| Lee_Lineage2020 | Lee et al., 2020, eLife | acknowledges Janelia Workstation, FlyLight and Fly Core for technical support |
+| Cachero2010 | Cachero et al., 2010, Curr. Biol. | stacks acquired on the lab's own Zeiss 710; single LMB affiliation |
+| Kohl2013 | Kohl et al., 2013, Cell | stacks acquired on a Zeiss 710; LMB is the only affiliation on the paper |
+| Ito2013 | Ito et al., 2013, Curr. Biol. | all authors at the University of Tokyo; imaging on the lab's Zeiss LSM 510 |
+| Yu2013 | Yu et al., 2013, Curr. Biol. | acknowledges the Janelia fly core and FlyLight team for support in data production |
+| Xie2018 | Xie et al., 2018, Cell Rep. | stacks acquired in house on a Zeiss LSM510/LSM700; raw files released by the lab |
+| Matsuo2016 | Matsuo et al., 2016, J. Comp. Neurol. | Japanese affiliations and funding only; methods text not openly accessible |
+| HeadMusclesMcKellar2020 | McKellar et al., 2020, eLife | stacks acquired on Janelia Zeiss confocals with Project Technical Resources support |
+| Nojima2021 | Nojima et al., 2021, Curr. Biol. | stacks acquired on a Leica TCS SP5; no external imaging provider acknowledged |
+| SplitNallasivan2025 | Nallasivan et al., 2026, eLife | stacks acquired on a Leica SP8 by the authors; driver lines from VDRC and Janelia |
+| McKellar2020 | McKellar et al., 2020, eLife | same study as the head muscle set; Janelia confocals and Fly Core |
+| Lillvis2018 | Ding et al., 2019, Curr. Biol. | acknowledges Janelia Project Technical Resources for dissection, histology and confocal imaging |
+
+Two recurring traps are worth naming, because both would give the wrong answer. Several of
+these studies use driver lines from Janelia or VDRC while acquiring their own images —
+`Xie2018` and `SplitNallasivan2025` both do — so the origin of a reagent is not the origin
+of an image. And several use FlyCircuit or FlyLight material as a reference for annotation
+rather than as source imagery.
+
+Citations are on each dataset's own page on VFB; cite the original study rather than VFB
+when you use the images.

--- a/content/en/docs/Data/LM/other/index.md
+++ b/content/en/docs/Data/LM/other/index.md
@@ -1,0 +1,86 @@
+---
+title: "Source not recorded in VFB"
+linkTitle: "Other sources"
+weight: 60
+tags: ["Split","Expression_pattern","dataset"]
+description: >
+    Light microscopy datasets whose imaging source is not recorded in VFB, including the per-paper split-GAL4 sets with no images loaded.
+---
+
+## Introduction
+
+VFB records where a dataset's images were produced either through the site
+cross-references carried by the images or in the dataset's own description. For the
+datasets below neither is present, so they are listed here rather than attributed to a
+provider. That is a gap in VFB's metadata, not a statement about where the images were
+produced.
+
+**Records in VFB** counts the individuals — images, expression patterns, single neurons —
+that VFB currently holds from the dataset. Where it reads *none loaded*, the dataset record
+exists and is linkable, but no images have been loaded. Most of the per-paper split-GAL4
+sets are in that state: the split combinations are recorded as FlyBase features and are
+searchable, but the imagery is not in VFB.
+
+The sets that do carry images here are mostly direct lab deposits — the neuroblast lineage
+clone collections from the Ito, Yu and Lee labs, the *fruitless* clones of Cachero et al.,
+and single-study sets such as Kohl et al. and Matsuo et al.
+
+## Datasets
+
+| Dataset | Contents | Records in VFB |
+|---|---|---|
+| [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | 462 |
+| [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | 119 |
+| [Kohl2013](http://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | 111 |
+| [Ito2013](http://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | 96 |
+| [Yu2013](http://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | 95 |
+| [Xie2018](http://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | 78 |
+| [Matsuo2016](http://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | 41 |
+| [FlyLight2019Strother2017](http://virtualflybrain.org/reports/FlyLight2019Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 32 |
+| [HeadMusclesMcKellar2020](http://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | 18 |
+| [Nojima2021](http://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | 15 |
+| [SplitNallasivan2025](http://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | 6 |
+| [McKellar2020](http://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | 5 |
+| [Lillvis2018](http://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | 2 |
+| [FlyLight2019Hampel2015](http://virtualflybrain.org/reports/FlyLight2019Hampel2015) | Grooming neurons and drivers (Hampel 2015) | none loaded |
+| [Gen1MCFOJovanic2019](http://virtualflybrain.org/reports/Gen1MCFOJovanic2019) | MCFO images of GMR-GAL4 lines from Jovanic et al., 2019 | none loaded |
+| [McKellar2019](http://virtualflybrain.org/reports/McKellar2019) | Images of aSP22 descending neuron from McKellar et al., 2019 | none loaded |
+| [SplitAso2014b](http://virtualflybrain.org/reports/SplitAso2014b) | Split-GAL4 lines from Aso et al., 2014b | none loaded |
+| [SplitBidaye2014](http://virtualflybrain.org/reports/SplitBidaye2014) | Split-GAL4 lines from Bidaye et al., 2014 | none loaded |
+| [SplitBidaye2020](http://virtualflybrain.org/reports/SplitBidaye2020) | Split-GAL4 lines from Bidaye et al., 2020 | none loaded |
+| [SplitCheong2024](http://virtualflybrain.org/reports/SplitCheong2024) | Split-GAL4 lines from Cheong et al., 2024 | none loaded |
+| [SplitDag2019](http://virtualflybrain.org/reports/SplitDag2019) | Split-GAL4 lines from Dag et al., 2019 | none loaded |
+| [SplitDavis2017](http://virtualflybrain.org/reports/SplitDavis2017) | Split-GAL4 lines from Turner-Evans et al., 2017 | none loaded |
+| [SplitFeng2014](http://virtualflybrain.org/reports/SplitFeng2014) | Split-GAL4 lines from Feng et al., 2014 | none loaded |
+| [SplitGarner2023](http://virtualflybrain.org/reports/SplitGarner2023) | Split-GAL4 lines from Garner et al., 2023 | none loaded |
+| [SplitGorko2024](http://virtualflybrain.org/reports/SplitGorko2024) | Split-GAL4 lines from Gorko et al., 2024 | none loaded |
+| [SplitHattori2017](http://virtualflybrain.org/reports/SplitHattori2017) | Split-GAL4 lines from Hattori et al., 2017 | none loaded |
+| [SplitHulse2021](http://virtualflybrain.org/reports/SplitHulse2021) | Split-GAL4 lines from Hulse et al., 2021 | none loaded |
+| [SplitLiang2017](http://virtualflybrain.org/reports/SplitLiang2017) | Split-GAL4 lines from Liang et al., 2017 | none loaded |
+| [SplitLillvis2022](http://virtualflybrain.org/reports/SplitLillvis2022) | Split-GAL4 lines from Lillvis et al., 2022 | none loaded |
+| [SplitLillvis2024](http://virtualflybrain.org/reports/SplitLillvis2024) | Split-GAL4 lines from Lillvis et al., 2024 | none loaded |
+| [SplitLiu2019](http://virtualflybrain.org/reports/SplitLiu2019) | Split-GAL4 lines from Liu et al., 2019 | none loaded |
+| [SplitLongden2021](http://virtualflybrain.org/reports/SplitLongden2021) | Split-GAL4 lines from Longden et al., 2021 | none loaded |
+| [SplitMais2021](http://virtualflybrain.org/reports/SplitMais2021) | Split-GAL4 lines from Mais et al., 2021 | none loaded |
+| [SplitMeissner2018](http://virtualflybrain.org/reports/SplitMeissner2018) | Split-GAL4 lines from Meissner et al., 2018 | none loaded |
+| [SplitNern2025](http://virtualflybrain.org/reports/SplitNern2025) | Split-GAL4 lines from Nern et al., 2025 | none loaded |
+| [SplitReyn2017](http://virtualflybrain.org/reports/SplitReyn2017) | Split-GAL4 lines from Reyn et al., 2017 | none loaded |
+| [SplitRibeiro2018](http://virtualflybrain.org/reports/SplitRibeiro2018) | Split-GAL4 lines from Ribeiro et al., 2018 | none loaded |
+| [SplitSchretter2024](http://virtualflybrain.org/reports/SplitSchretter2024) | Split-GAL4 lines from Schretter et al., 2024 | none loaded |
+| [SplitShao2017](http://virtualflybrain.org/reports/SplitShao2017) | Split-GAL4 lines from Shao et al., 2017 | none loaded |
+| [SplitSun2017](http://virtualflybrain.org/reports/SplitSun2017) | Split-GAL4 lines from Sun et al., 2017 | none loaded |
+| [SplitTakagi2017](http://virtualflybrain.org/reports/SplitTakagi2017) | Split-GAL4 lines from Takagi et al., 2017 | none loaded |
+| [SplitTakemura2017](http://virtualflybrain.org/reports/SplitTakemura2017) | Split-GAL4 lines from Takemura et al., 2017 | none loaded |
+| [SplitTanaka2008](http://virtualflybrain.org/reports/SplitTanaka2008) | Split-GAL4 lines from Tanaka et al., 2008 | none loaded |
+| [SplitTriphan2016](http://virtualflybrain.org/reports/SplitTriphan2016) | Split-GAL4 lines from Triphan et al., 2016 | none loaded |
+| [SplitTuthill2013](http://virtualflybrain.org/reports/SplitTuthill2013) | Split-GAL4 lines from Tuthill et al., 2013 | none loaded |
+| [SplitVijayan2023](http://virtualflybrain.org/reports/SplitVijayan2023) | Split-GAL4 lines from Vijayan et al., 2023 | none loaded |
+| [SplitVogt2014](http://virtualflybrain.org/reports/SplitVogt2014) | Split-GAL4 lines from Vogt et al., 2014 | none loaded |
+| [SplitWang2020c](http://virtualflybrain.org/reports/SplitWang2020c) | Split-GAL4 lines from Wang et al., 2020c | none loaded |
+| [SplitWolff2025](http://virtualflybrain.org/reports/SplitWolff2025) | Split-GAL4 lines from Wolff et al., 2025 | none loaded |
+| [SplitYoo2023](http://virtualflybrain.org/reports/SplitYoo2023) | Split-GAL4 lines from Yoo et al., 2023 | none loaded |
+| [SplitZhao2025](http://virtualflybrain.org/reports/SplitZhao2025) | Split-GAL4 lines from Zhao et al., 2025 | none loaded |
+| [SplitZung2025](http://virtualflybrain.org/reports/SplitZung2025) | Split-GAL4 lines from Zung et al., 2025 | none loaded |
+
+Records are the individuals VFB holds from each dataset. Citations are on each dataset's
+own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/LM/other/index.md
+++ b/content/en/docs/Data/LM/other/index.md
@@ -1,86 +1,70 @@
 ---
-title: "Source not recorded in VFB"
-linkTitle: "Other sources"
+title: "Datasets with no images loaded"
+linkTitle: "No images loaded"
 weight: 60
-tags: ["Split","Expression_pattern","dataset"]
+tags: ["Split","dataset"]
 description: >
-    Light microscopy datasets whose imaging source is not recorded in VFB, including the per-paper split-GAL4 sets with no images loaded.
+    Dataset records that exist in VFB but hold no light microscopy images.
 ---
 
 ## Introduction
 
-VFB records where a dataset's images were produced either through the site
-cross-references carried by the images or in the dataset's own description. For the
-datasets below neither is present, so they are listed here rather than attributed to a
-provider. That is a gap in VFB's metadata, not a statement about where the images were
-produced.
+The 37 datasets below have a record in VFB but no images loaded against it. Nearly all are
+per-paper split-GAL4 sets: the split combinations are recorded as FlyBase features and are
+searchable on VFB, and the dataset page carries the citation, but the imagery itself is not
+held here. There is therefore no imaging source to record for them — it is not that the
+source is unknown, but that there are no images to attribute.
 
-**Records in VFB** counts the individuals — images, expression patterns, single neurons —
-that VFB currently holds from the dataset. Where it reads *none loaded*, the dataset record
-exists and is linkable, but no images have been loaded. Most of the per-paper split-GAL4
-sets are in that state: the split combinations are recorded as FlyBase features and are
-searchable, but the imagery is not in VFB.
+Every VFB light microscopy dataset that does hold images has an attributed source: see
+[Janelia FlyLight](/docs/data/lm/flylight/), [VDRC](/docs/data/lm/vdrc/),
+[FlyCircuit](/docs/data/lm/flycircuit/), [BrainTrap](/docs/data/lm/braintrap/) and
+[Contributing laboratories](/docs/data/lm/labs/).
 
-The sets that do carry images here are mostly direct lab deposits — the neuroblast lineage
-clone collections from the Ito, Yu and Lee labs, the *fruitless* clones of Cachero et al.,
-and single-study sets such as Kohl et al. and Matsuo et al.
+For the imagery behind these studies, follow the citation on each dataset page to the
+original publication, or check the Janelia
+[split-GAL4 collection](https://splitgal4.janelia.org/) where the lines were released
+through FlyLight.
 
 ## Datasets
 
-| Dataset | Contents | Records in VFB |
-|---|---|---|
-| [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | 462 |
-| [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | 119 |
-| [Kohl2013](http://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | 111 |
-| [Ito2013](http://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | 96 |
-| [Yu2013](http://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | 95 |
-| [Xie2018](http://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | 78 |
-| [Matsuo2016](http://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | 41 |
-| [FlyLight2019Strother2017](http://virtualflybrain.org/reports/FlyLight2019Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 32 |
-| [HeadMusclesMcKellar2020](http://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | 18 |
-| [Nojima2021](http://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | 15 |
-| [SplitNallasivan2025](http://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | 6 |
-| [McKellar2020](http://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | 5 |
-| [Lillvis2018](http://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | 2 |
-| [FlyLight2019Hampel2015](http://virtualflybrain.org/reports/FlyLight2019Hampel2015) | Grooming neurons and drivers (Hampel 2015) | none loaded |
-| [Gen1MCFOJovanic2019](http://virtualflybrain.org/reports/Gen1MCFOJovanic2019) | MCFO images of GMR-GAL4 lines from Jovanic et al., 2019 | none loaded |
-| [McKellar2019](http://virtualflybrain.org/reports/McKellar2019) | Images of aSP22 descending neuron from McKellar et al., 2019 | none loaded |
-| [SplitAso2014b](http://virtualflybrain.org/reports/SplitAso2014b) | Split-GAL4 lines from Aso et al., 2014b | none loaded |
-| [SplitBidaye2014](http://virtualflybrain.org/reports/SplitBidaye2014) | Split-GAL4 lines from Bidaye et al., 2014 | none loaded |
-| [SplitBidaye2020](http://virtualflybrain.org/reports/SplitBidaye2020) | Split-GAL4 lines from Bidaye et al., 2020 | none loaded |
-| [SplitCheong2024](http://virtualflybrain.org/reports/SplitCheong2024) | Split-GAL4 lines from Cheong et al., 2024 | none loaded |
-| [SplitDag2019](http://virtualflybrain.org/reports/SplitDag2019) | Split-GAL4 lines from Dag et al., 2019 | none loaded |
-| [SplitDavis2017](http://virtualflybrain.org/reports/SplitDavis2017) | Split-GAL4 lines from Turner-Evans et al., 2017 | none loaded |
-| [SplitFeng2014](http://virtualflybrain.org/reports/SplitFeng2014) | Split-GAL4 lines from Feng et al., 2014 | none loaded |
-| [SplitGarner2023](http://virtualflybrain.org/reports/SplitGarner2023) | Split-GAL4 lines from Garner et al., 2023 | none loaded |
-| [SplitGorko2024](http://virtualflybrain.org/reports/SplitGorko2024) | Split-GAL4 lines from Gorko et al., 2024 | none loaded |
-| [SplitHattori2017](http://virtualflybrain.org/reports/SplitHattori2017) | Split-GAL4 lines from Hattori et al., 2017 | none loaded |
-| [SplitHulse2021](http://virtualflybrain.org/reports/SplitHulse2021) | Split-GAL4 lines from Hulse et al., 2021 | none loaded |
-| [SplitLiang2017](http://virtualflybrain.org/reports/SplitLiang2017) | Split-GAL4 lines from Liang et al., 2017 | none loaded |
-| [SplitLillvis2022](http://virtualflybrain.org/reports/SplitLillvis2022) | Split-GAL4 lines from Lillvis et al., 2022 | none loaded |
-| [SplitLillvis2024](http://virtualflybrain.org/reports/SplitLillvis2024) | Split-GAL4 lines from Lillvis et al., 2024 | none loaded |
-| [SplitLiu2019](http://virtualflybrain.org/reports/SplitLiu2019) | Split-GAL4 lines from Liu et al., 2019 | none loaded |
-| [SplitLongden2021](http://virtualflybrain.org/reports/SplitLongden2021) | Split-GAL4 lines from Longden et al., 2021 | none loaded |
-| [SplitMais2021](http://virtualflybrain.org/reports/SplitMais2021) | Split-GAL4 lines from Mais et al., 2021 | none loaded |
-| [SplitMeissner2018](http://virtualflybrain.org/reports/SplitMeissner2018) | Split-GAL4 lines from Meissner et al., 2018 | none loaded |
-| [SplitNern2025](http://virtualflybrain.org/reports/SplitNern2025) | Split-GAL4 lines from Nern et al., 2025 | none loaded |
-| [SplitReyn2017](http://virtualflybrain.org/reports/SplitReyn2017) | Split-GAL4 lines from Reyn et al., 2017 | none loaded |
-| [SplitRibeiro2018](http://virtualflybrain.org/reports/SplitRibeiro2018) | Split-GAL4 lines from Ribeiro et al., 2018 | none loaded |
-| [SplitSchretter2024](http://virtualflybrain.org/reports/SplitSchretter2024) | Split-GAL4 lines from Schretter et al., 2024 | none loaded |
-| [SplitShao2017](http://virtualflybrain.org/reports/SplitShao2017) | Split-GAL4 lines from Shao et al., 2017 | none loaded |
-| [SplitSun2017](http://virtualflybrain.org/reports/SplitSun2017) | Split-GAL4 lines from Sun et al., 2017 | none loaded |
-| [SplitTakagi2017](http://virtualflybrain.org/reports/SplitTakagi2017) | Split-GAL4 lines from Takagi et al., 2017 | none loaded |
-| [SplitTakemura2017](http://virtualflybrain.org/reports/SplitTakemura2017) | Split-GAL4 lines from Takemura et al., 2017 | none loaded |
-| [SplitTanaka2008](http://virtualflybrain.org/reports/SplitTanaka2008) | Split-GAL4 lines from Tanaka et al., 2008 | none loaded |
-| [SplitTriphan2016](http://virtualflybrain.org/reports/SplitTriphan2016) | Split-GAL4 lines from Triphan et al., 2016 | none loaded |
-| [SplitTuthill2013](http://virtualflybrain.org/reports/SplitTuthill2013) | Split-GAL4 lines from Tuthill et al., 2013 | none loaded |
-| [SplitVijayan2023](http://virtualflybrain.org/reports/SplitVijayan2023) | Split-GAL4 lines from Vijayan et al., 2023 | none loaded |
-| [SplitVogt2014](http://virtualflybrain.org/reports/SplitVogt2014) | Split-GAL4 lines from Vogt et al., 2014 | none loaded |
-| [SplitWang2020c](http://virtualflybrain.org/reports/SplitWang2020c) | Split-GAL4 lines from Wang et al., 2020c | none loaded |
-| [SplitWolff2025](http://virtualflybrain.org/reports/SplitWolff2025) | Split-GAL4 lines from Wolff et al., 2025 | none loaded |
-| [SplitYoo2023](http://virtualflybrain.org/reports/SplitYoo2023) | Split-GAL4 lines from Yoo et al., 2023 | none loaded |
-| [SplitZhao2025](http://virtualflybrain.org/reports/SplitZhao2025) | Split-GAL4 lines from Zhao et al., 2025 | none loaded |
-| [SplitZung2025](http://virtualflybrain.org/reports/SplitZung2025) | Split-GAL4 lines from Zung et al., 2025 | none loaded |
+| Dataset | Contents |
+|---|---|
+| [McKellar2019](http://virtualflybrain.org/reports/McKellar2019) | Images of aSP22 descending neuron from McKellar et al., 2019 |
+| [SplitAso2014b](http://virtualflybrain.org/reports/SplitAso2014b) | Split-GAL4 lines from Aso et al., 2014b |
+| [SplitBidaye2014](http://virtualflybrain.org/reports/SplitBidaye2014) | Split-GAL4 lines from Bidaye et al., 2014 |
+| [SplitBidaye2020](http://virtualflybrain.org/reports/SplitBidaye2020) | Split-GAL4 lines from Bidaye et al., 2020 |
+| [SplitCheong2024](http://virtualflybrain.org/reports/SplitCheong2024) | Split-GAL4 lines from Cheong et al., 2024 |
+| [SplitDag2019](http://virtualflybrain.org/reports/SplitDag2019) | Split-GAL4 lines from Dag et al., 2019 |
+| [SplitDavis2017](http://virtualflybrain.org/reports/SplitDavis2017) | Split-GAL4 lines from Turner-Evans et al., 2017 |
+| [SplitFeng2014](http://virtualflybrain.org/reports/SplitFeng2014) | Split-GAL4 lines from Feng et al., 2014 |
+| [SplitGarner2023](http://virtualflybrain.org/reports/SplitGarner2023) | Split-GAL4 lines from Garner et al., 2023 |
+| [SplitGorko2024](http://virtualflybrain.org/reports/SplitGorko2024) | Split-GAL4 lines from Gorko et al., 2024 |
+| [SplitHattori2017](http://virtualflybrain.org/reports/SplitHattori2017) | Split-GAL4 lines from Hattori et al., 2017 |
+| [SplitHulse2021](http://virtualflybrain.org/reports/SplitHulse2021) | Split-GAL4 lines from Hulse et al., 2021 |
+| [SplitLiang2017](http://virtualflybrain.org/reports/SplitLiang2017) | Split-GAL4 lines from Liang et al., 2017 |
+| [SplitLillvis2022](http://virtualflybrain.org/reports/SplitLillvis2022) | Split-GAL4 lines from Lillvis et al., 2022 |
+| [SplitLillvis2024](http://virtualflybrain.org/reports/SplitLillvis2024) | Split-GAL4 lines from Lillvis et al., 2024 |
+| [SplitLiu2019](http://virtualflybrain.org/reports/SplitLiu2019) | Split-GAL4 lines from Liu et al., 2019 |
+| [SplitLongden2021](http://virtualflybrain.org/reports/SplitLongden2021) | Split-GAL4 lines from Longden et al., 2021 |
+| [SplitMais2021](http://virtualflybrain.org/reports/SplitMais2021) | Split-GAL4 lines from Mais et al., 2021 |
+| [SplitMeissner2018](http://virtualflybrain.org/reports/SplitMeissner2018) | Split-GAL4 lines from Meissner et al., 2018 |
+| [SplitNern2025](http://virtualflybrain.org/reports/SplitNern2025) | Split-GAL4 lines from Nern et al., 2025 |
+| [SplitReyn2017](http://virtualflybrain.org/reports/SplitReyn2017) | Split-GAL4 lines from Reyn et al., 2017 |
+| [SplitRibeiro2018](http://virtualflybrain.org/reports/SplitRibeiro2018) | Split-GAL4 lines from Ribeiro et al., 2018 |
+| [SplitSchretter2024](http://virtualflybrain.org/reports/SplitSchretter2024) | Split-GAL4 lines from Schretter et al., 2024 |
+| [SplitShao2017](http://virtualflybrain.org/reports/SplitShao2017) | Split-GAL4 lines from Shao et al., 2017 |
+| [SplitSun2017](http://virtualflybrain.org/reports/SplitSun2017) | Split-GAL4 lines from Sun et al., 2017 |
+| [SplitTakagi2017](http://virtualflybrain.org/reports/SplitTakagi2017) | Split-GAL4 lines from Takagi et al., 2017 |
+| [SplitTakemura2017](http://virtualflybrain.org/reports/SplitTakemura2017) | Split-GAL4 lines from Takemura et al., 2017 |
+| [SplitTanaka2008](http://virtualflybrain.org/reports/SplitTanaka2008) | Split-GAL4 lines from Tanaka et al., 2008 |
+| [SplitTriphan2016](http://virtualflybrain.org/reports/SplitTriphan2016) | Split-GAL4 lines from Triphan et al., 2016 |
+| [SplitTuthill2013](http://virtualflybrain.org/reports/SplitTuthill2013) | Split-GAL4 lines from Tuthill et al., 2013 |
+| [SplitVijayan2023](http://virtualflybrain.org/reports/SplitVijayan2023) | Split-GAL4 lines from Vijayan et al., 2023 |
+| [SplitVogt2014](http://virtualflybrain.org/reports/SplitVogt2014) | Split-GAL4 lines from Vogt et al., 2014 |
+| [SplitWang2020c](http://virtualflybrain.org/reports/SplitWang2020c) | Split-GAL4 lines from Wang et al., 2020c |
+| [SplitWolff2025](http://virtualflybrain.org/reports/SplitWolff2025) | Split-GAL4 lines from Wolff et al., 2025 |
+| [SplitYoo2023](http://virtualflybrain.org/reports/SplitYoo2023) | Split-GAL4 lines from Yoo et al., 2023 |
+| [SplitZhao2025](http://virtualflybrain.org/reports/SplitZhao2025) | Split-GAL4 lines from Zhao et al., 2025 |
+| [SplitZung2025](http://virtualflybrain.org/reports/SplitZung2025) | Split-GAL4 lines from Zung et al., 2025 |
 
-Records are the individuals VFB holds from each dataset. Citations are on each dataset's
-own page on VFB; cite the original study rather than VFB when you use the images.
+Citations are on each dataset's own page on VFB.

--- a/content/en/docs/Data/LM/vdrc/index.md
+++ b/content/en/docs/Data/LM/vdrc/index.md
@@ -1,0 +1,33 @@
+---
+title: "VDRC — Dickson VT collection"
+linkTitle: "VDRC"
+weight: 30
+tags: ["Expression_pattern","transgene","VDRC","VT","Dickson"]
+description: >
+    VT enhancer-fragment GAL4 and LexA lines from the Dickson lab, imaged at the Vienna Drosophila Resource Center.
+---
+
+## Introduction
+
+The VT collection is the second large enhancer-fragment driver library for the adult
+brain, built in the Dickson lab and imaged at the [Vienna *Drosophila* Resource
+Center](https://stockcenter.vdrc.at/). It complements the FlyLight GMR collection: the two
+libraries tile the genome with different fragments, so a cell type poorly covered by one is
+often covered by the other. Stocks are distributed by VDRC.
+
+VFB holds the collection imaged in two places. `Dickson_VT` is the VDRC imaging of the
+library. `Dickson2017` is the subset re-imaged at Janelia through the FlyLight pipeline and
+registered to the FlyLight templates, which is what you want if you need a VT line and a
+GMR line in the same coordinate space. Single-neuron MCFO images of VT lines are listed
+under [Janelia FlyLight](/docs/data/lm/flylight/).
+
+## Datasets
+
+| Dataset | Contents | Records in VFB |
+|---|---|---|
+| [Dickson_VT](http://virtualflybrain.org/reports/Dickson_VT) | Dickson lab VT line collection - VDRC images | 18,016 |
+| [Dickson2017](http://virtualflybrain.org/reports/Dickson2017) | Dickson lab VT lines - FlyLight/Janelia images (2017) | 5,378 |
+| [Hampel2017](http://virtualflybrain.org/reports/Hampel2017) | LexA driver targetting mechanosensory eye bristles (Hampel2017) | 1 |
+
+Records are the individuals VFB holds from each dataset. Citations are on each dataset's
+own page on VFB; cite the original study rather than VFB when you use the images.


### PR DESCRIPTION
The LM section had a single provider page (FlyLight) and a nine-row summary table, so most of VFB's light microscopy datasets were not listed anywhere in the docs.

Adds pages for VDRC, FlyCircuit, BrainTrap and contributing laboratories, adds a dataset table to the existing FlyLight page, and turns the LM index into a provider overview. All 125 LM datasets are listed exactly once; the nine template and painted-domain sets link through to the Templates page rather than being duplicated.

Provider comes from what VFB records where it records it — the site cross-references on a dataset's images and the dataset description — and from the cited paper where it does not. A source is only assigned when it covers a majority of a dataset's records, so stock and reagent cross-references are not read as an imaging source. The contributing-laboratories page shows the basis for each attribution and marks the ones inferred from affiliation rather than stated outright.

Every dataset that holds images now has an attributed source. The 37 datasets with no images loaded are listed separately and described as such.

To check: `hugo server`, then `/docs/data/lm/` and each provider page; dataset links resolve to `virtualflybrain.org/reports/<id>`.
