### PR TITLE
Add a page of published work citing VFB

### DIFF
--- a/content/en/about/citeus.md
+++ b/content/en/about/citeus.md
@@ -82,5 +82,10 @@ If you specifically use or reference the Drosophila anatomy ontology developed a
 * Osumi-Sutherland, D., Reeve, S., Mungall, C. J., Neuhaus, F., Ruttenberg, A., Jefferis, G. S. and Armstrong, J. D. (2012). [A strategy for building neuroanatomy ontologies](https://dx.doi.org/doi:10.1093/bioinformatics/bts113)
 
 
+## Papers citing VFB
+
+For examples of how other groups have used Virtual Fly Brain in published work, see
+[papers citing VFB](/about/papers-citing-vfb/).
+
 ## Acknowledgements
 When appropriate, please also acknowledge the specific data sources integrated into Virtual Fly Brain that you have used, such as JFRC, FlyBase, FlyCircuit, and datasets from individual research groups.

--- a/content/en/about/papers-citing-vfb.md
+++ b/content/en/about/papers-citing-vfb.md
@@ -1,0 +1,347 @@
+---
+title: Papers citing Virtual Fly Brain
+linkTitle: Papers citing VFB
+description: "A curated selection of published work that used Virtual Fly Brain, with what each paper used VFB for. Examples of VFB in research practice across connectomics, neuroanatomy, expression and imaging."
+tags: [VFB,citation,publication,research]
+categories: [how to cite,acknowledgements]
+weight: 21
+---
+
+# Papers citing Virtual Fly Brain
+
+A curated selection of published work that used Virtual Fly Brain, with a short note
+on what each paper used it for. It is not a complete citation count — it is a sample
+showing how VFB is used in practice, from retrieving a single template to
+cross-linking transcriptomic and connectome data.
+
+If you have used VFB in a paper we have missed, please [get in touch](/about/contactus/).
+See [how to cite us](/about/citeus/) for the citations to use.
+
+## Research papers
+
+### 1. Shen D et al. — *Cell Reports*, 2025
+
+Cross-linked transcriptomic and connectome data using the query tool.
+
+Shen D, Vincent A, Udine E, Buhidma Y, Anoar S, Tsintzas E, Maeland M, Xu D, Carcolé M, Osumi-Sutherland D, Aleyakpo B, Hull A, Martínez Corrales G, Woodling N, Rademakers R, Isaacs AM, Frigerio C, van Blitterswijk M, Lashley T, Niccoli T. *Cell Reports* (2025). [doi:10.1016/j.celrep.2025.115459](https://doi.org/10.1016/j.celrep.2025.115459)
+Last author: Teresa Niccoli, UCL, UK
+
+### 2. Zhang T et al. — *PLoS Biology*, 2025
+
+Explored connectivity by brain region.
+
+Zhang T, Wu Z, Song Y, Ryu TH, Zhang X, Li W, Sun Y, Wong K, Schweizer J, Nguyen KH, Kwan A, Yu K, Kim WJ. *PLoS Biology* (2025). [doi:10.1371/journal.pbio.3003330](https://doi.org/10.1371/journal.pbio.3003330)
+Last author: Woo Jae Kim, University of Ottawa, Canada
+
+### 3. Dürr B et al. — *Cell Reports*, 2025
+
+Compared morphology in light- and electron-microscopy data.
+
+Dürr B, Bertolini E, Takagi S, Pascual J, Abuin L, Lucarelli G, Benton R, Auer T. *Cell Reports* (2025). [doi:10.1016/j.celrep.2025.115615](https://doi.org/10.1016/j.celrep.2025.115615)
+Last author: Thomas Auer, University of Fribourg, Switzerland
+
+### 4. Mohamed A et al. — *Frontiers in Physiology*, 2023
+
+Explored morphology and connectivity.
+
+Mohamed A, Malekou I, Sim T, O'Kane CJ, Maait Y, Scullion B, Masuda-Nakagawa LM. *Frontiers in Physiology* (2023). [doi:10.3389/fphys.2023.1111244](https://doi.org/10.3389/fphys.2023.1111244)
+Last author: Liria M. Masuda-Nakagawa, University of Cambridge, UK
+
+### 5. Yamakoshi H et al. — *iScience*, 2025
+
+Compared morphology.
+
+Yamakoshi H, Horigome M, Yamamoto S, Iwanami S, Iwami S, Tanaka R, Ishikawa Y, Kamikouchi A. *iScience* (2025). [doi:10.1016/j.isci.2025.113232](https://doi.org/10.1016/j.isci.2025.113232)
+Last author: Azusa Kamikouchi, Nagoya University, Japan
+
+### 6. Song Y et al. — *PLoS Biology*, 2025
+
+Explored morphology and expression pattern.
+
+Song Y, Zhang T, Ryu TH, Wong K, Wu Z, Wei Y, Schweizer J, Nguyen KH, Kwan A, Zhang X, Yu K, Kim WJ. *PLoS Biology* (2025). [doi:10.1371/journal.pbio.3003345](https://doi.org/10.1371/journal.pbio.3003345)
+Last author: Woo Jae Kim, University of Ottawa, Canada
+
+### 7. Goldschmidt D et al. — *bioRxiv*, 2023
+
+Explored morphology and expression pattern.
+
+Goldschmidt D, Tastekin I, Münch D, Park J-Y, Haberkern H, Serra L, Baltazar C, Jayaraman V, Rubin GM, Ribeiro C. *bioRxiv* (2023). [doi:10.1101/2023.07.19.549514](https://doi.org/10.1101/2023.07.19.549514)
+Last author: Carlos Ribeiro, Champalimaud, Portugal
+
+### 8. Cheong HSJ et al. — *eLife*, 2026
+
+Retrieved tract meshes.
+
+Cheong HSJ, Eichler K, Stürner T, Asinof SK, Champion AS, Marin EC, Oram TB, Sumathipala M, Venkatasubramanian L, Namiki S, Siwanowicz I, Costa M, Berg S, Janelia FlyEM Project Team, Jefferis GSXE, Card GM. *eLife* (2026). [doi:10.7554/eLife.96084](https://doi.org/10.7554/eLife.96084)
+Last author: Gwyneth M. Card, Columbia University, USA
+
+### 9. Davidson AM et al. — *eNeuro*, 2023
+
+Explored morphology and expression pattern.
+
+Davidson AM, Kaushik S, Hige T. *eNeuro* (2023). [doi:10.1523/ENEURO.0275-23.2023](https://doi.org/10.1523/ENEURO.0275-23.2023)
+Last author: Toshihide Hige, University of North Carolina at Chapel Hill, USA
+
+### 10. Imoto K et al. — *iScience*, 2024
+
+Visualised morphology.
+
+Imoto K, Ishikawa Y, Aso Y, Funke J, Tanaka R, Kamikouchi A. *iScience* (2024). [doi:10.1016/j.isci.2024.110266](https://doi.org/10.1016/j.isci.2024.110266)
+Last author: Azusa Kamikouchi, Nagoya University, Japan
+
+### 11. Castaneda AN et al. — *PLoS Genetics*, 2024
+
+Identified tracts.
+
+Castaneda AN, Huda A, Whitaker IBM, Reilly JE, Shelby GS, Bai H, Ni L. *PLoS Genetics* (2024). [doi:10.1371/journal.pgen.1011190](https://doi.org/10.1371/journal.pgen.1011190)
+Last author: Lina Ni, Virginia Tech, USA
+
+### 12. O'Hara MK et al. — *Sleep*, 2024
+
+Examined regional expression of GAL4 lines.
+
+O'Hara MK, Saul C, Handa A, Cho B, Zheng X, Sehgal A, Williams JA. *Sleep* (2024). [doi:10.1093/sleep/zsae096](https://doi.org/10.1093/sleep/zsae096)
+Last author: Julie A. Williams, University of Pennsylvania, USA
+
+### 13. Sakr R et al. — *EMBO Reports*, 2026
+
+Visualised neurons and brain regions.
+
+Sakr R, Monticelli S, Kizhakkenottiyath Shasthadevan S, Delaporte C, Zhang G, Tabiat T, Giangrande A, Cattenoz PB. *EMBO Reports* (2026). [doi:10.1038/s44319-026-00728-1](https://doi.org/10.1038/s44319-026-00728-1)
+Last author: Pierre B. Cattenoz, CNRS Illkirch, France
+
+### 14. Jiang H et al. — *bioRxiv*, 2025
+
+Used brain templates.
+
+Jiang H, Walker LA, Li Y, Duan B, Niu X, Hsieh JC, Cheng MC, Su H, Sheng K, Tang JP, Athukorala K, Greene S, Pan R, Parlapalli A, Yin P, Cui M, Cai D. *bioRxiv* (2025). [doi:10.1101/2025.05.31.657163](https://doi.org/10.1101/2025.05.31.657163)
+Last author: Dawen Cai, University of Michigan, USA
+
+### 15. Olivera RA et al. — *Neuroinformatics*, 2026
+
+Retrieved neuron names, aliases and neurotransmitter expression.
+
+Olivera RA. *Neuroinformatics* (2026). [doi:10.1007/s12021-026-09783-4](https://doi.org/10.1007/s12021-026-09783-4)
+Last author: R. A. Olivera, NST Mangalore, India
+
+### 16. Palmieri E et al. — *bioRxiv*, 2026
+
+Confirmed gene expression.
+
+Palmieri E, Coon M, Sobukunola A, Sutton L, Vonhoff FJ. *bioRxiv* (2026). [doi:10.64898/2026.04.22.720032](https://doi.org/10.64898/2026.04.22.720032)
+Last author: Fernando J. Vonhoff, University of Maryland, Baltimore County, USA
+
+### 17. Wright N et al. — *Bioinformatics Advances*, 2023
+
+Visualised brain regions and neurons.
+
+Wright N, Rowlands CJ. *Bioinformatics Advances* (2023). [doi:10.1093/bioadv/vbad182](https://doi.org/10.1093/bioadv/vbad182)
+Last author: Christopher J. Rowlands, Imperial College London, UK
+
+### 18. Münch D et al. — *Nature*, 2022
+
+Retrieved registered neurons for analysis.
+
+Münch D, Goldschmidt D, Ribeiro C. *Nature* (2022). [doi:10.1038/s41586-022-04909-5](https://doi.org/10.1038/s41586-022-04909-5)
+Last author: Carlos Ribeiro, Champalimaud, Portugal
+
+### 19. Jetti SK et al. — *Neuron*, 2023
+
+Explored morphology and connectivity.
+
+Jetti SK, Crane AB, Akbergenova Y, Aponte-Santiago NA, Cunningham KL, Whittaker CA, Littleton JT. *Neuron* (2023). [doi:10.1016/j.neuron.2023.07.019](https://doi.org/10.1016/j.neuron.2023.07.019)
+Last author: J. Troy Littleton, MIT, USA
+
+### 20. Xie T et al. — *Cell Reports*, 2018
+
+Retrieved templates and GAL4 expression patterns.
+
+Xie T, Ho MCW, Liu Q, Horiuchi W, Lin CC, Task D, Luan H, White BH, Potter CJ, Wu MN. *Cell Reports* (2018). [doi:10.1016/j.celrep.2018.03.068](https://doi.org/10.1016/j.celrep.2018.03.068)
+Last author: Mark N. Wu, Johns Hopkins, USA
+
+### 21. May CE et al. — *eLife*, 2020
+
+Visualised neurons.
+
+May CE, Rosander J, Gottfried J, Dennis E, Dus M. *eLife* (2020). [doi:10.7554/eLife.54530](https://doi.org/10.7554/eLife.54530)
+Last author: Monica Dus, University of Michigan, USA
+
+### 22. Goulard R et al. — *PLoS Computational Biology*, 2021
+
+Retrieved connectivity data.
+
+Goulard R, Buehlmann C, Niven JE, Graham P, Webb B. *PLoS Computational Biology* (2021). [doi:10.1371/journal.pcbi.1009383](https://doi.org/10.1371/journal.pcbi.1009383)
+Last author: Barbara Webb, University of Edinburgh, UK
+
+### 23. Coates KE et al. — *Journal of Neuroscience*, 2020
+
+Compared morphology and expression pattern.
+
+Coates KE, Calle-Schuler SA, Helmick LM, Knotts VL, Martik BN, Salman F, Warner LT, Valla SV, Bock DD, Dacks AM. *Journal of Neuroscience* (2020). [doi:10.1523/JNEUROSCI.0552-20.2020](https://doi.org/10.1523/JNEUROSCI.0552-20.2020)
+Last author: Andrew M. Dacks, West Virginia University, USA
+
+### 24. Gkanias E et al. — *eLife*, 2022
+
+Visualised neurons.
+
+Gkanias E, McCurdy LY, Nitabach MN, Webb B. *eLife* (2022). [doi:10.7554/eLife.75611](https://doi.org/10.7554/eLife.75611)
+Last author: Barbara Webb, University of Edinburgh, UK
+
+### 25. Chen KF et al. — *eLife*, 2019
+
+Retrieved GAL4 expression patterns.
+
+Chen KF, Lowe S, Lamaze A, Krätschmer P, Jepson J. *eLife* (2019). [doi:10.7554/eLife.38114](https://doi.org/10.7554/eLife.38114)
+Last author: James Jepson, UCL, UK
+
+### 26. Odell SR et al. — *Scientific Reports*, 2022
+
+Explored morphology and connectivity.
+
+Odell SR, Clark D, Zito N, Jain R, Gong H, Warnock K, Carrion-Lopez R, Maixner C, Prieto-Godino L, Mathew D. *Scientific Reports* (2022). [doi:10.1038/s41598-022-20147-1](https://doi.org/10.1038/s41598-022-20147-1)
+Last author: Dennis Mathew, University of Nevada, Reno, USA
+
+### 27. Tsuji M et al. — *Nature Communications*, 2023
+
+Explored morphology, expression patterns and connectivity.
+
+Tsuji M, Nishizuka Y, Emoto K. *Nature Communications* (2023). [doi:10.1038/s41467-023-39667-z](https://doi.org/10.1038/s41467-023-39667-z)
+Last author: Kazuo Emoto, University of Tokyo, Japan
+
+### 28. Hartenstein V et al. — *Developmental Biology*, 2015
+
+Identified tracts.
+
+Hartenstein V, Younossi-Hartenstein A, Lovick JK, Kong A, Omoto JJ, Ngo KT, Viktorin G. *Developmental Biology* (2015). [doi:10.1016/j.ydbio.2015.06.021](https://doi.org/10.1016/j.ydbio.2015.06.021)
+Last author: Volker Hartenstein, UCLA, USA
+
+### 29. Hildebrandt K et al. — *Developmental Biology*, 2022
+
+Assigned expression to structures and lineages.
+
+Hildebrandt K, Klöppel C, Gogel J, Hartenstein V, Walldorf U. *Developmental Biology* (2022). [doi:10.1016/j.ydbio.2022.09.006](https://doi.org/10.1016/j.ydbio.2022.09.006)
+Last author: Uwe Walldorf, Saarland University, Germany
+
+### 30. Afkhami M et al. — *Journal of Neurogenetics*, 2024
+
+Compared morphology and expression pattern.
+
+Afkhami M. *Journal of Neurogenetics* (2024). [doi:10.1080/01677063.2024.2396352](https://doi.org/10.1080/01677063.2024.2396352)
+Last author: Mehrnaz Afkhami, University of Oklahoma, USA
+
+### 31. Mollá-Albaladejo R et al. — *eLife*, 2025
+
+Retrieved skeletons and aligned them to a template.
+
+Mollá-Albaladejo R, Jiménez-Caballero M, Sanchez-Alcaniz JA. *eLife* (2025). [doi:10.7554/eLife.100947](https://doi.org/10.7554/eLife.100947)
+Last author: Juan Antonio Sanchez-Alcaniz, Institute of Neuroscience, Alicante, Spain
+
+### 32. Chen YD et al. — *Journal of Experimental Biology*, 2019
+
+Ran a morphology screen for candidate driver lines.
+
+Chen YD, Ahmad S, Amin K, Dahanukar A. *Journal of Experimental Biology* (2019). [doi:10.1242/jeb.210724](https://doi.org/10.1242/jeb.210724)
+Last author: Anupama Dahanukar, University of California Riverside, USA
+
+### 33. Aimon S et al. — *PLoS Biology*, 2019
+
+Visualised brain regions and neurons.
+
+Aimon S, Katsuki T, Jia T, Grosenick L, Broxton M, Deisseroth K, Sejnowski TJ, Greenspan RJ. *PLoS Biology* (2019). [doi:10.1371/journal.pbio.2006732](https://doi.org/10.1371/journal.pbio.2006732)
+Last author: Ralph J. Greenspan, UCSD, USA
+
+### 34. Zheng Z et al. — *Cell*, 2018
+
+Used a mesh in the template brain to trim skeletons of EM- and LM-reconstructed neurons.
+
+Zheng Z, Lauritzen JS, Perlman E, Robinson CG, Nichols M, Milkie D, Torrens O, Price J, Fisher CB, Sharifi N, Calle-Schuler SA, Kmecova L, Ali IJ, Karsh B, Trautman ET, Bogovic JA, Hanslovsky P, Jefferis GSXE, Kazhdan M, Khairy K, Saalfeld S, Fetter RD, Bock DD. *Cell* (2018). [doi:10.1016/j.cell.2018.06.019](https://doi.org/10.1016/j.cell.2018.06.019)
+Last author: Davi D. Bock, HHMI Janelia, USA
+
+### 35. Liang Q et al. — *bioRxiv*, 2026
+
+Analysed brain-region morphology of neurons.
+
+Liang Q, Liu Q, Ning J, Lv Q, Zhang X, Wang K, Sun Y. *bioRxiv* (2026). [doi:10.64898/2026.05.29.728103](https://doi.org/10.64898/2026.05.29.728103)
+Last author: Yi Sun, Westlake University, Zhejiang, China
+
+### 36. Bates AS et al. — *Current Biology*, 2020
+
+Retrieved reconstructions of neurons from EM data.
+
+Bates AS, Schlegel P, Roberts RJV, Drummond N, Tamimi IFM, Turnbull R, Zhao X, Marin EC, Popovici PD, Dhawan S, Jamasb A, Javier A, Serratosa Capdevila L, Li F, Rubin GM, Waddell S, Bock DD, Costa M, Jefferis GSXE. *Current Biology* (2020). [doi:10.1016/j.cub.2020.06.042](https://doi.org/10.1016/j.cub.2020.06.042)
+Last author: Gregory S. X. E. Jefferis, LMB and University of Cambridge, UK
+
+### 37. Okuno T et al. — *bioRxiv*, 2025
+
+Retrieved a brain-region atlas.
+
+Okuno T, Woodward A, Okano H, Hata J. *bioRxiv* (2025). [doi:10.1101/2025.07.01.662601](https://doi.org/10.1101/2025.07.01.662601)
+Last author: Junichi Hata, Tokyo Metropolitan University, Japan
+
+### 38. Otsuna H et al. — *bioRxiv*, 2018
+
+Retrieved reconstructions of neurons from EM data.
+
+Otsuna H, Ito M, Kawase T. *bioRxiv* (2018). [doi:10.1101/318006](https://doi.org/10.1101/318006)
+Last author: Takashi Kawase, HHMI Janelia, USA
+
+### 39. Mann K et al. — *Current Biology*, 2017
+
+Used a template and brain-region atlas to align calcium-imaging data.
+
+Mann K, Gallen CL, Clandinin TR. *Current Biology* (2017). [doi:10.1016/j.cub.2017.06.076](https://doi.org/10.1016/j.cub.2017.06.076)
+Last author: Thomas R. Clandinin, Stanford University, USA
+
+### 40. Yu HH et al. — *Current Biology*, 2013
+
+Explored morphology and expression pattern.
+
+Yu HH, Awasaki T, Schroeder MD, Long F, Yang JS, He Y, Ding P, Kao JC, Wu GY, Peng H, Myers G, Lee T. *Current Biology* (2013). [doi:10.1016/j.cub.2013.02.057](https://doi.org/10.1016/j.cub.2013.02.057)
+Last author: Tzumin Lee, HHMI Janelia and University of Massachusetts, USA
+
+### 41. Lee YJ et al. — *eLife*, 2020
+
+Explored morphology and expression pattern.
+
+Lee YJ, Yang CP, Miyares RL, Huang YF, He Y, Ren Q, Chen HM, Kawase T, Ito M, Otsuna H, Sugino K, Aso Y, Ito K, Lee T. *eLife* (2020). [doi:10.7554/eLife.53518](https://doi.org/10.7554/eLife.53518)
+Last author: Tzumin Lee, HHMI Janelia, USA
+
+### 42. Marquis M et al. — *Current Biology*, 2022
+
+Cross-referenced cell-type names against VFB exemplars.
+
+Marquis M, Wilson RI. *Current Biology* (2022). [doi:10.1016/j.cub.2022.11.008](https://doi.org/10.1016/j.cub.2022.11.008)
+Last author: Rachel I. Wilson, Harvard Medical School, USA
+
+### 43. Scheffer LK et al. — *eLife*, 2020
+
+Retrieved neuron names and synonyms.
+
+Scheffer LK, Xu CS, Januszewski M, Lu Z, Takemura SY, Hayworth KJ, Huang GB, Shinomiya K, Maitlin-Shepard J, Berg S, Clements J, Hubbard PM, Katz WT, et al.. *eLife* (2020). [doi:10.7554/eLife.57443](https://doi.org/10.7554/eLife.57443)
+Last author: Stephen M. Plaza, HHMI Janelia, USA
+
+## Honourable mentions
+
+Reviews, book chapters and papers that discuss VFB as a resource rather than using it
+for a specific analysis.
+
+### Fiala A et al. — *Learning & Memory (2024)*
+
+Cited VFB as a platform connecting connectome neurons to existing Drosophila resources, and as an example of the collaborative infrastructure behind 25 years of mushroom body research.
+
+Fiala A, Kaun KR. Learning & Memory (2024). [doi:10.1101/lm.053827.123](https://doi.org/10.1101/lm.053827.123)
+Last author: Karla R. Kaun, Brown University, USA
+
+### Forrest H et al. — *In: Home Cage Monitoring in Rodents: A Global Effort, Springer (2026)*
+
+Held up VFB's provenance system as an example of effective data integration, linking entries to original sources with machine-readable metadata.
+
+Forrest H, Huzard D, Restivo L, Baran SW, Petit-Demoulière B. In: Home Cage Monitoring in Rodents: A Global Effort, Springer (2026). [doi:10.1007/978-3-032-19781-8_10](https://doi.org/10.1007/978-3-032-19781-8_10)
+Last author: Benoit Petit-Demoulière, University of Strasbourg, France
+
+### Heinze S et al. — *eLife (2021)*
+
+Described VFB as the main repository for Drosophila anatomical data and the model for what a unified insect-neuroscience platform should provide.
+
+Heinze S, El Jundi B, Berg BG, Homberg U, Menzel R, Pfeiffer K, Hensgen R, Zittrell F, Dacke M, Warrant E, Pfuhl G, Rybak J, Tedore K. eLife (2021). [doi:10.7554/eLife.65376](https://doi.org/10.7554/eLife.65376)
+Last author: Kevin Tedore, Lund University, Sweden


### PR DESCRIPTION
## What

A new page at `/about/papers-citing-vfb/` listing published work that used Virtual
Fly Brain, with a one-line note on what each paper used it for. Linked from the
cite-us page.

43 research papers and 3 reviews or book chapters. Source is the curated citation
doc maintained by the VFB team.

Every entry has the same shape:

> ### 1. Shen D et al. — *Cell Reports*, 2025
> Cross-linked transcriptomic and connectome data using the query tool.
> *(full author list)*. *Cell Reports* (2025). [doi:10.1016/j.celrep.2025.115459]
> Last author: Teresa Niccoli, UCL, UK

## Summarised, not quoted

The source doc holds a verbatim quote from each paper. Those are not reproduced,
because the licences across the list are mixed. Checked against Crossref:

| CC-BY — quoting would be fine | Not open — quoting would not be |
|---|---|
| eLife, PLoS (Biol/Genet/Comput Biol), Frontiers, Nature Communications, Scientific Reports, EMBO Reports, Cell Reports (Dürr) | Nature, Neuron, Current Biology, Developmental Biology, J Exp Biol, Sleep, Neuroinformatics |

A page that quoted some papers and paraphrased others would look arbitrary, and
would need re-checking whenever a licence changed. Describing what a paper did
raises no licence question, reads better than a paragraph of methods prose, and
gives every entry the same shape.

The summary lines are the VFB team's own, from the source doc, not newly written —
with one exception noted below.

## Every DOI was verified

All 46 were resolved against the Crossref API and checked to match the cited first
author. **This caught a wrong DOI**: the Orthopedia paper (Hildebrandt et al.) is
`10.1016/j.ydbio.2022.09.006`, not `.005`, which is a different paper about the
exocyst complex.

One entry still flags in that check and is a false positive: Crossref stores
O'Hara with a curly apostrophe. Title and all seven authors match.

## Three judgement calls to check before merge

⚠️ **1. One summary line is mine, not the team's.** The source doc numbers two
papers as 42 (Marquis & Wilson, and Scheffer et al.), so its summary list has 42
entries for 43 papers. For Marquis & Wilson I wrote *"Cross-referenced cell-type
names against VFB exemplars."*

⚠️ **2. Two institutions differ from the source doc**, where its numbered list
disagreed with the entry's own line. Taken from the papers: Lina Ni is at Virginia
Tech, not Colorado Boulder; Fernando Vonhoff is at UMBC.

⚠️ **3. The source doc's two numbered lists drift out of step** with the paper list
around entries 41-42. Neither is used here — each entry's own inline "Last author"
line is unambiguous — but the doc itself is worth correcting.

## Checked

Builds clean: 193 pages, no `ERROR`. 46 DOI links and 46 last-author lines render.
