### PR TITLE
Add the MCP paper to the citation page

### DIFF
--- a/content/en/about/citeus.md
+++ b/content/en/about/citeus.md
@@ -41,6 +41,40 @@ Court, Robert, Costa, Marta, Pilgrim, Clare, Millburn, Gillian, Holmes, Alex, Mc
 ```
 ## Additional Citations
 
+### VFB Model Context Protocol (MCP) Tool
+
+If you used the VFB MCP tool — querying VFB through Claude or another AI assistant — please also
+cite the paper describing it and its evaluation:
+
+#### APA
+McLachlan, A. D., Court, R., Pilgrim, C., Longden, K., Brown, N. H., Osumi-Sutherland, D., Jefferis, G. S. X. E., & Armstrong, J. D. (2026). *VFB-MCP: Natural-language access to Drosophila neuroscience grounded by an expert-curated ontology-led knowledgebase* [Preprint]. bioRxiv. https://doi.org/10.64898/2026.06.16.732577
+
+#### MLA
+McLachlan, Alex D., et al. "VFB-MCP: Natural-Language Access to Drosophila Neuroscience Grounded by an Expert-Curated Ontology-Led Knowledgebase." *bioRxiv*, 2026, https://doi.org/10.64898/2026.06.16.732577. Preprint.
+
+#### Chicago
+McLachlan, Alex D., Robert Court, Clare Pilgrim, Kit Longden, Nicolas H. Brown, David Osumi-Sutherland, Gregory S. X. E. Jefferis, and J. Douglas Armstrong. "VFB-MCP: Natural-Language Access to Drosophila Neuroscience Grounded by an Expert-Curated Ontology-Led Knowledgebase." *bioRxiv* (2026). https://doi.org/10.64898/2026.06.16.732577.
+
+#### BibTeX
+```BibTeX
+@article{McLachlan_2026,
+  author = {Alex D. McLachlan and Robert Court and Clare Pilgrim and Kit Longden and Nicolas H. Brown and David Osumi-Sutherland and Gregory S. X. E. Jefferis and J. Douglas Armstrong},
+  title = "{VFB-MCP: Natural-Language Access to Drosophila Neuroscience Grounded by an Expert-Curated Ontology-Led Knowledgebase}",
+  journal = {bioRxiv},
+  year = {2026},
+  month = {jun},
+  note = {Preprint},
+  doi = {10.64898/2026.06.16.732577},
+  url = {https://doi.org/10.64898/2026.06.16.732577},
+}
+```
+
+This is a preprint. If a peer-reviewed version has appeared by the time you submit, cite that
+instead — the DOI above will point to it.
+
+Please cite this **in addition to** the primary citation, not instead of it: the MCP tool answers
+from the same curated knowledgebase the primary paper describes.
+
 ### Drosophila Anatomy Ontology
 
 If you specifically use or reference the Drosophila anatomy ontology developed as part of Virtual Fly Brain, please also cite:


### PR DESCRIPTION
Anyone querying VFB through the MCP tool had nothing to cite for it. The paper is
referenced in the launch news post, but not on the page people visit when writing
a methods section.

Adds a **VFB Model Context Protocol (MCP) Tool** section under *Additional
Citations*, in the same four formats as the primary citation — APA, MLA, Chicago
and BibTeX.

Two wording choices worth a look:

* marked as a **preprint**, with a note to cite the peer-reviewed version instead
  if one has appeared by submission time
* worded to be cited **in addition to** the primary paper rather than instead of
  it, since the tool answers from the same curated knowledgebase

Author list taken from the Crossref record for `10.64898/2026.06.16.732577`,
not from the news post, which says only "McLachlan et al." There are eight
authors: McLachlan, Court, Pilgrim, Longden, Brown, Osumi-Sutherland, Jefferis,
Armstrong.

Checked: builds clean, 192 pages, section renders as expected.
