### PR TITLE
Make the theme declare and target the pinned Hugo 0.122.0

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -11,7 +11,8 @@
 
 baseURL = "https://www.virtualflybrain.org/"
 title = "Virtual Fly Brain"
-locale = "en-gb"          # `languageCode` was deprecated in Hugo v0.158.0
+languageCode = "en-gb"    # `locale` replaces this at Hugo v0.158.0; the build
+                          # is pinned to 0.122.0, which does not know that key.
 defaultContentLanguage = "en"
 enableRobotsTXT = true
 theme = "vfb-nova"
@@ -52,8 +53,12 @@ timeZone = "Europe/London"
 [services.rss]
   limit = 20
 
-[pagination]
-  pagerSize = 100
+# `paginate`, not `[pagination] pagerSize`: the pagination block arrived in Hugo
+# v0.128.0 and the build is pinned to v0.122.0 (see Dockerfile — per-page
+# filesystem cost rose at v0.123.0 and the term corpus is on NFS). With the
+# block, 0.122 silently ignored it and every list page fell back to the default
+# of 10; the build summary read "Paginator pages | 0".
+paginate = 100
 
 
 [markup]

--- a/themes/vfb-nova/README.md
+++ b/themes/vfb-nova/README.md
@@ -41,7 +41,8 @@ trees — likely worth it once most nightly term pages are identical.
 
 ## Toolchain
 
-Verified on **Hugo 0.164.0, standard edition** — zero warnings, zero errors.
+Verified on **Hugo 0.122.0 extended** (what production runs) — zero warnings,
+zero errors. Also builds clean on 0.164.0 standard.
 Output is byte-identical between the standard and extended editions.
 
 | | |
@@ -56,9 +57,16 @@ was deprecated in Hugo v0.153.0 and Dart Sass is a separate binary the build
 host would have to install; avoiding both removes the migration and drops the
 extended-edition requirement.
 
-Minimum version is **0.128.0** (`[pagination] pagerSize`). `Dockerfile` and
-`docker-compose.yaml` pin `ghcr.io/gohugoio/hugo:v0.164.0`; the Rancher `hugo`
-service needs the same, as `rcourt/docsy-builder` predates the minimum.
+Minimum version is **0.122.0**, which is what production runs. `Dockerfile` pins
+`HUGO_VERSION=0.122.0` deliberately: per-page filesystem cost rose at v0.123.0,
+which rewrote page assembly, and the term corpus is read over NFS from a
+Synology. Do not raise it without measuring that first.
+
+Two config keys follow from that pin rather than from taste. `paginate = 100`
+rather than `[pagination] pagerSize` — the pagination block arrived at v0.128.0.
+`languageCode` rather than `locale` — `locale` arrived at v0.158.0. Both are the
+newer spelling everywhere else in the Hugo docs; on 0.122 the newer spelling is
+silently ignored.
 
 ### Two config keys that are not optional on current Hugo
 

--- a/themes/vfb-nova/theme.toml
+++ b/themes/vfb-nova/theme.toml
@@ -2,6 +2,6 @@ name = "VFB Nova"
 license = "MIT"
 description = "A modern, dark-first presentation layer for the Virtual Fly Brain static site. Drop-in for the existing content tree: no content changes, no Bootstrap, no Docsy."
 homepage = "https://github.com/VirtualFlyBrain/VFB2"
-min_version = "0.128.0"
+min_version = "0.122.0"
 tags = ["documentation", "science", "dark", "docs"]
 features = ["command palette search", "docs sidebar", "dark/light", "canvas hero"]


### PR DESCRIPTION
Stacked on  (#431) — this PR targets that branch so its diff shows only the config change; GitHub retargets it to  once #431 merges.

Production builds with **Hugo 0.122.0**, pinned deliberately in `Dockerfile`: per-page filesystem cost rose at v0.123.0, which rewrote page assembly, and the term corpus is read over NFS from a Synology. The theme declared `min_version = "0.128.0"`, so every production build logged

```
WARN  Module "vfb-nova" is not compatible with this Hugo version; run "hugo mod graph" for more information.
hugo v0.122.0-...+extended
```

Hugo warns and carries on, so this was not breaking anything, but it left the build permanently one warning short of clean and the declared floor did not match what actually runs.

Two config keys follow from the same pin:

- `[pagination] pagerSize` → `paginate`. The pagination block arrived at v0.128.0, so on 0.122 it is unknown and ignored.
- `locale` → `languageCode`. `locale` arrived at v0.158.0, same story.

Both are the newer spelling everywhere in the Hugo docs, which is presumably how they got here. **Neither has a visible effect today** — `_default/term.html` is the only template that paginates, and `disableKinds = ["taxonomy", "term"]` switches those off — so the `Paginator pages | 0` in the build summary is correct rather than a symptom. The pagination setting becomes live the moment `disableKinds` is relaxed, which `hugo.toml` explicitly invites ("Comment this line out to enable them"), and at that point every tag page would silently fall back to 10 per page.

`README.md` is updated to state 0.122.0 as the floor with the reason for the pin, so the next person does not raise it without measuring the NFS cost first.

Verified by building the whole authored site with Hugo 0.122.0 extended locally: **zero warnings, zero errors**, against one warning before.
