### PR TITLE
Fix the duplicated home card, and bring the MCP docs up to the deployed server

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -58,8 +58,8 @@ We always welcome user feedback
 {{% /blocks/feature %}}
 
 
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/VirtualFlyBrain" %}}
-We do a [Pull Request](https://github.com/VirtualFlyBrain/VFB2/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% blocks/feature icon="fas fa-comments" title="Ask VFB a question" url="/docs/tutorials/vfb-mcp-guide/" %}}
+Use **Claude** or another AI assistant to explore neurons, brain regions and connections just by asking. No sign-up, no key.
 {{% /blocks/feature %}}
 
 

--- a/content/en/blog/news/VFB_MCP_Tool.md
+++ b/content/en/blog/news/VFB_MCP_Tool.md
@@ -38,7 +38,9 @@ The tool provides seamless access to VFB's databases through a simple interface.
 
 ## Getting Started
 
-Visit the **[VFB MCP Tool](https://vfb3-mcp.virtualflybrain.org/)** to begin exploring. You can:
+Visit the **[VFB MCP Tool](https://vfb3-mcp.virtualflybrain.org/)** to begin exploring. The hosted
+service is currently **v1.11.0**; that page always states the deployed version and the current setup
+instructions for each client. You can:
 
 1. Access through Claude or other MCP-compatible LLMs
 2. Browse the integration documentation and examples

--- a/content/en/docs/Tutorials/vfb-mcp-guide.md
+++ b/content/en/docs/Tutorials/vfb-mcp-guide.md
@@ -19,6 +19,10 @@ The Model Context Protocol is a standard that allows LLMs to interact with exter
 
 The VFB MCP tool is available at: **[vfb3-mcp.virtualflybrain.org](https://vfb3-mcp.virtualflybrain.org/)**
 
+The hosted service is currently **v1.11.0**. That page always states the deployed version and the
+full client setup instructions, including GitHub Copilot, VS Code and Gemini, so check it there
+rather than here if the two disagree.
+
 ### Quick Start
 
 #### Use the Live Service (Recommended)
@@ -130,8 +134,9 @@ If you prefer to run the MCP server locally, see the [VFB3-MCP repository README
 
 ## Core Features
 
-The server exposes a set of tools covering search, term lookup, connectivity and the precomputed
-queries behind the VFB website. The three below are the ones you will use most; the server's own
+The server exposes a set of tools covering search, term lookup, hierarchy, connectivity, name
+resolution and the precomputed queries behind the VFB website. The ones below are the tools as
+deployed in v1.11.0; the server's own
 page at [vfb3-mcp.virtualflybrain.org](https://vfb3-mcp.virtualflybrain.org/) lists the full set as
 deployed, which is the authoritative source if this page has fallen behind.
 
@@ -178,6 +183,58 @@ Execute specific queries on VFB terms, including NBLAST similarity analysis.
 **Example Query:**
 ```text
 "What neurons are morphologically similar to IN02A049?"
+```
+
+### 4. **Hierarchy Trees** (`get_hierarchy`)
+
+Walk the ontology up or down from a term. Use `part_of` for how a region is built from its parts,
+and `subclass_of` for cell type taxonomies. Start one level deep and go further only if you need to.
+
+**Example Query:**
+```text
+"What are the parts of the mushroom body?"
+"What types of Kenyon cell are there?"
+```
+
+Asking for the parts of the mushroom body (FBbt_00005801) one level down returns 17 children,
+including the calyx, pedunculus, spur and lobe system, each for adult and larval stages.
+
+### 5. **Search Facets** (`list_search_facets`)
+
+List the type names that searches can filter, exclude, boost or demote by, with the number of terms
+carrying each. There are 233 of them and they come from the index's own annotations rather than a
+curated list, so they change as data is added. Worth listing rather than guessing.
+
+**Example Query:**
+```text
+"What connectivity filters can I search by?"
+```
+
+That returns `has_neuron_connectivity` (488,110 terms) and `has_region_connectivity` (22,587).
+
+### 6. **Name Resolution** (`resolve_entity`)
+
+Turn a name as written in a paper into FlyBase and VFB IDs — gene symbols, driver lines, construct
+names. It tries an exact match first, then synonyms, then a broad pattern match, and tells you which
+of the three it used.
+
+**Example Query:**
+```text
+"What is Hb9-GAL4?"
+"Tell me about P{VT054895-GAL4.DBD}"
+```
+
+⚠️ When the match came from a synonym or a broad pattern rather than an exact name, check the
+result is the entity you meant before building on it. Your assistant should say which it was.
+
+### 7. **Split-GAL4 Combinations** (`resolve_combination`)
+
+Resolve a split-GAL4 combination name to its FBco ID and the component hemidrivers that make it up.
+
+**Example Query:**
+```text
+"What are the components of SS04495?"
+"What is MB002B?"
 ```
 
 ## Example Use Cases


### PR DESCRIPTION
## Three things

**1. The home page showed the same card twice.**

`content/en/_index.html` carried an identical "Contributions welcome!" card in
both feature rows. Both were added on 20 December 2021 and neither was noticed
since; the new theme made the repetition obvious.

The first row's copy becomes an invitation to query VFB in natural language.
Worded without jargon — the home page is read by fly biologists, and "MCP"
means nothing to most of them. It links to the guide rather than to
`vfb3-mcp.virtualflybrain.org`, which serves a developer-facing server page.

The second row keeps a contributions card, so nothing is lost.

**2. The guide documented three tools. The server deploys nine.**

Missing entirely: `get_hierarchy`, `list_search_facets`, `resolve_entity`,
`resolve_combination`. Readers had no way to know the hierarchy walk or the
FlyBase name resolution existed.

Each now has a section, with examples taken from live calls rather than
invented:

* the mushroom body (`FBbt_00005801`) returns 17 direct parts
* the connectivity facets are `has_neuron_connectivity` (488,110 terms) and
  `has_region_connectivity` (22,587), out of 233 facet names

The "Core Features" preamble still said "the three below". Corrected.

**3. Neither page stated a version.**

Both now say **v1.11.0**, and point at the server's own page as the authority
for the version and per-client setup. That page already carries Copilot, VS Code
and Gemini instructions, so linking beats copying — a copy here would drift the
same way the tool list did.

## Checked

Built clean: 192 pages, no `ERROR`.
