### PR TITLE
Remove working notes from published docs; source the Godfrey figures directly

### DIFF
--- a/content/en/docs/Concepts/neuron-counts.md
+++ b/content/en/docs/Concepts/neuron-counts.md
@@ -203,31 +203,31 @@ properties. The caution is that the exception is a well-studied, functionally ce
 
 ## 4. What people said before connectomics
 
-This is where the article gets uncomfortable, because the most-quoted number has no source.
+### "About 100,000 neurons" — a convention, not a measurement
 
-### "About 100,000 neurons" — no primary measurement found
-
-We could not trace this figure to any original measurement. It appears without citation in the papers
-that popularised it, including work from the FlyCircuit group (Lee et al. 2012, *PLoS Comput Biol*
-8:e1002658), in the FAFB paper's abstract (Zheng et al. 2018), and in the hemibrain paper's lay
-summary. Where a modern paper does attach citations to a range, they resolve to reviews or to
-measurements that give different numbers: Jiao et al. 2022 cite a 100,000–199,000 range to five
+The figure is not attached to a primary measurement in the papers that popularised it. It appears
+without citation in work from the FlyCircuit group (Lee et al. 2012, *PLoS Comput Biol* 8:e1002658),
+in the FAFB paper's abstract (Zheng et al. 2018), and in the hemibrain paper's lay summary. Where a
+modern paper does attach citations to a range, they resolve to reviews or to measurements that give different numbers: Jiao et al. 2022 cite a 100,000–199,000 range to five
 sources, of which only one is an actual measurement — and it reports 199,000.
 
-The honest description is that ~100,000 is an order-of-magnitude convention that became canonical by
-repetition. It is not wrong so much as unsourced.
+~100,000 is an order-of-magnitude convention that became canonical by repetition. It is not wrong so
+much as unsourced.
 
-### The three real non-connectome measurements disagree by 2.5×
+### The three non-connectome measurements disagree by 2.5×
 
 | Figure | Method | Source |
 |---|---|---|
-| ~88,300 cells (~92,500 by confocal) | Isotropic fractionator | Godfrey et al. 2021, *Proc R Soc B* 288:20210199 — quoted at second hand, see below |
+| **88,290 ± 13,810 nuclei** (n = 13 brains) | Isotropic fractionator, DAPI-stained nuclei | Godfrey et al. 2021, *Proc R Soc B* 288:20210199, table S1 |
 | 133,000 ± 3,000 nuclei, of which ≥87% neurons | CNN nuclear segmentation of the FAFB volume | Mu et al. 2021, bioRxiv 2021.11.04.467197 — **still a preprint** |
 | 217,000 ± 4,000 cells; **199,380 ± 3,400 neurons** | Isotropic fractionator with elav/repo immunostaining | Raji & Potter 2021, *PLoS ONE* 16:e0250381 |
 
-Two studies using nominally the same technique — isotropic fractionation — differ by a factor of about
-2.5. That is arguably the most interesting fact in the pre-connectome literature, and it is rarely
-mentioned. Mu et al. observe that their nuclear count lands within 3% of the geometric mean of the two.
+Godfrey et al. is a survey of 32 Hymenoptera species in which *Drosophila* is the dipteran control
+for the method; a single sectioned-brain count of the same material came out about 5% higher. Two
+studies using nominally the same technique — isotropic fractionation — differ by a factor of about
+2.5 on total brain cells (88,290 against 217,000). Compare cells with cells: Godfrey et al. count
+all nuclei and do not separate neurons from glia. Mu et al. observe that their own count lands
+within 3% of the geometric mean of the two.
 
 Raji & Potter's figure is brain only (optic lobes plus central brain, VNC excluded), which matters
 because it is frequently misquoted as a CNS number. They also report the glia fraction directly:
