### PR TITLE
Fix the 404 page layout, and point it at the 3D browser

### DIFF
--- a/themes/vfb-nova/assets/css/base.css
+++ b/themes/vfb-nova/assets/css/base.css
@@ -214,3 +214,38 @@ a.pill:hover { border-color: var(--brand); color: var(--text); text-decoration: 
   overflow: hidden; clip: rect(0 0 0 0);
   white-space: nowrap; border: 0;
 }
+
+/* --------------------------------------------------------------------------
+   404 page.
+
+   layouts/404.html has always carried .oops and .oops__code, but neither was
+   ever defined, so the page rendered unstyled: the "404" came out at body size
+   tucked under the site logo, the heading ran beneath the fixed navbar, and the
+   block sat jammed against the top with a tall empty band above the footer.
+
+   The header is position:fixed, so the offset has to be --nav-h, the same
+   variable docs.css uses. min-height fills the viewport so the footer sits at
+   the bottom rather than halfway up.
+   -------------------------------------------------------------------------- */
+.oops {
+  min-height: calc(100vh - var(--nav-h) - 12rem);
+  padding-top: calc(var(--nav-h) + var(--sp-7));
+  padding-bottom: var(--sp-7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.oops > div { max-width: 46rem; }
+.oops__code {
+  font-size: clamp(4.5rem, 14vw, 9rem);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  background: linear-gradient(120deg, var(--violet), var(--cyan));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+/* .lede is max-width:62ch and left-aligned by default; centre it here. */
+.oops .lede { margin-inline: auto; text-align: center; }

--- a/themes/vfb-nova/layouts/404.html
+++ b/themes/vfb-nova/layouts/404.html
@@ -4,13 +4,12 @@
     <div class="oops__code">404</div>
     <h1 style="margin-top:1rem">We can’t find that page</h1>
     <p class="lede">The link may be out of date, or the address may have a typo.</p>
-    <p class="lede">Looking for a neuron or a brain region? Those pages live under
-      <code>/term/</code>, and the quickest way to one is the search box above or the
-      3D browser.</p>
+    <p class="lede">Looking for a neuron, a brain region or an expression pattern?
+      Open the 3D browser and search there — that is where the anatomy lives.</p>
     <div style="display:flex;gap:.75rem;justify-content:center;flex-wrap:wrap;margin-top:2rem">
-      <button class="btn btn--primary js-search" type="button"><i class="fas fa-magnifying-glass"></i> Search the site</button>
+      <a class="btn btn--primary" href="{{ .Site.Params.app_url }}" target="_blank" rel="noopener"><i class="fas fa-cube"></i> Open the 3D browser</a>
+      <button class="btn js-search" type="button"><i class="fas fa-magnifying-glass"></i> Search this site</button>
       <a class="btn" href="{{ "/" | relURL }}">Home</a>
-      <a class="btn" href="{{ "/docs/" | relURL }}">Documentation</a>
     </div>
   </div>
 </div>

--- a/themes/vfb-nova/layouts/404.html
+++ b/themes/vfb-nova/layouts/404.html
@@ -2,9 +2,11 @@
 <div class="wrap oops">
   <div>
     <div class="oops__code">404</div>
-    <h1 style="margin-top:1rem">This page isn’t registered to any template.</h1>
-    <p class="lede" style="margin-inline:auto">The address may have moved. Anatomy terms live under
-      <code>/term/</code> and are best reached through search or the 3D browser.</p>
+    <h1 style="margin-top:1rem">We can’t find that page</h1>
+    <p class="lede">The link may be out of date, or the address may have a typo.</p>
+    <p class="lede">Looking for a neuron or a brain region? Those pages live under
+      <code>/term/</code>, and the quickest way to one is the search box above or the
+      3D browser.</p>
     <div style="display:flex;gap:.75rem;justify-content:center;flex-wrap:wrap;margin-top:2rem">
       <button class="btn btn--primary js-search" type="button"><i class="fas fa-magnifying-glass"></i> Search the site</button>
       <a class="btn" href="{{ "/" | relURL }}">Home</a>


### PR DESCRIPTION
## The layout

`layouts/404.html` has always carried `.oops` and `.oops__code`, but **neither was
ever defined in CSS**. The page rendered completely unstyled:

* the `404` came out at body-text size, tucked behind the site logo
* the heading ran underneath the fixed navbar
* the block sat jammed against the top of the viewport, with a tall empty band
  above the footer

Adds the two rules. The header is `position:fixed`, so the offset uses `--nav-h` —
the same variable `docs.css` already uses. `min-height` fills the viewport so the
footer sits at the bottom. The numeral picks up the brand gradient.

Three inline `style=` attributes that were compensating for the missing CSS are
gone.

## The copy

It said:

> This page isn't registered to any template.

That describes Hugo's internals, not the visitor's problem. "Template" means
nothing to a fly biologist who followed a stale link.

Now:

> **We can't find that page**
>
> The link may be out of date, or the address may have a typo.
>
> Looking for a neuron, a brain region or an expression pattern? Open the 3D
> browser and search there — that is where the anatomy lives.

## The actions

`Open the 3D browser` (primary) · `Search this site` · `Home`

Someone who hit a dead link looking for a neuron wants the atlas, not the docs.
The site search only covers authored pages — anatomy terms, images, expression
patterns and connectivity all live in the 3D browser, so that becomes the primary
action and search drops to secondary.

The button uses `Site.Params.app_url` rather than a hardcoded URL, so it tracks
the nav and footer if that ever moves. Documentation comes off: three buttons is
enough and it is one click away in the nav.

## Checked

Rendered headless at 1440px and 390px. Builds clean, 192 pages, no `ERROR`. The
button carries the real app URL in the built output.
