### PR TITLE
Advertise the term sitemap index instead of 38 hardcoded shards

### DIFF
--- a/themes/vfb-nova/layouts/robots.txt
+++ b/themes/vfb-nova/layouts/robots.txt
@@ -8,7 +8,14 @@
 {{- end }}
 User-agent: *
 {{ if not $allowCrawling }}Disallow: /{{- end }}
+
+# Hand-authored pages. Built by Hugo from this repo.
 Sitemap: {{ "/sitemap.xml" | absURL }}
-{{ range $index, $element := (seq 38) }}
-Sitemap: https://www.virtualflybrain.org/sitemap{{- (add $index 1) -}}.xml
-{{- end }}
+
+# Generated term pages. sitemap-terms.xml is a sitemap index over
+# sitemap1.xml .. sitemapN.xml, written by the update_vfb_terms_to_static_site
+# Jenkins job after the Hugo build. Advertising the index rather than each shard
+# keeps the shard count out of this file: it was pinned at 38 here while the job
+# was producing 189, so roughly four fifths of the term corpus was never
+# advertised to crawlers.
+Sitemap: {{ "/sitemap-terms.xml" | absURL }}


### PR DESCRIPTION
`robots.txt` listed `sitemap1.xml` through `sitemap38.xml`. The `update_vfb_terms_to_static_site` Jenkins job that writes those shards printed **189** on build #268, so roughly four fifths of the term corpus — around 754,000 URLs — was never advertised to any crawler. Since the term pages exist specifically so search engines can index terms that are not indexable inside the VFB browser, that is the whole point of them going unmet.

The job is being changed to emit `sitemap-terms.xml`, a sitemap index over however many shards it actually produced. This advertises that index instead of an enumerated list, so the count lives in one place and cannot drift again. It also drops the hardcoded hostname in favour of `absURL`.

The job change fixes three other things in the same pass: the shards were plain text served under a `.xml` name, so a sitemap parser could not read them at all; the loop dropped one URL at every shard boundary; and 5,000 URLs per shard against a 50,000 limit is what let the count reach 189 in the first place.

**Merge order matters.** Land this together with the Jenkins job change, not before it — on its own this de-advertises the 38 shards that currently work, and `sitemap-terms.xml` will not exist until the job has run.

To check, after the job has run once: `curl -s https://www.virtualflybrain.org/robots.txt`, then confirm `sitemap-terms.xml` parses as XML and its shard count matches the files on disk.