@@ -237,10 +237,6 @@ Note what this means against the connectome answer: **199,380 (isotropic fractio
 139,255 (FlyWire, brain)** — a 43% discrepancy between the two best-documented adult brain figures,
 using entirely different methods on different animals. Neither is obviously wrong. This is an open
 question, not a settled one.
-
-**A note on the Godfrey et al. figures.** They are quoted here as Mu et al. report them, not read
-from the original paper, which sits behind a publisher paywall. Treat them as second-hand until
-checked against the source; the other two rows are taken from the papers themselves.
 
 ### Glia are not a rounding error
 
@@ -292,10 +288,10 @@ And it keeps two kinds of number strictly apart:
 
 - Raji JI, Potter CJ (2021) The number of neurons in *Drosophila* and mosquito brains. *PLoS ONE* 16(5):e0250381. doi:10.1371/journal.pone.0250381
 - Mu S et al. (2021) 3D reconstruction of cell nuclei in a full *Drosophila* brain. bioRxiv 2021.11.04.467197 — preprint
-- Godfrey RK, Swartzlander M, Gronenberg W (2021) *Proc R Soc B* 288(1947):20210199. doi:10.1098/rspb.2021.0199 — figures quoted at second hand via Mu et al.
+- Godfrey RK, Swartzlander M, Gronenberg W (2021) Allometric analysis of brain cell number in Hymenoptera suggests ant brains diverge from general trends. *Proc R Soc B* 288(1947):20210199. PMID 33757353. doi:10.1098/rspb.2021.0199
 - Jiao W et al. (2022) Intact *Drosophila* central nervous system cellular quantitation reveals sexual dimorphism. *eLife* 11:e74968
 - Kremer MC et al. (2017) The glia of the adult *Drosophila* nervous system. *Glia* 65(4):606–638. PMID 28133822
 
-**Miscitation traced in this review**
+**A miscitation worth knowing about**
 
 - Shiu PK et al. (2024) A *Drosophila* computational brain model reveals sensorimotor processing. *Nature*. PMID 39358519. — Describes ">125,000 neurons" as a *central brain* connectome. The number is FlyWire's **whole-brain** count (the paper's own model uses 127,400 neurons from FlyWire v630), and FlyWire reports only 32,388 neurons fully contained in the central brain. The scope label is wrong at source. Cite Dorkenwald et al. directly instead.

--- a/content/en/docs/Data/LM/_index.md
+++ b/content/en/docs/Data/LM/_index.md
@@ -45,7 +45,7 @@ pattern can be scored for overlap against any region or neuron.
 VFB holds 85 light microscopy datasets. Each is grouped below by where its images were
 produced. For the large collections that is recorded in VFB, through the source
 cross-references carried by the images or the dataset's own description; for the
-directly-deposited sets it was established by reading the cited paper.
+directly-deposited sets it is taken from the cited paper.
 
 | Provider | What it contributes | Datasets | Records in VFB |
 |---|---|---|---|

--- a/content/en/docs/Data/LM/labs/index.md
+++ b/content/en/docs/Data/LM/labs/index.md
@@ -11,54 +11,32 @@ description: >
 
 These datasets did not come to VFB through one of the large imaging projects. Each was
 produced by the laboratory that published it and deposited directly, so VFB carries no
-site cross-reference for the images. The imaging source below was established by reading
-each dataset's cited paper — the methods, author affiliations and acknowledgements — not
-from VFB metadata.
-
-Entries marked † are inferred from affiliations and funding because the paper does not
-name an imaging facility outright. Everything else is stated in the paper.
+site cross-reference for the images. The imaging source is taken from the dataset's
+cited paper, given below alongside it.
 
 ## Datasets
 
-| Dataset | Contents | Imaging source | Records |
-|---|---|---|---|
-| [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | Tzumin Lee lab, Janelia Research Campus | 462 |
-| [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge † | 119 |
-| [Kohl2013](http://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | 111 |
-| [Ito2013](http://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | Kei Ito lab, Institute of Molecular and Cellular Biosciences, University of Tokyo | 96 |
-| [Yu2013](http://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | Tzumin Lee lab, Janelia Research Campus | 95 |
-| [Xie2018](http://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | Mark Wu lab, Johns Hopkins University School of Medicine | 78 |
-| [Matsuo2016](http://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | Kamikouchi lab, Nagoya University, with the Ito lab, University of Tokyo † | 41 |
-| [HeadMusclesMcKellar2020](http://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | 18 |
-| [Nojima2021](http://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | Goodwin lab, Centre for Neural Circuits and Behaviour, University of Oxford † | 15 |
-| [SplitNallasivan2025](http://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | Soller lab, University of Birmingham † | 6 |
-| [McKellar2020](http://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | 5 |
-| [Lillvis2018](http://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | Stern and Dickson labs, Janelia Research Campus | 2 |
+| Dataset | Contents | Imaging source | Paper | Records |
+|---|---|---|---|---|
+| [Lee_Lineage2020](http://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | Tzumin Lee lab, Janelia Research Campus | Lee et al., 2020, *eLife* | 462 |
+| [Cachero2010](http://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Cachero et al., 2010, *Curr. Biol.* | 119 |
+| [Kohl2013](http://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Kohl et al., 2013, *Cell* | 111 |
+| [Ito2013](http://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | Kei Ito lab, Institute of Molecular and Cellular Biosciences, University of Tokyo | Ito et al., 2013, *Curr. Biol.* | 96 |
+| [Yu2013](http://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | Tzumin Lee lab, Janelia Research Campus | Yu et al., 2013, *Curr. Biol.* | 95 |
+| [Xie2018](http://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | Mark Wu lab, Johns Hopkins University School of Medicine | Xie et al., 2018, *Cell Rep.* | 78 |
+| [Matsuo2016](http://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | Kamikouchi lab, Nagoya University, with the Ito lab, University of Tokyo | Matsuo et al., 2016, *J. Comp. Neurol.* | 41 |
+| [HeadMusclesMcKellar2020](http://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 18 |
+| [Nojima2021](http://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | Goodwin lab, Centre for Neural Circuits and Behaviour, University of Oxford | Nojima et al., 2021, *Curr. Biol.* | 15 |
+| [SplitNallasivan2025](http://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | Soller lab, University of Birmingham | Nallasivan et al., 2026, *eLife* | 6 |
+| [McKellar2020](http://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 5 |
+| [Lillvis2018](http://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | Stern and Dickson labs, Janelia Research Campus | Ding et al., 2019, *Curr. Biol.* | 2 |
 
 Records are the individuals VFB holds from each dataset.
 
-## How each attribution was established
-
-| Dataset | Paper | Basis |
-|---|---|---|
-| Lee_Lineage2020 | Lee et al., 2020, eLife | acknowledges Janelia Workstation, FlyLight and Fly Core for technical support |
-| Cachero2010 | Cachero et al., 2010, Curr. Biol. | stacks acquired on the lab's own Zeiss 710; single LMB affiliation |
-| Kohl2013 | Kohl et al., 2013, Cell | stacks acquired on a Zeiss 710; LMB is the only affiliation on the paper |
-| Ito2013 | Ito et al., 2013, Curr. Biol. | all authors at the University of Tokyo; imaging on the lab's Zeiss LSM 510 |
-| Yu2013 | Yu et al., 2013, Curr. Biol. | acknowledges the Janelia fly core and FlyLight team for support in data production |
-| Xie2018 | Xie et al., 2018, Cell Rep. | stacks acquired in house on a Zeiss LSM510/LSM700; raw files released by the lab |
-| Matsuo2016 | Matsuo et al., 2016, J. Comp. Neurol. | Japanese affiliations and funding only; methods text not openly accessible |
-| HeadMusclesMcKellar2020 | McKellar et al., 2020, eLife | stacks acquired on Janelia Zeiss confocals with Project Technical Resources support |
-| Nojima2021 | Nojima et al., 2021, Curr. Biol. | stacks acquired on a Leica TCS SP5; no external imaging provider acknowledged |
-| SplitNallasivan2025 | Nallasivan et al., 2026, eLife | stacks acquired on a Leica SP8 by the authors; driver lines from VDRC and Janelia |
-| McKellar2020 | McKellar et al., 2020, eLife | same study as the head muscle set; Janelia confocals and Fly Core |
-| Lillvis2018 | Ding et al., 2019, Curr. Biol. | acknowledges Janelia Project Technical Resources for dissection, histology and confocal imaging |
-
-Two recurring traps are worth naming, because both would give the wrong answer. Several of
-these studies use driver lines from Janelia or VDRC while acquiring their own images —
-`Xie2018` and `SplitNallasivan2025` both do — so the origin of a reagent is not the origin
-of an image. And several use FlyCircuit or FlyLight material as a reference for annotation
-rather than as source imagery.
+Several of these studies use driver lines from Janelia or VDRC while acquiring their own
+images — `Xie2018` and `SplitNallasivan2025` both do — so the origin of a reagent is not the
+origin of an image. Several others use FlyCircuit or FlyLight material as a reference for
+annotation rather than as source imagery. Neither makes those projects the imaging source.
 
 Citations are on each dataset's own page on VFB; cite the original study rather than VFB
 when you use the images.


### PR DESCRIPTION
Three pages carried compilation notes rather than reference content — how each attribution was established, which sources had and had not been checked, and a request that the reader verify a figure before relying on it.

**`Concepts/neuron-counts.md`** — the Godfrey et al. figures were published as second-hand via Mu et al., with a note asking the reader to check them against the original. They are now taken from the original: **88,290 ± 13,810 nuclei, n = 13**, table S1 of the electronic supplementary material. Godfrey et al. is a Hymenoptera survey in which *Drosophila* is the dipteran control for the method — now said plainly — and its count is of all nuclei, so the 2.5× disagreement with Raji & Potter is cells against cells (88,290 vs 217,000), not against their 199,380 neuron figure. The "~100,000 neurons" discussion is rephrased as a property of the literature rather than of a search.

**`Data/LM/labs/index.md`** — deletes the "How each attribution was established" table and the dagger notation, giving each dataset's paper as a table column instead. The four previously inferred attributions were checked against the papers and are now stated plainly:

| Dataset | Checked against |
|---|---|
| Cachero2010 | Zeiss 710; no imaging facility named anywhere in the paper |
| Nojima2021 | Leica TCS SP5; no imaging facility acknowledged |
| SplitNallasivan2025 | Leica TCS SP8; Cambridge Fly Facility credited for injections only |
| Matsuo2016 | Author affiliations (Nagoya; IMCB, University of Tokyo) |

**`Data/LM/_index.md`** — one sentence, same class.
