### PR TITLE
Add "Which fly is this?" and the missing technique pages

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -12,9 +12,10 @@ cascade:
     path: "/**"
 description: "Virtual Fly Brain (VFB) is an interactive tool for neurobiologists to explore the detailed neuroanatomy, neuron connectivity and gene expression of Drosophila melanogaster. Our goal is to make it easier for researchers to find relevant anatomical information and reagents. We integrate the neuroanatomical and expression data from the published literature, as well as image datasets onto the same brain template, making it possible to run cross searches, find similar neurons and compare image data on our 3D Viewer."
 ---
-About Virtual Fly Brain: [what it is](/about/whatisvfb/) and who builds it, the
-[people](/about/members/) and [collaborators](/about/collaborators/) behind it, the
-[funding](/about/funding/) that supports it, and [how to cite it](/about/citeus/).
+About Virtual Fly Brain: [what it is](/about/whatisvfb/) and who builds it,
+[which fly the data came from](/about/whichfly/), the [people](/about/members/) and
+[collaborators](/about/collaborators/) behind it, the [funding](/about/funding/) that
+supports it, and [how to cite it](/about/citeus/).
 
 For the underlying platform see [Geppetto](/about/geppetto/), and to get in touch see
 [contact us](/about/contactus/).

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -293,7 +293,19 @@ onto a common template ([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB
 comparison possible at all. The current standard, JRC2018, was built by groupwise
 registration — the unisex brain template from 62 individuals, 124 images counting
 left–right flips ([Bogovic et al., 2020](https://doi.org/10.1371/journal.pone.0236495)).
-See [Registration](/docs/concepts/registration/) and [Templates](/docs/data/templates/).
+
+No single template ever won, so comparing across studies means bridging between them. The
+transforms form a graph, maintained in the community `navis-flybrains` and `nat.flybrains`
+packages so that everyone gets the same answer, and a conversion between two spaces is a
+computed route through it — often several transforms deep:
+
+<p align="center">
+<img src="https://github.com/schlegelp/navis-flybrains/blob/main/_static/bridging_graph.png?raw=true" width="800" alt="Graph of bridging registrations between Drosophila template spaces">
+</p>
+
+See [Registration](/docs/concepts/registration/),
+[Bridging registrations](/docs/concepts/bridging/) and
+[Templates](/docs/data/templates/).
 
 **Wiring diagrams.** Volume EM at synaptic resolution, then reconstruction: serial-section
 TEM for FAFB and the larval CNS

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -26,12 +26,13 @@ at Columbia, and the animal almost every technique described below was built aro
 The more precise answer is that most of the connectomic data on VFB came from one
 laboratory cross, repeated for five different specimens.
 
-## The same cross, five times
+## The same cross, every time
 
 The flagship EM volumes were not taken from a wild population or from a lab's general
-stock. Four of the five below are the offspring of a cross between the wild-type
-**Canton-S strain G1** and **w<sup>1118</sup>**, both isogenised, reared on a 12-hour
-day/night cycle and dissected 1.5 hours after lights-on.
+stock. Every one of them is the F1 of a cross between the wild-type **Canton-S strain G1**
+and ***w<sup>1118</sup>***. The Janelia volumes were reared on a 12-hour day/night cycle
+and dissected 1.5 hours after lights-on; the direction of the cross as written varies
+between papers.
 
 | Volume in VFB | Stage and sex | Age | Genotype | Source |
 |---|---|---|---|---|
@@ -39,9 +40,19 @@ day/night cycle and dissected 1.5 hours after lights-on.
 | Hemibrain | Adult female | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
 | MANC (male VNC) | Adult male | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
 | Optic lobe | Adult male | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
+| male-CNS | Adult male | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
+| BANC | Adult female | 5–6 days post-eclosion | F1 of *w<sup>1118</sup>* × Canton-S | [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
 | L1 larval CNS | First-instar female larva | 6 hours after hatching | Canton-S G1 [iso] × *w<sup>1118</sup>* [iso] 5905 | [Winding et al. (2023)](https://doi.org/10.1126/science.add9330), volume from [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
 
-Two things follow from this table, and both matter when you read a result off VFB.
+Two rows of that table are the **same individual fly**. Both the optic lobe study and the
+male-CNS study name their specimen `Z0720-07m`, selected as the best of 44 preparations
+screened by X-ray CT; the male-CNS paper describes the optic lobe work as "an earlier
+study of the same sample". Counting neurons across those two datasets therefore
+double-counts the same cells — the male-brain equivalent of the FlyWire/hemibrain problem
+set out on the [neuron counts](/docs/concepts/neuron-counts/) page, except that here it is
+literally one animal rather than two animals imaged in the same region.
+
+Two further things follow from this table, and both matter when you read a result off VFB.
 
 **Each connectome is one animal.** A connectome is not a population average; it is a
 census of the individual that was sectioned. Where two connectomes disagree about a
@@ -50,11 +61,24 @@ The [neuron counts](/docs/concepts/neuron-counts/) page works through what this 
 any number you might want to quote, including the fact that FlyWire and the hemibrain
 partly re-reconstruct the same tissue.
 
-**Sex and stage are properties of the dataset, not of "the fly".** The adult brain
-connectomes are female; the VNC and optic lobe connectomes are male; the larval
-connectome is a six-hour-old first instar. A cell type present in one is not guaranteed
-to be present, or to have the same partners, in another. VFB keeps sex and stage on the
-dataset record for exactly this reason.
+**Sex and stage are properties of the dataset, not of "the fly".** FAFB, the hemibrain and
+BANC are female; MANC, the optic lobe and male-CNS are male; the larval connectome is a
+six-hour-old first instar. A cell type present in one is not guaranteed to be present, or
+to have the same partners, in another — which is the point of the male-CNS study, which
+reports 7,205 isomorphic, 114 dimorphic, 262 male-specific and 69 female-specific types
+between the male and female brain connectomes
+([Berg et al., 2025](https://doi.org/10.1101/2025.10.09.680999)). VFB keeps sex and stage
+on the dataset record for exactly this reason.
+
+**One of them was not a random fly.** The BANC specimen was chosen by behaviour. The
+authors screened 5–6-day-old females and picked one that "turned right 70% of the time
+over 582 choices when walking in an acrylic Y-maze", putting it "at the 97th percentile
+for handedness in the population (n = 1,095)"
+([Bates et al., 2026](https://doi.org/10.1038/s41586-026-10735-w)). That was a deliberate
+and reasonable choice — a strong behavioural phenotype makes the connectome more
+interpretable — but it means the BANC animal is a documented outlier on at least one axis,
+not a draw from the middle of the distribution. Worth knowing before treating it as
+typical.
 
 ### What that genotype actually is
 
@@ -147,10 +171,13 @@ neuroscience gave vertebrate neuroscience.
 ## What making one of these datasets actually involves
 
 The reason the fly scales is that the bench work is cheap in everything except patience.
-A generation takes about ten days at 25 °C. Flies are reared in vials on a cornmeal or
-molasses medium, anaesthetised on CO<sub>2</sub> to be sorted under a dissecting scope, and
-scored by eye — which is why so many classical markers are visible ones such as eye
-colour, wing shape and bristle morphology.
+Flies are reared in vials on a standard medium — the BANC animals, for instance, were
+"raised on standard cornmeal–dextrose medium at room temperature (around 20 °C) in natural
+lighting conditions"
+([Bates et al., 2026](https://doi.org/10.1038/s41586-026-10735-w)) — anaesthetised on
+CO<sub>2</sub> to be sorted under a dissecting scope, and scored by eye, which is why so
+many classical markers are visible ones such as eye colour, wing shape and bristle
+morphology.
 
 A typical light microscopy dataset on VFB is the end of a chain of crosses. Virgin females
 of one genotype are collected — they must be picked before they mate — and crossed to
@@ -334,6 +361,8 @@ using the strategy described in
 - Scheffer LK et al. (2020) A connectome and analysis of the adult *Drosophila* central brain. *eLife* 9:e57443. doi:10.7554/eLife.57443
 - Takemura S et al. (2024) A connectome of the male *Drosophila* ventral nerve cord. *eLife* 13:RP97769. doi:10.7554/eLife.97769.1 — reviewed preprint
 - Nern A et al. (2025) Connectome-driven neural inventory of a complete visual system. *Nature* 641:1225–1237. doi:10.1038/s41586-025-08746-0
+- Berg S et al. (2025) Sexual dimorphism in the complete connectome of the *Drosophila* male central nervous system. bioRxiv 2025.10.09.680999. doi:10.1101/2025.10.09.680999 — preprint
+- Bates AS et al. (2026) Distributed control circuits across a brain-and-cord connectome. *Nature*. doi:10.1038/s41586-026-10735-w
 - Ohyama T et al. (2015) A multilevel multimodal circuit enhances action selection in *Drosophila*. *Nature* 520:633–639. doi:10.1038/nature14297
 - Winding M et al. (2023) The connectome of an insect brain. *Science* 379(6636):eadd9330. doi:10.1126/science.add9330
 - Dorkenwald S et al. (2024) Neuronal wiring diagram of an adult brain. *Nature* 634:124–138. doi:10.1038/s41586-024-07558-y

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -23,8 +23,9 @@ all.
 *Drosophila melanogaster*: the fruit fly Thomas Hunt Morgan's group bred in the Fly Room
 at Columbia, and the animal almost every technique described below was built around.
 
-The more precise answer is that most of the connectomic data on VFB came from one
-laboratory cross, repeated for five different specimens.
+The more precise answer is that the connectomic data on VFB came from one laboratory
+cross, repeated — and in two cases, from a single individual whose brain and optic lobe
+were reconstructed separately.
 
 ## The same cross, every time
 
@@ -309,13 +310,42 @@ segmentation with human proofreading
 [Dorkenwald et al., 2022](https://doi.org/10.1038/s41592-021-01330-0)). See
 [EM reconstruction](/docs/concepts/em-reconstruction/).
 
-**Names.** None of the above is comparable across studies without agreed terms. VFB's
-data is classified with the Drosophila Anatomy Ontology, built on the systematic
-nomenclatures for the brain ([Ito et al., 2014](https://doi.org/10.1016/j.neuron.2013.12.017))
-and the ventral nerve cord ([Court et al., 2020](https://doi.org/10.1016/j.neuron.2020.08.005)),
-using the strategy described in
-[Osumi-Sutherland et al. (2012)](https://doi.org/10.1093/bioinformatics/bts113). See
+**Names.** None of the above is comparable across studies without agreed terms. VFB is
+built around the **Drosophila Anatomy Ontology**
+([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)), a manually curated,
+queryable classification expressed in OWL, using a schema that records a neuron's
+location, connectivity, lineage and function and supports basic spatial reasoning
+([Osumi-Sutherland et al., 2012](https://doi.org/10.1093/bioinformatics/bts113)). Built
+from over 1,000 curated papers, the DAO represents some 13,000 neuroanatomical structures
+and cell types, including over 9,800 terms for neuron types — of which more than 3,800 are
+predicted from connectomics data
+([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)). The region names
+themselves come from the community nomenclatures for the brain
+([Ito et al., 2014](https://doi.org/10.1016/j.neuron.2013.12.017)) and the ventral nerve
+cord ([Court et al., 2020](https://doi.org/10.1016/j.neuron.2020.08.005)). See
 [Cell types](/docs/concepts/cell_types/).
+
+The ontology has its own inclusion rule, and it is the reason a VFB term can be treated as
+evidence rather than opinion: the DAO includes a named class "only ... where there is good
+scientific evidence for the presence in wild-type animals of structures with the properties
+described", with links to the literature that supports it, and classes added in error have
+been obsoleted. Terminology varies between groups and over time, so terms carry multiple
+synonyms wherever possible, "linked to papers where they originate or that provide
+examples of their usage", with disambiguation comments where usage conflicts — which is
+why searching VFB for an old or lab-specific name still finds the right structure. Much of
+the classification is not hand-asserted but inferred: relations such as `part_of` and
+`capable_of`, combined with Gene Ontology process terms and property chains, let a
+reasoner derive the hierarchy and let disjointness axioms catch contradictions
+([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)).
+
+VFB itself began as an interface onto that idea. The original paper describes two aims —
+"a hub for neuro-anatomical data integration" and "an easily accessible and usable tool to
+disseminate community agreed anatomical standards" — built over the BrainName reference
+stack for the adult brain, with queries answered by an OWL2 reasoner rather than by
+lookup, so that asking for neurons with presynaptic terminals in one region and
+postsynaptic terminals in another was a question the ontology could answer
+([Milyaev et al., 2012](https://doi.org/10.1093/bioinformatics/btr677)). The templates,
+datasets and connectomes described on this page were added to that frame.
 
 ## What to keep in mind when you use VFB
 
@@ -410,4 +440,5 @@ using the strategy described in
 **Virtual Fly Brain**
 
 - Milyaev N et al. (2012) The Virtual Fly Brain browser and query interface. *Bioinformatics* 28:411–415. doi:10.1093/bioinformatics/btr677
+- Costa M, Reeve S, Grumbling G, Osumi-Sutherland D (2013) The *Drosophila* anatomy ontology. *J Biomed Semantics* 4:32. doi:10.1186/2041-1480-4-32
 - Court R et al. (2023) Virtual Fly Brain — an interactive atlas of the *Drosophila* nervous system. *Front Physiol* 14:1076533. doi:10.3389/fphys.2023.1076533

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -122,10 +122,13 @@ embryo, and in doing so demonstrated that a developmental programme could be enu
 gene by gene ([Nüsslein-Volhard and Wieschaus, 1980](https://doi.org/10.1038/287795a0)).
 The three shared the 1995 Nobel Prize in Physiology or Medicine.
 
-**2000: the genome.** The *Drosophila* sequence was the largest genome assembled by
-whole-genome shotgun sequencing at the time, and served as the proof of principle for the
-human assembly that followed ([Adams et al., 2000](https://doi.org/10.1126/science.287.5461.2185);
-[Rubin and Lewis, 2000](https://doi.org/10.1126/science.287.5461.2216)).
+**2000: the genome.** The roughly 120-megabase euchromatic portion of the genome was
+sequenced by a whole-genome shotgun strategy, and reported to encode about 13,600 genes
+([Adams et al., 2000](https://doi.org/10.1126/science.287.5461.2185)). Rubin and Lewis,
+reviewing the nine decades behind it, note that genetic and physical mapping, whole-genome
+mutational screens, and functional alteration of the genome by gene transfer were all
+pioneered in metazoans using this fly
+([Rubin and Lewis, 2000](https://doi.org/10.1126/science.287.5461.2216)).
 
 What accumulated alongside those results is the part that matters for VFB: balancer
 chromosomes that hold a mutation stable over generations, isogenic wild-type stocks,
@@ -150,13 +153,16 @@ scored by eye — which is why so many classical markers are visible ones such a
 colour, wing shape and bristle morphology.
 
 A typical light microscopy dataset on VFB is the end of a chain of crosses. Virgin females
-of one genotype are collected — they must be picked within hours of eclosion, before they
-mate — and crossed to males of another. Where a genotype cannot be made homozygous,
-**balancer chromosomes** hold it stable: multiply-inverted chromosomes that suppress
-recombination and carry a dominant visible marker and a recessive lethal, so the stock
-maintains itself and the right progeny can be picked out by their markers. This machinery,
-and the isogenic wild-type stocks it accompanies, is the classical genetics described in
-[Kaufman (2017)](https://doi.org/10.1534/genetics.117.199950).
+of one genotype are collected — they must be picked before they mate — and crossed to
+males of another. Where a genotype cannot be made homozygous, **balancer chromosomes**
+hold it stable. A balancer carries "one or more inverted sequences relative to a normal
+chromosome to prevent the recovery of exchange events", so the arrangement it is paired
+with is passed on intact; to be useful it should also carry "a recessive lethal mutation
+not related to the lesion being balanced", which stops the balancer going homozygous, and
+"a dominant visible mutation so that it can be easily followed in crossing schemes"
+([Kaufman, 2017](https://doi.org/10.1534/genetics.117.199950)). That is what lets a lethal
+mutation, or a chromosome carrying a particular set of transgenes, sit in a stock
+indefinitely and still be identified by eye in the next generation.
 
 The animal is then dissected — a CNS is taken out under saline in a few minutes — fixed,
 immunostained (typically an antibody against the tag on the reporter, plus a neuropil
@@ -211,8 +217,11 @@ regulatory element the transposon landed near, turning random insertion into a s
 expression patterns ([O'Kane and Gehring, 1987](https://doi.org/10.1073/pnas.84.24.9123)).
 
 **Separating "where" from "what".** The decisive step was Brand and Perrimon's
-adaptation of yeast GAL4: one line carries GAL4 under a genomic fragment, another carries
-the effector under UAS, and the cross determines what happens where
+adaptation of yeast GAL4. In their system the GAL4 gene "is inserted randomly into the
+*Drosophila* genome to drive GAL4 expression from one of a diverse array of genomic
+enhancers", and a separate transgene carrying GAL4 binding sites in its promoter is
+activated wherever GAL4 is present — so one line supplies the pattern, another the
+payload, and the cross decides what happens where
 ([Brand and Perrimon, 1993](https://doi.org/10.1242/dev.118.2.401)). Every driver line on
 VFB is downstream of this. See
 [Binary expression systems](/docs/concepts/binary-expression/).

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -56,11 +56,37 @@ connectome is a six-hour-old first instar. A cell type present in one is not gua
 to be present, or to have the same partners, in another. VFB keeps sex and stage on the
 dataset record for exactly this reason.
 
-The choice of that particular cross is not arbitrary. Canton-S is a long-standing
-wild-type laboratory strain; *w<sup>1118</sup>* is a white-eyed mutant used as a
-standard genetic background. Crossing two isogenic stocks gives an F1 that is
-genetically uniform between individuals, so the specimen is reproducible in a way a
-wild-caught fly would not be. Isogenic backgrounds are also what the
+### What that genotype actually is
+
+Both halves of the cross have FlyBase records, and reading them turns the genotype into a
+short history of the field.
+
+**Canton-S** ([FBsn0000274](https://flybase.org/reports/FBsn0000274)) is a wild-type
+strain derived from a natural population collected at Canton, Ohio. FlyBase records that
+it was selected by **C. Bridges**, who established that its salivary chromosomes were
+normal — the same Bridges whose salivary gland maps are cited below. It is still
+distributed, by Bloomington (64349) and Kyoto (105666). The report also notes a recessive
+for multiple thoracic and scutellar bristles that surfaces sporadically in strains partly
+derived from it, which is a useful reminder that "wild type" names a stock, not an
+absence of variation.
+
+***w<sup>1118</sup>*** ([FBal0018186](https://flybase.org/reports/FBal0018186)) is a
+spontaneous partial deletion of *white*, attributed to R. Levis — a loss-of-function
+allele of the very gene Morgan reported in 1910. It is the standard white-eyed background
+for transgenics, and not by accident: P-element and φC31 constructs are typically marked
+with **mini-*white*** — the P{GawB} enhancer-trap construct that produced many early GAL4
+lines carries *w<sup>+mW.hs</sup>*
+([FBtp0000352](https://flybase.org/reports/FBtp0000352)) — and a *white*<sup>+</sup> marker
+can only be scored in a *white*-mutant animal. The first mutant Morgan ever described is
+still the thing that tells you a transgene went in.
+
+You can see this in VFB itself: driver line records carry genotypes such as
+`w[1118];P{w[+mW.hs]=GawB}c135`, with the mutant background and the mini-*white* marker
+both written out, and each links to its FlyBase report.
+
+Crossing two isogenic stocks gives an F1 that is genetically uniform between individuals,
+so the specimen is reproducible in a way a wild-caught fly would not be. Isogenic
+backgrounds are also what the
 [*Drosophila* Genetic Reference Panel](https://doi.org/10.1038/nature10811) exploits at
 population scale.
 
@@ -101,7 +127,10 @@ What accumulated alongside those results is the part that matters for VFB: balan
 chromosomes that hold a mutation stable over generations, isogenic wild-type stocks,
 public stock centres that will post you a fly, and a curated genetic literature in
 [FlyBase](https://flybase.org)
-([Öztürk-Çolak et al., 2024](https://doi.org/10.1093/genetics/iyad211)). For the history
+([Öztürk-Çolak et al., 2024](https://doi.org/10.1093/genetics/iyad211)) — which is why the
+strains named above can be looked up a century later, and why a driver line in a 2012
+paper is still orderable today. FlyBase release FB2026_02 is current at the time of
+writing. For the history
 of the classical toolkit,
 [Kaufman (2017)](https://doi.org/10.1534/genetics.117.199950) is the readable account;
 [Hales et al. (2015)](https://doi.org/10.1534/genetics.115.183392) is a primer on the
@@ -277,6 +306,12 @@ using the strategy described in
 - Mackay TFC et al. (2012) The *Drosophila melanogaster* Genetic Reference Panel. *Nature* 482:173–178. doi:10.1038/nature10811
 - Öztürk-Çolak A et al. (2024) FlyBase: updates to the *Drosophila* genes and genomes database. *Genetics* 227:iyad211. doi:10.1093/genetics/iyad211
 - Zheng S et al. (2024) An introductory guide to using Bloomington Drosophila Stock Center and FlyBase for aging research. *Cells* 13:1192. doi:10.3390/cells13141192
+
+**FlyBase records for the strains above** (release FB2026_02)
+
+- Canton-S — strain report [FBsn0000274](https://flybase.org/reports/FBsn0000274)
+- *w<sup>1118</sup>* — allele report [FBal0018186](https://flybase.org/reports/FBal0018186)
+- P{GawB}, carrying the mini-*white* marker *w<sup>+mW.hs</sup>* — construct report [FBtp0000352](https://flybase.org/reports/FBtp0000352)
 
 **Specimens behind the EM volumes**
 

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -1,0 +1,331 @@
+---
+title: "Which fly is this?"
+linkTitle: "Which fly?"
+weight: 15
+date: 2026-08-18
+tags: [Drosophila, history, genetics, techniques, provenance]
+categories: ["overview","background"]
+description: >
+  The animal behind the data on Virtual Fly Brain — the species, the strains, the
+  individual flies that were imaged, and the century of genetics that makes any of it
+  interpretable.
+---
+
+Every image, neuron and connection on Virtual Fly Brain came out of a real animal. This
+page is about which animal: the species, the genetic background, and — for the electron
+microscopy volumes — the specific individual fly that was dissected on a specific
+morning. It also covers how a hundred years of *Drosophila* genetics produced the
+reagents and reference frames that let data from different laboratories be compared at
+all.
+
+## The short answer
+
+*Drosophila melanogaster*: the fruit fly Thomas Hunt Morgan's group bred in the Fly Room
+at Columbia, and the animal almost every technique described below was built around.
+
+The more precise answer is that most of the connectomic data on VFB came from one
+laboratory cross, repeated for five different specimens.
+
+## The same cross, five times
+
+The flagship EM volumes were not taken from a wild population or from a lab's general
+stock. Four of the five below are the offspring of a cross between the wild-type
+**Canton-S strain G1** and **w<sup>1118</sup>**, both isogenised, reared on a 12-hour
+day/night cycle and dissected 1.5 hours after lights-on.
+
+| Volume in VFB | Stage and sex | Age | Genotype | Source |
+|---|---|---|---|---|
+| FAFB / FlyWire | Adult female | 7 days post-eclosion | [iso] *w<sup>1118</sup>* × [iso] Canton-S G1 | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
+| Hemibrain | Adult female | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
+| MANC (male VNC) | Adult male | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
+| Optic lobe | Adult male | 5 days post-eclosion | Canton-S G1 × *w<sup>1118</sup>* | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
+| L1 larval CNS | First-instar female larva | 6 hours after hatching | Canton-S G1 [iso] × *w<sup>1118</sup>* [iso] 5905 | [Winding et al. (2023)](https://doi.org/10.1126/science.add9330), volume from [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
+
+Two things follow from this table, and both matter when you read a result off VFB.
+
+**Each connectome is one animal.** A connectome is not a population average; it is a
+census of the individual that was sectioned. Where two connectomes disagree about a
+neuron's partners, the difference may be reconstruction, or it may be that flies differ.
+The [neuron counts](/docs/concepts/neuron-counts/) page works through what this does to
+any number you might want to quote, including the fact that FlyWire and the hemibrain
+partly re-reconstruct the same tissue.
+
+**Sex and stage are properties of the dataset, not of "the fly".** The adult brain
+connectomes are female; the VNC and optic lobe connectomes are male; the larval
+connectome is a six-hour-old first instar. A cell type present in one is not guaranteed
+to be present, or to have the same partners, in another. VFB keeps sex and stage on the
+dataset record for exactly this reason.
+
+The choice of that particular cross is not arbitrary. Canton-S is a long-standing
+wild-type laboratory strain; *w<sup>1118</sup>* is a white-eyed mutant used as a
+standard genetic background. Crossing two isogenic stocks gives an F1 that is
+genetically uniform between individuals, so the specimen is reproducible in a way a
+wild-caught fly would not be. Isogenic backgrounds are also what the
+[*Drosophila* Genetic Reference Panel](https://doi.org/10.1038/nature10811) exploits at
+population scale.
+
+Light microscopy data is more varied — expression patterns are collected in whatever
+background the driver line lives in — but the same principle applies: an image is of one
+animal, and the [templates](/docs/data/templates/) exist to make many such animals
+comparable.
+
+## Why a fly at all
+
+The fly's advantage is not that it is simple. It is that a century of work has already
+been done on it, and the results were kept.
+
+**1910–1935: the chromosome theory.** Morgan reported a white-eyed male and showed the
+trait was sex-linked ([Morgan, 1910](https://doi.org/10.1126/science.32.812.120)). His
+student Alfred Sturtevant used recombination frequencies between six sex-linked factors
+to place them in linear order — the first genetic map
+([Sturtevant, 1913](https://doi.org/10.1002/jez.1400140104)). Hermann Muller showed X-rays
+induce mutations, turning mutation into something a laboratory could produce on demand
+([Muller, 1927](https://doi.org/10.1126/science.66.1699.84)). Calvin Bridges' salivary
+gland chromosome maps gave a physical coordinate system to put the genetic one against
+([Bridges, 1935](https://doi.org/10.1093/oxfordjournals.jhered.a104022)).
+
+**1978–1980: genetics as a way of finding genes by function.** Ed Lewis worked out the
+bithorax complex and its role in segment identity
+([Lewis, 1978](https://doi.org/10.1038/276565a0)). Christiane Nüsslein-Volhard and Eric
+Wieschaus ran a saturation screen for mutations affecting the segmental pattern of the
+embryo, and in doing so demonstrated that a developmental programme could be enumerated
+gene by gene ([Nüsslein-Volhard and Wieschaus, 1980](https://doi.org/10.1038/287795a0)).
+The three shared the 1995 Nobel Prize in Physiology or Medicine.
+
+**2000: the genome.** The *Drosophila* sequence was the largest genome assembled by
+whole-genome shotgun sequencing at the time, and served as the proof of principle for the
+human assembly that followed ([Adams et al., 2000](https://doi.org/10.1126/science.287.5461.2185);
+[Rubin and Lewis, 2000](https://doi.org/10.1126/science.287.5461.2216)).
+
+What accumulated alongside those results is the part that matters for VFB: balancer
+chromosomes that hold a mutation stable over generations, isogenic wild-type stocks,
+public stock centres that will post you a fly, and a curated genetic literature in
+[FlyBase](https://flybase.org)
+([Öztürk-Çolak et al., 2024](https://doi.org/10.1093/genetics/iyad211)). For the history
+of the classical toolkit,
+[Kaufman (2017)](https://doi.org/10.1534/genetics.117.199950) is the readable account;
+[Hales et al. (2015)](https://doi.org/10.1534/genetics.115.183392) is a primer on the
+modern system; [Bellen et al. (2010)](https://doi.org/10.1038/nrn2839) covers what fly
+neuroscience gave vertebrate neuroscience.
+
+## What making one of these datasets actually involves
+
+The reason the fly scales is that the bench work is cheap in everything except patience.
+A generation takes about ten days at 25 °C. Flies are reared in vials on a cornmeal or
+molasses medium, anaesthetised on CO<sub>2</sub> to be sorted under a dissecting scope, and
+scored by eye — which is why so many classical markers are visible ones such as eye
+colour, wing shape and bristle morphology.
+
+A typical light microscopy dataset on VFB is the end of a chain of crosses. Virgin females
+of one genotype are collected — they must be picked within hours of eclosion, before they
+mate — and crossed to males of another. Where a genotype cannot be made homozygous,
+**balancer chromosomes** hold it stable: multiply-inverted chromosomes that suppress
+recombination and carry a dominant visible marker and a recessive lethal, so the stock
+maintains itself and the right progeny can be picked out by their markers. This machinery,
+and the isogenic wild-type stocks it accompanies, is the classical genetics described in
+[Kaufman (2017)](https://doi.org/10.1534/genetics.117.199950).
+
+The animal is then dissected — a CNS is taken out under saline in a few minutes — fixed,
+immunostained (typically an antibody against the tag on the reporter, plus a neuropil
+counterstain such as nc82), mounted, and imaged on a confocal microscope. The stack is
+[registered](/docs/concepts/registration/) to a template, and only then does it become
+something that can be compared with anyone else's data.
+
+The EM datasets follow the same start and then diverge sharply in cost: the same rearing
+and dissection, then months of sectioning and imaging and, historically, years of tracing.
+See [EM reconstruction](/docs/concepts/em-reconstruction/).
+
+What makes any of this reusable is that the reagents are public. Driver lines, balancers
+and effector stocks are distributed by stock centres — Bloomington, the VDRC, Kyoto — and
+catalogued in FlyBase, so a line named in a paper can be ordered and re-used
+([Zheng et al., 2024](https://doi.org/10.3390/cells13141192)). VFB links each transgene
+record back to FlyBase and to the stock, which is usually what a user actually wants: not
+the image, but the reagent that produced it.
+
+## The techniques the data rests on
+
+VFB is an integrator: nearly everything in it was generated by someone else, using one
+of a small number of methods. Each has a page.
+
+| To get this | You need this | Page |
+|---|---|---|
+| Any transgene expressed in chosen cells | A binary expression system — GAL4/UAS, LexA/LexAop, Q | [Binary expression systems](/docs/concepts/binary-expression/) |
+| A pattern narrow enough to be one cell type | Split drivers — two hemidrivers intersecting | [Split driver expression](/docs/concepts/splits/) |
+| One neuron's shape out of a whole pattern | Stochastic labelling — FLP-out, MARCM, MCFO | [Stochastic labelling](/docs/concepts/stochastic-labelling/) |
+| Images from different animals in one space | Registration to a standard template | [Registration](/docs/concepts/registration/), [Templates](/docs/data/templates/) |
+| Comparison between two template spaces | Bridging transforms | [Bridging registrations](/docs/concepts/bridging/) |
+| Synapse-level morphology and wiring | Volume EM, segmentation and proofreading | [EM reconstruction](/docs/concepts/em-reconstruction/), [EM data](/docs/data/em/) |
+| A wiring diagram you can query | Connectivity derived from those reconstructions | [Connectivity](/docs/data/connectivity/) |
+| Which cells express which genes | Single-cell and single-nucleus RNA sequencing | [scRNAseq data](/docs/data/scrnaseq/) |
+| "Is this the same neuron as that one?" | Morphological similarity scoring | [NBLAST](/docs/concepts/nblast/) |
+| A name that means the same thing across studies | An anatomy ontology | [Cell types](/docs/concepts/cell_types/) |
+
+### The reagent lineage, in one paragraph each
+
+**Getting DNA into the germline.** Rubin and Spradling showed that P-element vectors
+could carry DNA into the *Drosophila* germline
+([Rubin and Spradling, 1982](https://doi.org/10.1126/science.6289436)). Insertion site was
+uncontrolled, which mattered: where a construct lands affects how it is expressed. The
+φC31 integrase system fixed that by allowing insertion at a defined attP landing site,
+so two constructs can be compared without confounding position effects
+([Groth et al., 2004](https://doi.org/10.1534/genetics.166.4.1775)). Large insertion
+resources followed ([Bellen et al., 2004](https://doi.org/10.1534/genetics.104.026427);
+[Venken et al., 2011](https://doi.org/10.1038/nmeth.1662)), and CRISPR/Cas9 made targeted
+editing routine ([Gratz et al., 2013](https://doi.org/10.1534/genetics.113.152710)).
+
+**Finding out where a gene is expressed.** Enhancer traps put a reporter next to whatever
+regulatory element the transposon landed near, turning random insertion into a screen for
+expression patterns ([O'Kane and Gehring, 1987](https://doi.org/10.1073/pnas.84.24.9123)).
+
+**Separating "where" from "what".** The decisive step was Brand and Perrimon's
+adaptation of yeast GAL4: one line carries GAL4 under a genomic fragment, another carries
+the effector under UAS, and the cross determines what happens where
+([Brand and Perrimon, 1993](https://doi.org/10.1242/dev.118.2.401)). Every driver line on
+VFB is downstream of this. See
+[Binary expression systems](/docs/concepts/binary-expression/).
+
+**Seeing anything at all.** GFP made a live, genetically encoded reporter possible
+([Chalfie et al., 1994](https://doi.org/10.1126/science.8303295)), which is what turns a
+driver line into an image.
+
+**Industrial-scale driver collections.** Janelia built thousands of GAL4 lines from
+defined genomic fragments at a fixed landing site and imaged the CNS of each
+([Pfeiffer et al., 2008](https://doi.org/10.1073/pnas.0803697105);
+[Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011) — 7,000 lines, image
+data published for 6,650). The Vienna Tiles collection characterised 7,705 enhancer
+candidates ([Kvon et al., 2014](https://doi.org/10.1038/nature13395)). These two
+collections are the backbone of the light microscopy on VFB.
+
+**Making a pattern specific enough to be useful.** Even a good GAL4 line usually labels
+more than one cell type. Splitting a transcription factor into an activation domain and a
+DNA-binding domain, each under a different enhancer, restricts expression to the
+intersection ([Luan et al., 2006](https://doi.org/10.1016/j.neuron.2006.08.028);
+[Pfeiffer et al., 2010](https://doi.org/10.1534/genetics.110.119917);
+[Dionne et al., 2018](https://doi.org/10.1534/genetics.118.300682)). The Janelia
+split-GAL4 resource is the large published application
+([Meissner et al., 2025](https://doi.org/10.7554/eLife.98405)). See
+[Split driver expression](/docs/concepts/splits/).
+
+**Getting down to one neuron.** Site-specific recombination
+([Golic and Lindquist, 1989](https://doi.org/10.1016/0092-8674(89)90033-0)) underpins
+MARCM ([Lee and Luo, 1999](https://doi.org/10.1016/S0896-6273(00)80701-1)) and MultiColor
+FlpOut ([Nern et al., 2015](https://doi.org/10.1073/pnas.1506763112)). These produce the
+single-neuron light microscopy images that can be compared against EM reconstructions.
+See [Stochastic labelling](/docs/concepts/stochastic-labelling/).
+
+**Putting everything in one coordinate frame.** Nonrigid registration of confocal stacks
+onto a common template ([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506);
+[Jefferis et al., 2007](https://doi.org/10.1016/j.cell.2007.01.040)) is what makes cross-study
+comparison possible at all. The current standard, JRC2018, was built by groupwise
+registration — the unisex brain template from 62 individuals, 124 images counting
+left–right flips ([Bogovic et al., 2020](https://doi.org/10.1371/journal.pone.0236495)).
+See [Registration](/docs/concepts/registration/) and [Templates](/docs/data/templates/).
+
+**Wiring diagrams.** Volume EM at synaptic resolution, then reconstruction: serial-section
+TEM for FAFB and the larval CNS
+([Bock et al., 2011](https://doi.org/10.1038/nature09802);
+[Zheng et al., 2018](https://doi.org/10.1016/j.cell.2018.06.019)), FIB-SEM for the
+hemibrain, MANC and the optic lobe
+([Xu et al., 2017](https://doi.org/10.7554/eLife.25916);
+[Hayworth et al., 2015](https://doi.org/10.1038/nmeth.3292)). Reconstruction moved from
+manual tracing in CATMAID
+([Saalfeld et al., 2009](https://doi.org/10.1093/bioinformatics/btp266);
+[Schneider-Mizell et al., 2016](https://doi.org/10.7554/eLife.12059)) to automated
+segmentation with human proofreading
+([Januszewski et al., 2018](https://doi.org/10.1038/s41592-018-0049-4);
+[Dorkenwald et al., 2022](https://doi.org/10.1038/s41592-021-01330-0)). See
+[EM reconstruction](/docs/concepts/em-reconstruction/).
+
+**Names.** None of the above is comparable across studies without agreed terms. VFB's
+data is classified with the Drosophila Anatomy Ontology, built on the systematic
+nomenclatures for the brain ([Ito et al., 2014](https://doi.org/10.1016/j.neuron.2013.12.017))
+and the ventral nerve cord ([Court et al., 2020](https://doi.org/10.1016/j.neuron.2020.08.005)),
+using the strategy described in
+[Osumi-Sutherland et al. (2012)](https://doi.org/10.1093/bioinformatics/bts113). See
+[Cell types](/docs/concepts/cell_types/).
+
+## What to keep in mind when you use VFB
+
+- **A cell type is an abstraction over individuals.** When VFB says two images are the
+  same cell type, that is a curatorial or computational judgement about neurons in
+  different animals, not an observation of the same cell twice.
+- **Sex, stage and background travel with the dataset.** Check them before comparing.
+  The adult connectomes are not all the same sex, and the larval one is a different
+  animal entirely.
+- **Registration is lossy.** A neuron in template space is an estimate of where it was in
+  its own brain. [Bridging](/docs/concepts/bridging/) between templates compounds this.
+- **Predictions are labelled as such.** Neurotransmitter assignments in the connectomes
+  are predictions from EM image features, not measurements
+  ([Eckstein et al., 2024](https://doi.org/10.1016/j.cell.2024.03.016)); see
+  [confidence values](/docs/concepts/confidence-value/).
+
+## Sources
+
+**History and background**
+
+- Morgan TH (1910) Sex limited inheritance in *Drosophila*. *Science* 32(812):120–122. doi:10.1126/science.32.812.120
+- Sturtevant AH (1913) The linear arrangement of six sex-linked factors in *Drosophila*, as shown by their mode of association. *J Exp Zool* 14:43–59. doi:10.1002/jez.1400140104
+- Muller HJ (1927) Artificial transmutation of the gene. *Science* 66(1699):84–87. doi:10.1126/science.66.1699.84
+- Bridges CB (1935) Salivary chromosome maps. *J Hered* 26:60–64. doi:10.1093/oxfordjournals.jhered.a104022
+- Lewis EB (1978) A gene complex controlling segmentation in *Drosophila*. *Nature* 276:565–570. doi:10.1038/276565a0
+- Nüsslein-Volhard C, Wieschaus E (1980) Mutations affecting segment number and polarity in *Drosophila*. *Nature* 287:795–801. doi:10.1038/287795a0
+- Adams MD et al. (2000) The genome sequence of *Drosophila melanogaster*. *Science* 287(5461):2185–2195. doi:10.1126/science.287.5461.2185
+- Rubin GM, Lewis EB (2000) A brief history of *Drosophila*'s contributions to genome research. *Science* 287(5461):2216–2218. doi:10.1126/science.287.5461.2216
+- Bellen HJ, Tong C, Tsuda H (2010) 100 years of *Drosophila* research and its impact on vertebrate neuroscience. *Nat Rev Neurosci* 11:514–522. doi:10.1038/nrn2839
+- Hales KG et al. (2015) Genetics on the fly: a primer on the *Drosophila* model system. *Genetics* 201:815–842. doi:10.1534/genetics.115.183392
+- Kaufman TC (2017) A short history and description of *Drosophila melanogaster* classical genetics. *Genetics* 206:665–689. doi:10.1534/genetics.117.199950
+- Mackay TFC et al. (2012) The *Drosophila melanogaster* Genetic Reference Panel. *Nature* 482:173–178. doi:10.1038/nature10811
+- Öztürk-Çolak A et al. (2024) FlyBase: updates to the *Drosophila* genes and genomes database. *Genetics* 227:iyad211. doi:10.1093/genetics/iyad211
+- Zheng S et al. (2024) An introductory guide to using Bloomington Drosophila Stock Center and FlyBase for aging research. *Cells* 13:1192. doi:10.3390/cells13141192
+
+**Specimens behind the EM volumes**
+
+- Zheng Z et al. (2018) A complete electron microscopy volume of the brain of adult *Drosophila melanogaster*. *Cell* 174(3):730–743. doi:10.1016/j.cell.2018.06.019
+- Scheffer LK et al. (2020) A connectome and analysis of the adult *Drosophila* central brain. *eLife* 9:e57443. doi:10.7554/eLife.57443
+- Takemura S et al. (2024) A connectome of the male *Drosophila* ventral nerve cord. *eLife* 13:RP97769. doi:10.7554/eLife.97769.1 — reviewed preprint
+- Nern A et al. (2025) Connectome-driven neural inventory of a complete visual system. *Nature* 641:1225–1237. doi:10.1038/s41586-025-08746-0
+- Ohyama T et al. (2015) A multilevel multimodal circuit enhances action selection in *Drosophila*. *Nature* 520:633–639. doi:10.1038/nature14297
+- Winding M et al. (2023) The connectome of an insect brain. *Science* 379(6636):eadd9330. doi:10.1126/science.add9330
+- Dorkenwald S et al. (2024) Neuronal wiring diagram of an adult brain. *Nature* 634:124–138. doi:10.1038/s41586-024-07558-y
+- Schlegel P et al. (2024) Whole-brain annotation and multi-connectome cell typing of *Drosophila*. *Nature* 634:139–152. doi:10.1038/s41586-024-07686-5
+
+**Techniques**
+
+- Rubin GM, Spradling AC (1982) Genetic transformation of *Drosophila* with transposable element vectors. *Science* 218:348–353. doi:10.1126/science.6289436
+- O'Kane CJ, Gehring WJ (1987) Detection in situ of genomic regulatory elements in *Drosophila*. *PNAS* 84:9123–9127. doi:10.1073/pnas.84.24.9123
+- Golic KG, Lindquist S (1989) The FLP recombinase of yeast catalyzes site-specific recombination in the *Drosophila* genome. *Cell* 59:499–509. doi:10.1016/0092-8674(89)90033-0
+- Brand AH, Perrimon N (1993) Targeted gene expression as a means of altering cell fates and generating dominant phenotypes. *Development* 118:401–415. doi:10.1242/dev.118.2.401
+- Chalfie M et al. (1994) Green fluorescent protein as a marker for gene expression. *Science* 263:802–805. doi:10.1126/science.8303295
+- Lee T, Luo L (1999) Mosaic analysis with a repressible cell marker for studies of gene function in neuronal morphogenesis. *Neuron* 22:451–461. doi:10.1016/S0896-6273(00)80701-1
+- Rohlfing T, Maurer CR (2003) Nonrigid image registration in shared-memory multiprocessor environments. *IEEE Trans Inf Technol Biomed* 7:16–25. doi:10.1109/TITB.2003.808506
+- Groth AC et al. (2004) Construction of transgenic *Drosophila* by using the site-specific integrase from phage φC31. *Genetics* 166:1775–1782. doi:10.1534/genetics.166.4.1775
+- Bellen HJ et al. (2004) The BDGP gene disruption project. *Genetics* 167:761–781. doi:10.1534/genetics.104.026427
+- Luan H et al. (2006) Refined spatial manipulation of neuronal function by combinatorial restriction of transgene expression. *Neuron* 52:425–436. doi:10.1016/j.neuron.2006.08.028
+- Jefferis GSXE et al. (2007) Comprehensive maps of *Drosophila* higher olfactory centers. *Cell* 128:1187–1203. doi:10.1016/j.cell.2007.01.040
+- Pfeiffer BD et al. (2008) Tools for neuroanatomy and neurogenetics in *Drosophila*. *PNAS* 105:9715–9720. doi:10.1073/pnas.0803697105
+- Saalfeld S et al. (2009) CATMAID: collaborative annotation toolkit for massive amounts of image data. *Bioinformatics* 25:1984–1986. doi:10.1093/bioinformatics/btp266
+- Pfeiffer BD et al. (2010) Refinement of tools for targeted gene expression in *Drosophila*. *Genetics* 186:735–755. doi:10.1534/genetics.110.119917
+- Bock DD et al. (2011) Network anatomy and in vivo physiology of visual cortical neurons. *Nature* 471:177–182. doi:10.1038/nature09802
+- Venken KJT et al. (2011) MiMIC: a highly versatile transposon insertion resource for engineering *Drosophila melanogaster* genes. *Nat Methods* 8:737–743. doi:10.1038/nmeth.1662
+- Jenett A et al. (2012) A GAL4-driver line resource for *Drosophila* neurobiology. *Cell Rep* 2:991–1001. doi:10.1016/j.celrep.2012.09.011
+- Osumi-Sutherland D et al. (2012) A strategy for building neuroanatomy ontologies. *Bioinformatics* 28:1262–1269. doi:10.1093/bioinformatics/bts113
+- Gratz SJ et al. (2013) Genome engineering of *Drosophila* with the CRISPR RNA-guided Cas9 nuclease. *Genetics* 194:1029–1035. doi:10.1534/genetics.113.152710
+- Ito K et al. (2014) A systematic nomenclature for the insect brain. *Neuron* 81:755–765. doi:10.1016/j.neuron.2013.12.017
+- Kvon EZ et al. (2014) Genome-scale functional characterization of *Drosophila* developmental enhancers in vivo. *Nature* 512:91–95. doi:10.1038/nature13395
+- Hayworth KJ et al. (2015) Ultrastructurally smooth thick partitioning and volume stitching for large-scale connectomics. *Nat Methods* 12:319–322. doi:10.1038/nmeth.3292
+- Nern A, Pfeiffer BD, Rubin GM (2015) Optimized tools for multicolor stochastic labeling reveal diverse stereotyped cell arrangements in the fly visual system. *PNAS* 112:E2967–E2976. doi:10.1073/pnas.1506763112
+- Costa M et al. (2016) NBLAST: rapid, sensitive comparison of neuronal structure and construction of neuron family databases. *Neuron* 91:293–311. doi:10.1016/j.neuron.2016.06.012
+- Schneider-Mizell CM et al. (2016) Quantitative neuroanatomy for connectomics in *Drosophila*. *eLife* 5:e12059. doi:10.7554/eLife.12059
+- Xu CS et al. (2017) Enhanced FIB-SEM systems for large-volume 3D imaging. *eLife* 6:e25916. doi:10.7554/eLife.25916
+- Dionne H et al. (2018) Genetic reagents for making split-GAL4 lines in *Drosophila*. *Genetics* 209:31–35. doi:10.1534/genetics.118.300682
+- Januszewski M et al. (2018) High-precision automated reconstruction of neurons with flood-filling networks. *Nat Methods* 15:605–610. doi:10.1038/s41592-018-0049-4
+- Bogovic JA et al. (2020) An unbiased template of the *Drosophila* brain and ventral nerve cord. *PLoS ONE* 15(12):e0236495. doi:10.1371/journal.pone.0236495
+- Court R et al. (2020) A systematic nomenclature for the *Drosophila* ventral nerve cord. *Neuron* 107:1071–1079. doi:10.1016/j.neuron.2020.08.005
+- Dorkenwald S et al. (2022) FlyWire: online community for whole-brain connectomics. *Nat Methods* 19:119–128. doi:10.1038/s41592-021-01330-0
+- Eckstein N et al. (2024) Neurotransmitter classification from electron microscopy images at synaptic sites in *Drosophila melanogaster*. *Cell* 187:2574–2594. doi:10.1016/j.cell.2024.03.016
+- Meissner GW et al. (2025) A split-GAL4 driver line resource for *Drosophila* neuron types. *eLife* 13:RP98405. doi:10.7554/eLife.98405
+
+**Virtual Fly Brain**
+
+- Milyaev N et al. (2012) The Virtual Fly Brain browser and query interface. *Bioinformatics* 28:411–415. doi:10.1093/bioinformatics/btr677
+- Court R et al. (2023) Virtual Fly Brain — an interactive atlas of the *Drosophila* nervous system. *Front Physiol* 14:1076533. doi:10.3389/fphys.2023.1076533

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -144,7 +144,9 @@ bithorax complex and its role in segment identity
 Wieschaus ran a saturation screen for mutations affecting the segmental pattern of the
 embryo, and in doing so demonstrated that a developmental programme could be enumerated
 gene by gene ([Nüsslein-Volhard and Wieschaus, 1980](https://doi.org/10.1038/287795a0)).
-The three shared the 1995 Nobel Prize in Physiology or Medicine.
+Lewis, Nüsslein-Volhard and Wieschaus shared the
+[1995 Nobel Prize in Physiology or Medicine](https://www.nobelprize.org/prizes/medicine/1995/summary/)
+"for their discoveries concerning the genetic control of early embryonic development".
 
 **2000: the genome.** The roughly 120-megabase euchromatic portion of the genome was
 sequenced by a whole-genome shotgun strategy, and reported to encode about 13,600 genes

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -61,18 +61,22 @@ dataset record for exactly this reason.
 Both halves of the cross have FlyBase records, and reading them turns the genotype into a
 short history of the field.
 
-**Canton-S** ([FBsn0000274](https://flybase.org/reports/FBsn0000274)) is a wild-type
-strain derived from a natural population collected at Canton, Ohio. FlyBase records that
-it was selected by **C. Bridges**, who established that its salivary chromosomes were
-normal — the same Bridges whose salivary gland maps are cited below. It is still
-distributed, by Bloomington (64349) and Kyoto (105666). The report also notes a recessive
-for multiple thoracic and scutellar bristles that surfaces sporadically in strains partly
-derived from it, which is a useful reminder that "wild type" names a stock, not an
-absence of variation.
+**Canton-S**, or Canton-Special
+([FBsn0000274](https://flybase.org/reports/FBsn0000274)), is one of the standard wild-type
+laboratory strains. FlyBase records that it was "selected by C. Bridges", and that
+"C. Bridges found that salivary chromosomes were normal" — the same Bridges whose salivary
+gland maps are cited below, vetting the stock with the technique he had just built. It is
+still distributed, by Bloomington (64349) and Kyoto (105666). The report also notes that
+it "contains a recessive for multiple thoracic and scutellar bristles, which overlaps wild
+type in most flies but appears sporadically in strains partly derived from Canton-S" — a
+useful reminder that "wild type" names a stock, not an absence of variation.
 
 ***w<sup>1118</sup>*** ([FBal0018186](https://flybase.org/reports/FBal0018186)) is a
-spontaneous partial deletion of *white*, attributed to R. Levis — a loss-of-function
-allele of the very gene Morgan reported in 1910. It is the standard white-eyed background
+loss-of-function allele of the very gene Morgan reported in 1910: FlyBase gives the
+mutagen as spontaneous and the lesion as a "partial deletion of the w locus", citing
+[Hazelrigg et al. (1984)](https://doi.org/10.1016/0092-8674(84)90240-X) — the same paper
+that worked out how transduced copies of *white* behave, which is what made it usable as
+a transformation marker. It is the standard white-eyed background
 for transgenics, and not by accident: P-element and φC31 constructs are typically marked
 with **mini-*white*** — the P{GawB} enhancer-trap construct that produced many early GAL4
 lines carries *w<sup>+mW.hs</sup>*
@@ -327,6 +331,7 @@ using the strategy described in
 **Techniques**
 
 - Rubin GM, Spradling AC (1982) Genetic transformation of *Drosophila* with transposable element vectors. *Science* 218:348–353. doi:10.1126/science.6289436
+- Hazelrigg T, Levis R, Rubin GM (1984) Transformation of *white* locus DNA in *Drosophila*: dosage compensation, zeste interaction, and position effects. *Cell* 36:469–481. doi:10.1016/0092-8674(84)90240-X
 - O'Kane CJ, Gehring WJ (1987) Detection in situ of genomic regulatory elements in *Drosophila*. *PNAS* 84:9123–9127. doi:10.1073/pnas.84.24.9123
 - Golic KG, Lindquist S (1989) The FLP recombinase of yeast catalyzes site-specific recombination in the *Drosophila* genome. *Cell* 59:499–509. doi:10.1016/0092-8674(89)90033-0
 - Brand AH, Perrimon N (1993) Targeted gene expression as a means of altering cell fates and generating dominant phenotypes. *Development* 118:401–415. doi:10.1242/dev.118.2.401

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -243,10 +243,12 @@ more than one cell type. Splitting a transcription factor into an activation dom
 DNA-binding domain, each under a different enhancer, restricts expression to the
 intersection ([Luan et al., 2006](https://doi.org/10.1016/j.neuron.2006.08.028);
 [Pfeiffer et al., 2010](https://doi.org/10.1534/genetics.110.119917);
-[Dionne et al., 2018](https://doi.org/10.1534/genetics.118.300682)). The Janelia
-split-GAL4 resource is the large published application
-([Meissner et al., 2025](https://doi.org/10.7554/eLife.98405)). See
-[Split driver expression](/docs/concepts/splits/).
+[Dionne et al., 2018](https://doi.org/10.1534/genetics.118.300682)). The scale of the
+effort this takes is worth stating: the Janelia resource reports 3,060 cell-type-specific
+split-GAL4 lines for the adult CNS and 1,373 characterised in third-instar larvae, drawn
+from the examination of **over 77,000 split combinations** between 2013 and 2023
+([Meissner et al., 2025](https://doi.org/10.7554/eLife.98405)). Specificity is expensive.
+See [Split driver expression](/docs/concepts/splits/).
 
 **Getting down to one neuron.** Site-specific recombination
 ([Golic and Lindquist, 1989](https://doi.org/10.1016/0092-8674(89)90033-0)) underpins

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -338,6 +338,27 @@ the classification is not hand-asserted but inferred: relations such as `part_of
 reasoner derive the hierarchy and let disjointness axioms catch contradictions
 ([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)).
 
+**How an image becomes a queryable fact.** The bridge between the pictures and the
+ontology is that images are modelled as OWL *individuals*. The painted neuropil domains on
+a template are individuals of the relevant class, tied to it by a `has_exemplar` axiom, so
+a term page can find its own illustration with a query. Every other image — single neuron,
+clone, expression pattern — is registered onto that same template, and image analysis of
+which regions it overlaps is written back as a type assertion on the individual. That is
+what makes "show me neurons with a synaptic terminal in the antennal lobe" answerable at
+all: the answer is inferred, not looked up. Reasoning propagates over partonomy through
+property chains on `overlaps` and its subproperties — `fasciculates_with`,
+`has_synaptic_terminal_in` — so a query at one level of the part hierarchy also returns
+what was asserted further down it
+([Osumi-Sutherland et al., 2014](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)).
+
+There is a deliberate limit here, and it is worth knowing because it shapes what you can
+ask. To keep reasoning fast enough to run live, VFB confines the ontology almost entirely
+to the **EL profile** of OWL and uses the ELK reasoner. The payoff is speed. The cost is
+expressiveness: EL has no negation, so VFB's compound queries combine their legs with
+*and* and cannot express "neurons that synapse in the mushroom body but **not** in the
+lateral horn" — a query the same paper argues would be genuinely useful for choosing
+specific reagents, and sets out closure-axiom and disjointness patterns to support.
+
 VFB itself began as an interface onto that idea. The original paper describes two aims —
 "a hub for neuro-anatomical data integration" and "an easily accessible and usable tool to
 disseminate community agreed anatomical standards" — built over the BrainName reference
@@ -441,4 +462,5 @@ datasets and connectomes described on this page were added to that frame.
 
 - Milyaev N et al. (2012) The Virtual Fly Brain browser and query interface. *Bioinformatics* 28:411–415. doi:10.1093/bioinformatics/btr677
 - Costa M, Reeve S, Grumbling G, Osumi-Sutherland D (2013) The *Drosophila* anatomy ontology. *J Biomed Semantics* 4:32. doi:10.1186/2041-1480-4-32
+- Osumi-Sutherland D, Costa M, Court R, O'Kane CJ (2014) Virtual Fly Brain — using OWL to support the mapping and genetic dissection of the *Drosophila* brain. *Proceedings of OWLED 2014*, CEUR Workshop Proceedings 1265:85–96. [PDF](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)
 - Court R et al. (2023) Virtual Fly Brain — an interactive atlas of the *Drosophila* nervous system. *Front Physiol* 14:1076533. doi:10.3389/fphys.2023.1076533

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -362,13 +362,16 @@ property chains on `overlaps` and its subproperties — `fasciculates_with`,
 what was asserted further down it
 ([Osumi-Sutherland et al., 2014](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)).
 
-There is a deliberate limit here, and it is worth knowing because it shapes what you can
-ask. To keep reasoning fast enough to run live, VFB confines the ontology almost entirely
-to the **EL profile** of OWL and uses the ELK reasoner. The payoff is speed. The cost is
-expressiveness: EL has no negation, so VFB's compound queries combine their legs with
-*and* and cannot express "neurons that synapse in the mushroom body but **not** in the
-lateral horn" — a query the same paper argues would be genuinely useful for choosing
-specific reagents, and sets out closure-axiom and disjointness patterns to support.
+There is a deliberate design trade-off here. To keep reasoning fast enough to run live, the
+ontology is confined almost entirely to the **EL profile** of OWL, which is what allows the
+ELK reasoner to classify it in well under a second. The cost is expressiveness: EL has no
+negation, which is why the ontology-level compound queries were built to combine their legs
+with *and*. The 2014 paper makes the case that queries such as "neurons that synapse in the
+mushroom body but **not** in the lateral horn" would be genuinely useful for choosing
+specific reagents, and sets out closure-axiom and disjointness patterns that could support
+them ([Osumi-Sutherland et al., 2014](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)).
+What the current interface offers is documented under
+[search and query](/docs/website-features/search_query/).
 
 VFB itself began as an interface onto that idea. The original paper describes two aims —
 "a hub for neuro-anatomical data integration" and "an easily accessible and usable tool to

--- a/content/en/about/whichfly.md
+++ b/content/en/about/whichfly.md
@@ -313,16 +313,27 @@ segmentation with human proofreading
 **Names.** None of the above is comparable across studies without agreed terms. VFB is
 built around the **Drosophila Anatomy Ontology**
 ([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)), a manually curated,
-queryable classification expressed in OWL, using a schema that records a neuron's
-location, connectivity, lineage and function and supports basic spatial reasoning
-([Osumi-Sutherland et al., 2012](https://doi.org/10.1093/bioinformatics/bts113)). Built
+queryable classification expressed in OWL. The schema behind it is a small, deliberate set
+of relations — `part_of` and `has_part`, `overlaps` derived from them, and then the ones
+that carry the neurobiology: `has_soma_location`, `fasciculates_with`,
+`has_synaptic_terminal_in` with its pre- and post-synaptic forms, `synapsed_to`,
+`upstream_in_neural_path_with`, `innervates`, `develops_from`
+([Osumi-Sutherland et al., 2012](https://doi.org/10.1093/bioinformatics/bts113)). Properties
+are asserted at the leaves and the hierarchy is left to a reasoner, because the alternative
+does not scale: "a conventional relational database approach provides no means to automate
+classification. Without this, maintaining the multiple inheritance classification schemes
+biologists typically use quickly becomes impractical." Built
 from over 1,000 curated papers, the DAO represents some 13,000 neuroanatomical structures
 and cell types, including over 9,800 terms for neuron types — of which more than 3,800 are
 predicted from connectomics data
-([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)). The region names
-themselves come from the community nomenclatures for the brain
-([Ito et al., 2014](https://doi.org/10.1016/j.neuron.2013.12.017)) and the ventral nerve
-cord ([Court et al., 2020](https://doi.org/10.1016/j.neuron.2020.08.005)). See
+([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)). The region names came
+in from outside: VFB "adapted and updated the *Drosophila* anatomy ontology to incorporate
+the BrainName standard terminology"
+([Milyaev et al., 2012](https://doi.org/10.1093/bioinformatics/btr677)), the community
+standard later published as the systematic nomenclature for the insect brain
+([Ito et al., 2014](https://doi.org/10.1016/j.neuron.2013.12.017)); the ventral nerve cord
+got the same treatment
+([Court et al., 2020](https://doi.org/10.1016/j.neuron.2020.08.005)). See
 [Cell types](/docs/concepts/cell_types/).
 
 The ontology has its own inclusion rule, and it is the reason a VFB term can be treated as

--- a/content/en/docs/Concepts/FlyLight_tiles.md
+++ b/content/en/docs/Concepts/FlyLight_tiles.md
@@ -8,9 +8,11 @@ description: >
   Tiles used during FlyLight Split-GAL4 expression pattern imaging.
 ---
 
-While most first-generation FlyLight expression pattern images are single 20x objective acquisitions, many Split-GAL4 lines were imaged using 63x or 40x objectives. This requires multiple image acquisitions to cover the CNS regions of interest. VFB integrates only the combined images derived from these tiles and lists the tiles used to create these combined images in the comment section for each image, for example: "tile(s): 'left_dorsal, right_dorsal, ventral". These tiles do not necessarily cover the entire brain or VNC, which complicates the assessment of the specificity of these lines. VFB notes in the comment where the combined tiles do not provide full coverage. For further information refer to Figure 4 Supplemental File 1 from 'A split-GAL4 driver line resource for Drosophila CNS cell types' [direct link](https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.01.09.574419/DC6/embed/media-6.pdf?download=true). This is a preprint and may be updated.
+While most first-generation FlyLight expression pattern images are single 20x objective acquisitions, many Split-GAL4 lines were imaged using 63x or 40x objectives. This requires multiple image acquisitions to cover the CNS regions of interest. VFB integrates only the combined images derived from these tiles and lists the tiles used to create these combined images in the comment section for each image, for example: "tile(s): 'left_dorsal, right_dorsal, ventral". These tiles do not necessarily cover the entire brain or VNC, which complicates the assessment of the specificity of these lines. VFB notes in the comment where the combined tiles do not provide full coverage. For further information refer to Figure 4 Supplemental File 1 of the FlyLight split-GAL4 resource paper, [Meissner et al. (2025)](https://doi.org/10.7554/eLife.98405) — [direct link to the supplement on the preprint](https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.01.09.574419/DC6/embed/media-6.pdf?download=true), which was titled 'A split-GAL4 driver line resource for Drosophila CNS cell types'.
 
-Sets of tiles from FlyLight (Meissner et al., 2024):
+The reagents themselves are covered on the [split driver expression](/docs/concepts/splits/) page, and the underlying method on [binary expression systems](/docs/concepts/binary-expression/).
+
+Sets of tiles from FlyLight ([Meissner et al., 2025](https://doi.org/10.7554/eLife.98405)):
 
 <img src="/images/FlyLight_Tiles/FlyLight_Tiles_1.png" max-width="50%" alt="FlyLight 63x Brain Tiles.">
 

--- a/content/en/docs/Concepts/_index.md
+++ b/content/en/docs/Concepts/_index.md
@@ -9,3 +9,8 @@ The ideas the rest of the documentation assumes. Each page here explains one thi
 VFB stores or presents data, and that is worth understanding before interpreting a result: how
 neurons are classified into cell types, how images from different studies are brought into a common
 space, how morphological similarity is scored, and how to read a count or a confidence value.
+
+Several pages here describe the laboratory techniques the data was produced by — binary
+expression systems, split drivers, stochastic labelling, registration and EM
+reconstruction. For how those techniques came about, and for the specimens the
+connectomes were made from, see [which fly is this?](/about/whichfly/)

--- a/content/en/docs/Concepts/binary-expression.md
+++ b/content/en/docs/Concepts/binary-expression.md
@@ -96,6 +96,20 @@ Both are searchable on VFB, registered to the [standard templates](/docs/data/te
 and classified with anatomy ontology terms, so you can ask which lines label a region or
 cell type rather than reading pattern images one at a time.
 
+## What "expression pattern" means on VFB, formally
+
+The term has a precise definition behind it. VFB defines a relation `expresses` holding
+between an anatomical entity and a gene or transgene, and then defines an **expression
+pattern** as the anatomical entity consisting of the mereological sum of *all* cells that
+express that gene or transgene
+([Osumi-Sutherland et al., 2014](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)).
+
+That is why VFB distinguishes an expression pattern from an **expression pattern
+fragment**. An image of a single neuron or a clone picked out of a driver's pattern depicts
+only part of that sum, so it is modelled as a part of the expression pattern rather than as
+the pattern itself. The distinction is not cosmetic: it is what stops a sparse MCFO image
+of one cell being treated as the full extent of what a driver labels.
+
 ## What an expression pattern image is, and is not
 
 - **It is the whole pattern of that driver**, not of one cell type. A GAL4 line usually
@@ -149,3 +163,4 @@ both from each transgene record. See
 - Kvon EZ et al. (2014) Genome-scale functional characterization of *Drosophila* developmental enhancers in vivo. *Nature* 512:91–95. doi:10.1038/nature13395
 - Perkins LA et al. (2015) The Transgenic RNAi Project at Harvard Medical School: resources and validation. *Genetics* 201:843–852. doi:10.1534/genetics.115.180208
 - Talay M et al. (2017) Transsynaptic mapping of second-order taste neurons in flies by trans-Tango. *Neuron* 96:783–795. doi:10.1016/j.neuron.2017.10.011
+- Osumi-Sutherland D, Costa M, Court R, O'Kane CJ (2014) Virtual Fly Brain — using OWL to support the mapping and genetic dissection of the *Drosophila* brain. *Proceedings of OWLED 2014*, CEUR Workshop Proceedings 1265:85–96. [PDF](https://ceur-ws.org/Vol-1265/owled2014_submission_12.pdf)

--- a/content/en/docs/Concepts/binary-expression.md
+++ b/content/en/docs/Concepts/binary-expression.md
@@ -63,6 +63,16 @@ next to it reported on whatever regulatory element it landed near
 ([O'Kane and Gehring, 1987](https://doi.org/10.1073/pnas.84.24.9123)). Useful, but neither
 systematic nor reproducible in insertion site.
 
+This is also where the *w<sup>1118</sup>* background in so many stock genotypes comes
+from. Transformation constructs carry a selectable marker, and the classical one is
+**mini-*white***: the P{GawB} enhancer-trap construct behind many early GAL4 lines is
+marked with *w<sup>+mW.hs</sup>*
+([FBtp0000352](https://flybase.org/reports/FBtp0000352)). A *white*<sup>+</sup> marker
+restores eye pigment, so it can only be scored in a *white*-mutant animal — which is why
+driver line genotypes on VFB so often read `w[1118];P{w[+mW.hs]=GawB}…`, and why the first
+*Drosophila* mutant ever described is still the standard way of telling that a transgene
+went in.
+
 Two changes made large collections possible. First, φC31 integrase allowed constructs to
 be placed at a defined attP landing site, so lines differ only in their enhancer fragment
 and not in where the construct sits

--- a/content/en/docs/Concepts/binary-expression.md
+++ b/content/en/docs/Concepts/binary-expression.md
@@ -52,9 +52,12 @@ another ([Lai and Lee, 2006](https://doi.org/10.1038/nn1681);
 ## Control in time as well as space
 
 GAL80 represses GAL4. A temperature-sensitive GAL80 therefore gates GAL4 activity by
-temperature, which converts a spatial tool into a spatiotemporal one
-([McGuire et al., 2003](https://doi.org/10.1126/science.1089035)). GAL80 is also what makes
-MARCM work — see [stochastic labelling](/docs/concepts/stochastic-labelling/).
+temperature, converting a spatial tool into a spatiotemporal one — the **TARGET** system,
+"temporal and regional gene expression targeting", which McGuire et al. used to rescue a
+memory defect transiently in the adult mushroom bodies and so rule out a developmental
+cause ([McGuire et al., 2003](https://doi.org/10.1126/science.1089035)). GAL80 is also what
+makes MARCM work — see
+[stochastic labelling](/docs/concepts/stochastic-labelling/).
 
 ## Where the driver lines came from
 
@@ -73,11 +76,13 @@ driver line genotypes on VFB so often read `w[1118];P{w[+mW.hs]=GawB}…`, and w
 *Drosophila* mutant ever described is still the standard way of telling that a transgene
 went in.
 
-Two changes made large collections possible. First, φC31 integrase allowed constructs to
-be placed at a defined attP landing site, so lines differ only in their enhancer fragment
-and not in where the construct sits
-([Groth et al., 2004](https://doi.org/10.1534/genetics.166.4.1775)). Second, defined
-genomic fragments were cloned systematically rather than trapped
+Two changes made large collections possible. First, the φC31 integrase — which catalyses
+unidirectional site-specific recombination between attB and attP sites — was shown to work
+in *Drosophila*, and attP sites were integrated into the genome to act as defined landing
+sites ([Groth et al., 2004](https://doi.org/10.1534/genetics.166.4.1775)). Constructs
+placed there differ only in their enhancer fragment, not in where they sit, so patterns
+can be compared without position effects confounding them. Second, defined genomic
+fragments were cloned systematically rather than trapped
 ([Pfeiffer et al., 2008](https://doi.org/10.1073/pnas.0803697105)).
 
 The two collections that dominate VFB's light microscopy followed:

--- a/content/en/docs/Concepts/binary-expression.md
+++ b/content/en/docs/Concepts/binary-expression.md
@@ -1,0 +1,136 @@
+---
+title: "Binary Expression Systems"
+linkTitle: "Binary Expression"
+weight: 313
+date: 2026-08-18
+categories: ["overview","help"]
+tags: ["GAL4","UAS","LexA","Q system","transgene","Expression_pattern"]
+description: >
+  GAL4/UAS and the other two-part systems that produced almost every driver line and
+  expression pattern on VFB.
+---
+
+Almost every light microscopy image on Virtual Fly Brain exists because someone put a
+reporter into a defined set of cells using a **binary expression system**. Understanding
+the two-part structure explains what an expression pattern on VFB is an image *of*, and
+why the same driver appears in dozens of different experiments.
+
+## The two parts
+
+A binary system separates *where* from *what*:
+
+- A **driver** transgene puts a transcription factor under the control of a piece of
+  genomic DNA — usually an enhancer fragment — so the factor is made in whatever cells
+  that fragment is active in.
+- An **effector** (or reporter) transgene puts the gene you actually want expressed
+  downstream of a binding site for that factor. On its own it does nothing.
+
+Cross the two lines, and the effector is expressed only where the driver is active. The
+same driver can be crossed to a fluorescent reporter to image a pattern, to a silencer to
+switch those cells off, or to an optogenetic channel to switch them on — without
+rebuilding the driver.
+
+Brand and Perrimon adapted the yeast GAL4 transcription factor and its UAS binding site
+for exactly this ([Brand and Perrimon, 1993](https://doi.org/10.1242/dev.118.2.401)). It
+remains the dominant system in fly neurobiology, and every `GAL4` line on VFB is an
+instance of it.
+
+## The systems you will meet on VFB
+
+| System | Driver | Effector | Typical use |
+|---|---|---|---|
+| GAL4/UAS | GAL4 | UAS-*x* | The default; nearly all driver lines |
+| LexA/LexAop | LexA | LexAop-*x* | A second, independent channel in the same animal |
+| Q system | QF | QUAS-*x* | A third channel; repressible by QS |
+| Split-GAL4 | GAL4-AD + GAL4-DBD | UAS-*x* | Intersection of two patterns — see [split driver expression](/docs/concepts/splits/) |
+
+Having more than one orthogonal system matters because it lets you label two populations
+in different colours, or drive an effector in one population while reporting activity in
+another ([Lai and Lee, 2006](https://doi.org/10.1038/nn1681);
+[Potter et al., 2010](https://doi.org/10.1016/j.cell.2010.02.025)).
+
+## Control in time as well as space
+
+GAL80 represses GAL4. A temperature-sensitive GAL80 therefore gates GAL4 activity by
+temperature, which converts a spatial tool into a spatiotemporal one
+([McGuire et al., 2003](https://doi.org/10.1126/science.1089035)). GAL80 is also what makes
+MARCM work — see [stochastic labelling](/docs/concepts/stochastic-labelling/).
+
+## Where the driver lines came from
+
+Early drivers were enhancer traps: a transposon inserted at random, and the reporter
+next to it reported on whatever regulatory element it landed near
+([O'Kane and Gehring, 1987](https://doi.org/10.1073/pnas.84.24.9123)). Useful, but neither
+systematic nor reproducible in insertion site.
+
+Two changes made large collections possible. First, φC31 integrase allowed constructs to
+be placed at a defined attP landing site, so lines differ only in their enhancer fragment
+and not in where the construct sits
+([Groth et al., 2004](https://doi.org/10.1534/genetics.166.4.1775)). Second, defined
+genomic fragments were cloned systematically rather than trapped
+([Pfeiffer et al., 2008](https://doi.org/10.1073/pnas.0803697105)).
+
+The two collections that dominate VFB's light microscopy followed:
+
+- The **Janelia GAL4 collection** — 7,000 lines, with CNS expression imaged and published
+  for 6,650 ([Jenett et al., 2012](https://doi.org/10.1016/j.celrep.2012.09.011)).
+- The **Vienna Tiles (VT)** collection — 7,705 enhancer candidates characterised in vivo
+  ([Kvon et al., 2014](https://doi.org/10.1038/nature13395)).
+
+Both are searchable on VFB, registered to the [standard templates](/docs/data/templates/)
+and classified with anatomy ontology terms, so you can ask which lines label a region or
+cell type rather than reading pattern images one at a time.
+
+## What an expression pattern image is, and is not
+
+- **It is the whole pattern of that driver**, not of one cell type. A GAL4 line usually
+  labels several unrelated populations. Specificity is what split drivers address.
+- **It is one animal.** Expression varies between individuals, and between rearing
+  conditions. Patterns on VFB are registered so that many such images can be compared.
+- **Absence of signal is weak evidence.** A pattern may fail to show a cell because the
+  enhancer is not active there, or because the reporter was too dim, or because that part
+  of the CNS was not imaged — see [FlyLight imaging tiles](/docs/concepts/flylight_tiles/).
+- **Reporter choice changes what you see.** Membrane-targeted, nuclear and cytoplasmic
+  reporters give visibly different images of the same driver.
+
+## Effectors beyond reporters
+
+The same drivers carry non-imaging effectors, which is why a driver line found on VFB is
+usually the starting point for a functional experiment:
+
+- **Silencing** — temperature-sensitive *shibire* to block synaptic vesicle recycling
+  ([Kitamoto, 2001](https://doi.org/10.1002/neu.1018)), or Kir2.1 to hyperpolarise.
+- **Activation** — channelrhodopsins such as CsChrimson
+  ([Klapoetke et al., 2014](https://doi.org/10.1038/nmeth.2836)).
+- **Activity imaging** — GCaMP calcium indicators
+  ([Chen et al., 2013](https://doi.org/10.1038/nature12354)).
+- **Knockdown** — UAS-RNAi from the VDRC and TRiP collections
+  ([Dietzl et al., 2007](https://doi.org/10.1038/nature05954);
+  [Perkins et al., 2015](https://doi.org/10.1534/genetics.115.180208)).
+- **Connectivity reporters** — GRASP
+  ([Feinberg et al., 2008](https://doi.org/10.1016/j.neuron.2007.11.030)) and trans-Tango
+  ([Talay et al., 2017](https://doi.org/10.1016/j.neuron.2017.10.011)).
+
+VFB indexes the expression patterns; the reagents themselves are catalogued in
+[FlyBase](https://flybase.org) and distributed by the stock centres, and VFB links out to
+both from each transgene record. See
+[transgene expression curation](/docs/concepts/transgene/) for how that record is built.
+
+## Sources
+
+- Brand AH, Perrimon N (1993) Targeted gene expression as a means of altering cell fates and generating dominant phenotypes. *Development* 118:401–415. doi:10.1242/dev.118.2.401
+- O'Kane CJ, Gehring WJ (1987) Detection in situ of genomic regulatory elements in *Drosophila*. *PNAS* 84:9123–9127. doi:10.1073/pnas.84.24.9123
+- Kitamoto T (2001) Conditional modification of behavior in *Drosophila* by targeted expression of a temperature-sensitive *shibire* allele in defined neurons. *J Neurobiol* 47:81–92. doi:10.1002/neu.1018
+- McGuire SE et al. (2003) Spatiotemporal rescue of memory dysfunction in *Drosophila*. *Science* 302:1765–1768. doi:10.1126/science.1089035
+- Groth AC et al. (2004) Construction of transgenic *Drosophila* by using the site-specific integrase from phage φC31. *Genetics* 166:1775–1782. doi:10.1534/genetics.166.4.1775
+- Lai S-L, Lee T (2006) Genetic mosaic with dual binary transcriptional systems in *Drosophila*. *Nat Neurosci* 9:703–709. doi:10.1038/nn1681
+- Dietzl G et al. (2007) A genome-wide transgenic RNAi library for conditional gene inactivation in *Drosophila*. *Nature* 448:151–156. doi:10.1038/nature05954
+- Feinberg EH et al. (2008) GFP reconstitution across synaptic partners (GRASP) defines cell contacts and synapses in living nervous systems. *Neuron* 57:353–363. doi:10.1016/j.neuron.2007.11.030
+- Pfeiffer BD et al. (2008) Tools for neuroanatomy and neurogenetics in *Drosophila*. *PNAS* 105:9715–9720. doi:10.1073/pnas.0803697105
+- Potter CJ et al. (2010) The Q system: a repressible binary system for transgene expression, lineage tracing, and mosaic analysis. *Cell* 141:536–548. doi:10.1016/j.cell.2010.02.025
+- Jenett A et al. (2012) A GAL4-driver line resource for *Drosophila* neurobiology. *Cell Rep* 2:991–1001. doi:10.1016/j.celrep.2012.09.011
+- Chen T-W et al. (2013) Ultrasensitive fluorescent proteins for imaging neuronal activity. *Nature* 499:295–300. doi:10.1038/nature12354
+- Klapoetke NC et al. (2014) Independent optical excitation of distinct neural populations. *Nat Methods* 11:338–346. doi:10.1038/nmeth.2836
+- Kvon EZ et al. (2014) Genome-scale functional characterization of *Drosophila* developmental enhancers in vivo. *Nature* 512:91–95. doi:10.1038/nature13395
+- Perkins LA et al. (2015) The Transgenic RNAi Project at Harvard Medical School: resources and validation. *Genetics* 201:843–852. doi:10.1534/genetics.115.180208
+- Talay M et al. (2017) Transsynaptic mapping of second-order taste neurons in flies by trans-Tango. *Neuron* 96:783–795. doi:10.1016/j.neuron.2017.10.011

--- a/content/en/docs/Concepts/bridging.md
+++ b/content/en/docs/Concepts/bridging.md
@@ -4,8 +4,8 @@ weight: 304
 date: 2026-08-18
 tag: [Template,Registration,Alignment,nat,navis,flybrains,Transforms]
 description: >
-  Transformations to map between different canonical Drosophila templates, and where VFB
-  keeps them.
+  Transformations to map between different canonical Drosophila templates, where VFB keeps
+  them, and how a route between two spaces is worked out.
 ---
 
 A [registration](/docs/concepts/registration/) puts one animal's image into a template's
@@ -14,86 +14,126 @@ template space onto another, so data registered to different standards can still
 compared.
 
 This matters because no single template ever won. Data on VFB arrives registered to
-whichever standard its producers used — JRC2018 unisex, JRC2018F or M, JFRC2, a
-connectome's own space such as the hemibrain or FAFB — and the only way to put a FlyWire
-neuron next to a split-GAL4 expression pattern is to bridge between them.
+whichever standard its producers used — JRC2018 unisex, JRC2018F or M, JFRC2, or a
+connectome's own space such as the hemibrain, FAFB or MANC — and the only way to put a
+FlyWire neuron next to a split-GAL4 expression pattern is to bridge between them.
 
 ## Where the transforms live
 
-VFB does not keep a private set of these. The bridging and mirroring transforms are
-maintained in the community packages — **navis-flybrains** for Python and
-**nat.flybrains** for R — so that the same transform is available to anyone, and everyone
-chaining between two spaces gets the same answer. A registration that only exists inside
-one resource is a registration nobody else can check.
+VFB keeps no private set. Its bridging and mirroring registrations are published through
+the community packages — [**navis-flybrains**](https://github.com/navis-org/navis-flybrains)
+for Python and [**nat.flybrains**](https://natverse.org/nat.flybrains/index.html) for R —
+so the same transform is available to anyone and everyone chaining between two spaces gets
+the same answer. A registration that exists only inside one resource is a registration
+nobody else can check.
 
-Between them these packages cover 30-odd template and connectome spaces — including
-JRC2018F/M/U, JFRC2, FAFB14, FlyWire, the hemibrain (JRCFIB2018F), maleCNS
-(JRCFIB2022M), MANC, FANC and BANC — and wrap several kinds of transform: CMTK
-registrations, H5 deformation fields, Elastix transforms and landmark-based mappings.
-Which underlying technology is used is mostly invisible in normal use.
+They are a named set in the package. Alongside the Jefferis lab and Janelia collections,
+`flybrains` provides a one-off download of "various CMTK bridging and mirror transforms
+generated or collated by VirtualFlyBrain.org":
 
-<p align="center">
-<img src="https://github.com/schlegelp/navis-flybrains/blob/main/_static/bridging_graph.png?raw=true" width="800">
-</p>
+```python
+import flybrains
+
+flybrains.download_jefferislab_transforms()   # CMTK, Jefferis lab
+flybrains.download_jrc_transforms()           # H5, Janelia brain
+flybrains.download_jrc_vnc_transforms()       # H5, Janelia VNC
+flybrains.download_vfb_transforms()           # CMTK, VirtualFlyBrain.org
+
+flybrains.report()   # what is actually available, Python and R downloads alike
+```
+
+If you already hold these registrations from the R side, `flybrains` will find and register
+them rather than duplicating the download. Using the Jefferis lab or VFB transforms needs
+[CMTK](https://www.nitrc.org/projects/cmtk/) installed; the FANC and BANC transforms need
+[elastix](https://elastix.lumc.nl/index.php).
+
+The package ships metadata and surface meshes for 31 light-level templates and connectome
+datasets, and wraps several kinds of transform — CMTK registrations, H5 deformation
+fields, elastix transforms and landmark-based (thin-plate spline) mappings. Which
+technology underlies a given hop is mostly invisible in normal use.
 
 ## It is a graph, and the route is computed
 
-The picture above is not an illustration — it is the data structure. Each template space
-is a node, each registration an edge, and a conversion between two spaces is a **path**
-through it. Most useful pairs are not directly connected, so the transform you actually
-apply is usually a **sequence of several**, assembled on demand.
+<p align="center">
+<img src="https://github.com/schlegelp/navis-flybrains/blob/main/_static/bridging_graph.png?raw=true" width="800" alt="Graph of bridging registrations between Drosophila template spaces">
+</p>
 
-The routing is what makes this practical:
+The picture is not an illustration — it is the data structure. Each template space is a
+node, each registration an edge, and a conversion between two spaces is a **path** through
+it. Most useful pairs are not directly connected, so the transform you actually apply is
+usually a **sequence**, assembled on demand. Asking navis to take a point from FAFB to
+JRC2018F, for example, routes it through several intermediate spaces including a unit
+conversion:
 
-- **Shortest path, by weight.** Every edge carries a cost, and the route is the
-  cheapest path from source to target — not necessarily the one with fewest hops.
-  Lower weight wins.
-- **Edges can be traversed backwards.** Many registrations are invertible, so a
-  transform registered as A→B can be used to get from B to A. Running one in reverse
-  carries its own cost, so the router can be told to detour rather than go backwards.
-- **A purpose-built registration beats an inverted one.** Where two spaces are joined
-  both by a registration made for that direction and by the inverse of its counterpart,
-  the purpose-built one is used regardless of which is cheaper.
-- **Some hops are free.** Aliases — the same space under another name, or the same data
-  in different units — are registered at zero cost, so they never distort a route.
-- **A single registration may itself be multi-stage.** Some CMTK transforms need an
-  affine applied before or after the main warp; these are modelled as extra intermediate
-  nodes, so what looks like one edge can be several transforms deep.
-- **Units are explicit.** EM datasets are natively in nanometres or voxels rather than
-  microns, so their spaces are registered under unit-tagged names to stop a
-  correctly-routed transform silently producing a result off by a factor of a thousand.
+```
+JRCFIB2018Fraw → JRCFIB2018F → JRCFIB2018Fum → JRC2018F
+```
 
-You can ask for the route before running it, and force it through a particular
-waystation if you need to.
+The routing rules are what make this practical:
+
+- **Shortest path, by weight.** Every edge carries a cost and the route is the cheapest
+  path from source to target, not necessarily the one with fewest hops.
+- **Edges can be traversed backwards.** Many registrations are invertible, so a transform
+  registered A→B can serve B→A. Running one in reverse has its own cost, so the router can
+  be told to detour rather than invert.
+- **A purpose-built registration beats an inverted one** where a pair of spaces is joined
+  by both, regardless of which is cheaper.
+- **Some hops are free.** Aliases — the same space under another name, or the same data in
+  different units — are registered at zero cost so they never distort a route.
+- **A single edge may itself be multi-stage.** Some CMTK registrations need an affine
+  applied before or after the main warp; these become extra intermediate nodes.
+- **Units are explicit.** EM datasets are natively in nanometres or voxels, so their spaces
+  carry unit-tagged names. This is what stops a correctly-routed transform silently
+  producing an answer off by a factor of a thousand.
 
 ## Using them
 
-In Python, importing `flybrains` registers the transforms with
-[navis](https://navis.readthedocs.io/en/latest/source/tutorials/transforming.html), after
-which a conversion is one call:
+Importing `flybrains` registers everything with
+[navis](https://navis-org.github.io/navis/stable/), after which a conversion is one call:
 
 ```python
 import navis, flybrains
+import numpy as np
 
-# run a conversion — the route is worked out for you
-navis.xform_brain(neuron, source='FAFB', target='JRC2018F')
-
-# or ask what it would do first
-navis.transforms.registry.shortest_bridging_seq(source='FAFB', target='JRC2018F')
+points = np.array([[429536, 205240, 38400]])
+navis.xform_brain(points, source='FAFB', target='JRC2018F')
+# array([[241.53969657, 100.99399233, 35.96977733]])
 ```
 
-In R the equivalent lives in [nat.flybrains](https://natverse.org/nat.flybrains/index.html),
+`xform_brain` reports the path it took, so you can see how many hops a comparison actually
+went through. To see what is registered before you start,
+`navis.transforms.registry.summary()` tabulates every transform with its source, target,
+invertibility and weight.
+
+**Mirroring** is a related operation with its own transforms: `navis.mirror_brain()`
+reflects coordinates about the midpoint of the mirror axis, then applies a warp to
+compensate for asymmetry. A symmetrical template such as JRC2018F needs only the
+reflection; an asymmetrical one benefits from the warp. Mirroring is how VFB brings data
+onto one side of the brain so that left and right examples of a cell type can be compared.
+
+Full detail is in the
+[navis transforms tutorial](https://navis-org.github.io/navis/stable/generated/gallery/6_misc/tutorial_misc_01_transforms/).
+The R equivalents live in [nat.flybrains](https://natverse.org/nat.flybrains/index.html),
 part of the natverse ([Bates et al., 2020](https://doi.org/10.7554/eLife.53350)).
 
 ## What it costs
 
-- **Chaining compounds error.** Each bridge is an approximation, and a route of four hops
-  applies four of them in series. A comparison made within one space is stronger evidence
-  than one made across a long path — and because the route is computed rather than
-  declared, it is worth checking how long it actually is before trusting a fine-grained
-  result.
+- **Chaining compounds error.** Each bridge is an approximation, and a four-hop route
+  applies four of them in series. The navis documentation is explicit that longer paths
+  risk greater spatial distortion. A comparison made within one space is stronger evidence
+  than one made across a long path — and since the route is computed rather than declared,
+  it is worth looking at how long it is before trusting a fine-grained result.
 - **Coverage is not uniform.** Transforms exist between the spaces people needed to
   connect. Some pairs are reachable only by a long path, and some not at all.
+- **Units must be consistent through the chain.** The unit-tagged spaces exist precisely
+  because this is the easy mistake to make.
 - **A bridged position is still an estimate.** See
-  [registration](/docs/concepts/registration/) for what that means for fine structures,
-  and [templates](/docs/data/templates/) for the spaces themselves.
+  [registration](/docs/concepts/registration/) for what that means for fine structures, and
+  [templates](/docs/data/templates/) for the spaces themselves.
+
+## Sources
+
+- navis-flybrains — [documentation and source](https://github.com/navis-org/navis-flybrains). Schlegel P, Court R. doi:10.5281/zenodo.4966640
+- navis — [transforms tutorial](https://navis-org.github.io/navis/stable/generated/gallery/6_misc/tutorial_misc_01_transforms/)
+- nat.flybrains — [documentation](https://natverse.org/nat.flybrains/index.html)
+- Bates AS et al. (2020) The natverse, a versatile toolbox for combining and analysing neuroanatomical data. *eLife* 9:e53350. doi:10.7554/eLife.53350

--- a/content/en/docs/Concepts/bridging.md
+++ b/content/en/docs/Concepts/bridging.md
@@ -1,15 +1,99 @@
 ---
 title: "Bridging Registrations"
 weight: 304
+date: 2026-08-18
 tag: [Template,Registration,Alignment,nat,navis,flybrains,Transforms]
 description: >
-  Transformations to map between different canonical Drosophila templates.
+  Transformations to map between different canonical Drosophila templates, and where VFB
+  keeps them.
 ---
 
-Many transforms to map between different Drosophila template brains are available.
+A [registration](/docs/concepts/registration/) puts one animal's image into a template's
+coordinate space. A **bridging registration** does something different: it maps one
+template space onto another, so data registered to different standards can still be
+compared.
+
+This matters because no single template ever won. Data on VFB arrives registered to
+whichever standard its producers used — JRC2018 unisex, JRC2018F or M, JFRC2, a
+connectome's own space such as the hemibrain or FAFB — and the only way to put a FlyWire
+neuron next to a split-GAL4 expression pattern is to bridge between them.
+
+## Where the transforms live
+
+VFB does not keep a private set of these. The bridging and mirroring transforms are
+maintained in the community packages — **navis-flybrains** for Python and
+**nat.flybrains** for R — so that the same transform is available to anyone, and everyone
+chaining between two spaces gets the same answer. A registration that only exists inside
+one resource is a registration nobody else can check.
+
+Between them these packages cover 30-odd template and connectome spaces — including
+JRC2018F/M/U, JFRC2, FAFB14, FlyWire, the hemibrain (JRCFIB2018F), maleCNS
+(JRCFIB2022M), MANC, FANC and BANC — and wrap several kinds of transform: CMTK
+registrations, H5 deformation fields, Elastix transforms and landmark-based mappings.
+Which underlying technology is used is mostly invisible in normal use.
 
 <p align="center">
 <img src="https://github.com/schlegelp/navis-flybrains/blob/main/_static/bridging_graph.png?raw=true" width="800">
 </p>
 
-You can see how to use the above in python using [navis-flybrains](https://navis.readthedocs.io/en/latest/source/tutorials/transforming.html) or in R using [nat.flybrains](https://natverse.org/nat.flybrains/index.html)
+## It is a graph, and the route is computed
+
+The picture above is not an illustration — it is the data structure. Each template space
+is a node, each registration an edge, and a conversion between two spaces is a **path**
+through it. Most useful pairs are not directly connected, so the transform you actually
+apply is usually a **sequence of several**, assembled on demand.
+
+The routing is what makes this practical:
+
+- **Shortest path, by weight.** Every edge carries a cost, and the route is the
+  cheapest path from source to target — not necessarily the one with fewest hops.
+  Lower weight wins.
+- **Edges can be traversed backwards.** Many registrations are invertible, so a
+  transform registered as A→B can be used to get from B to A. Running one in reverse
+  carries its own cost, so the router can be told to detour rather than go backwards.
+- **A purpose-built registration beats an inverted one.** Where two spaces are joined
+  both by a registration made for that direction and by the inverse of its counterpart,
+  the purpose-built one is used regardless of which is cheaper.
+- **Some hops are free.** Aliases — the same space under another name, or the same data
+  in different units — are registered at zero cost, so they never distort a route.
+- **A single registration may itself be multi-stage.** Some CMTK transforms need an
+  affine applied before or after the main warp; these are modelled as extra intermediate
+  nodes, so what looks like one edge can be several transforms deep.
+- **Units are explicit.** EM datasets are natively in nanometres or voxels rather than
+  microns, so their spaces are registered under unit-tagged names to stop a
+  correctly-routed transform silently producing a result off by a factor of a thousand.
+
+You can ask for the route before running it, and force it through a particular
+waystation if you need to.
+
+## Using them
+
+In Python, importing `flybrains` registers the transforms with
+[navis](https://navis.readthedocs.io/en/latest/source/tutorials/transforming.html), after
+which a conversion is one call:
+
+```python
+import navis, flybrains
+
+# run a conversion — the route is worked out for you
+navis.xform_brain(neuron, source='FAFB', target='JRC2018F')
+
+# or ask what it would do first
+navis.transforms.registry.shortest_bridging_seq(source='FAFB', target='JRC2018F')
+```
+
+In R the equivalent lives in [nat.flybrains](https://natverse.org/nat.flybrains/index.html),
+part of the natverse ([Bates et al., 2020](https://doi.org/10.7554/eLife.53350)).
+
+## What it costs
+
+- **Chaining compounds error.** Each bridge is an approximation, and a route of four hops
+  applies four of them in series. A comparison made within one space is stronger evidence
+  than one made across a long path — and because the route is computed rather than
+  declared, it is worth checking how long it actually is before trusting a fine-grained
+  result.
+- **Coverage is not uniform.** Transforms exist between the spaces people needed to
+  connect. Some pairs are reachable only by a long path, and some not at all.
+- **A bridged position is still an estimate.** See
+  [registration](/docs/concepts/registration/) for what that means for fine structures,
+  and [templates](/docs/data/templates/) for the spaces themselves.

--- a/content/en/docs/Concepts/cell_types.md
+++ b/content/en/docs/Concepts/cell_types.md
@@ -25,6 +25,12 @@ Neurons on VFB are annotated with cell types from the Drosophila Anatomy Ontolog
 
 We also use terms from the Drosophila Anatomy Ontology to annotate CNS regions (for the `Template ROI Browser` tool and neuron `connectivity per region` query) and other anatomical features.
 
+## What defines a cell type here
+
+A DAO cell type is not defined by a picture or by a name — it is defined by properties, and the classification follows from them. The worked example in the original schema paper is the DL1 adPN: an antennal lobe projection neuron whose soma sits in the antennal lobe cortex, with post-synaptic terminals in antennal lobe glomerulus DL1, pre-synaptic terminals in the lateral horn and the mushroom body calyx, developing from the antero-dorsal antennal lobe neuroblast. State those facts and a reasoner concludes, without anyone asserting it, that DL1 adPN is a subclass of adPN ([Osumi-Sutherland et al., 2012](https://doi.org/10.1093/bioinformatics/bts113)).
+
+The relations doing the work are a small set: `has_soma_location`, `fasciculates_with`, `has_synaptic_terminal_in` (with pre- and post-synaptic forms), `synapsed_to`, `upstream_in_neural_path_with`, `innervates` and `develops_from`, all layered on `part_of`. Because these propagate over the part hierarchy, a query aimed at a whole neuropil also returns neurons annotated against one of its subregions.
+
 ## What is in the ontology, and what is not
 
 The DAO admits a named class only where there is good scientific evidence for the presence of that structure in wild-type animals, with links to the literature supporting it; classes added in error have been obsoleted. Much of the hierarchy is not asserted by hand but inferred — `part_of` and `capable_of` relations combined with Gene Ontology process terms let a reasoner derive classifications, and disjointness axioms catch contradictions ([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)).

--- a/content/en/docs/Concepts/cell_types.md
+++ b/content/en/docs/Concepts/cell_types.md
@@ -24,3 +24,11 @@ Neurons on VFB are annotated with cell types from the Drosophila Anatomy Ontolog
 
 
 We also use terms from the Drosophila Anatomy Ontology to annotate CNS regions (for the `Template ROI Browser` tool and neuron `connectivity per region` query) and other anatomical features.
+
+## What is in the ontology, and what is not
+
+The DAO admits a named class only where there is good scientific evidence for the presence of that structure in wild-type animals, with links to the literature supporting it; classes added in error have been obsoleted. Much of the hierarchy is not asserted by hand but inferred — `part_of` and `capable_of` relations combined with Gene Ontology process terms let a reasoner derive classifications, and disjointness axioms catch contradictions ([Costa et al., 2013](https://doi.org/10.1186/2041-1480-4-32)).
+
+At the time of the VFB 2023 paper the ontology covered around 13,000 neuroanatomical structures and cell types, including over 9,800 terms for neuron types, curated from more than 1,000 papers; over 3,800 of those neuron types are predicted from connectomics data, and over 2,750 have curated lineage ([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)).
+
+For where the underlying data and the naming standards came from, see [which fly is this?](/about/whichfly/)

--- a/content/en/docs/Concepts/em-reconstruction.md
+++ b/content/en/docs/Concepts/em-reconstruction.md
@@ -1,0 +1,127 @@
+---
+title: "EM Imaging and Reconstruction"
+linkTitle: "EM Reconstruction"
+weight: 318
+date: 2026-08-18
+categories: ["overview","help"]
+tags: ["EM","ssTEM","FIB-SEM","segmentation","proofreading","connectome"]
+description: >
+  How a fly brain becomes a connectome — sectioning and imaging, segmentation,
+  proofreading and synapse detection — and what each step means for the data you query.
+---
+
+Every neuron and synapse in VFB's [EM datasets](/docs/data/em/) came out of the same
+four-stage pipeline: fix and section the tissue, image it at a resolution where synapses
+are visible, decide which voxels belong to which neuron, and decide which pairs of neurons
+are connected. Each stage introduces its own kind of error, and knowing which stage a
+number came from is most of what you need to interpret it.
+
+## 1. Imaging: two families of method
+
+To see a synapse you need roughly single-digit nanometre resolution in the imaging plane,
+across a volume hundreds of micrometres on a side. Two approaches get there.
+
+**Serial-section TEM (ssTEM).** The tissue is physically cut into ultrathin sections,
+which are then imaged in a transmission electron microscope. Parallel image formation
+makes TEM fast, which is why it scaled to whole brains first: FAFB was cut at 40 nm and
+imaged at 4 × 4 nm ([Bock et al., 2011](https://doi.org/10.1038/nature09802);
+[Zheng et al., 2018](https://doi.org/10.1016/j.cell.2018.06.019)). The cost is that
+sections can be lost, folded or distorted, and section thickness sets a coarse *z*
+resolution.
+
+**FIB-SEM.** A focused ion beam mills away a thin layer, the block face is imaged, and the
+cycle repeats — so there are no physical sections to lose and *z* resolution is close to
+isotropic. Historically it was too slow for large volumes; enhanced systems and
+"hot-knife" partitioning, which splits a brain into thick slabs that are imaged separately
+and stitched, made whole-region volumes practical
+([Hayworth et al., 2015](https://doi.org/10.1038/nmeth.3292);
+[Xu et al., 2017](https://doi.org/10.7554/eLife.25916)). The hemibrain, MANC and the optic
+lobe volumes are FIB-SEM. Serial block-face SEM
+([Denk and Horstmann, 2004](https://doi.org/10.1371/journal.pbio.0020329)) is the third
+member of the family, less used for these datasets.
+
+Which method was used is a property of the dataset and is listed on the
+[EM data](/docs/data/em/) page.
+
+## 2. Segmentation: which voxels are which neuron
+
+Early reconstruction was manual: a human traced a skeleton through the volume, node by
+node. CATMAID was built for exactly this, distributed across many annotators
+([Saalfeld et al., 2009](https://doi.org/10.1093/bioinformatics/btp266);
+[Schneider-Mizell et al., 2016](https://doi.org/10.7554/eLife.12059)), and VFB
+[hosts CATMAID instances](/hosted/) for several of these datasets — in some cases as the
+only remaining public copy.
+
+Manual tracing does not scale to a whole brain, so modern reconstructions are automatic
+first. Flood-filling networks segment neurons by iteratively growing a predicted object
+through the volume ([Januszewski et al., 2018](https://doi.org/10.1038/s41592-018-0049-4)).
+The output is never correct as produced: it contains **splits** (one neuron broken into
+fragments) and **merges** (two neurons fused into one). Human **proofreading** then
+corrects it, which for FlyWire was organised as a community effort over the FAFB volume
+([Dorkenwald et al., 2022](https://doi.org/10.1038/s41592-021-01330-0);
+[Dorkenwald et al., 2024](https://doi.org/10.1038/s41586-024-07558-y)).
+
+This is why **dense** and **sparse** reconstruction mean very different things:
+
+- **Dense** — the whole volume is segmented, so the dataset aims to contain every neuron.
+- **Sparse** — only neurons someone chose to trace exist in the dataset. Absence of a
+  neuron says nothing about the animal.
+
+## 3. Synapse detection: which neurons are connected
+
+Synapses are annotated separately from morphology. In the fly they are identified from
+ultrastructure — a presynaptic T-bar and the postsynaptic profiles opposite it — and, at
+whole-brain scale, by classifiers rather than by eye
+([Buhmann et al., 2021](https://doi.org/10.1038/s41592-021-01183-7)).
+
+Two consequences worth carrying:
+
+- **An edge is a count of detected synapses**, subject to both false positives and misses.
+  Weak edges (one or two synapses) are the least reliable and are commonly thresholded
+  out. See [connectivity data](/docs/data/connectivity/) for what an edge means in VFB.
+- **Connectivity inherits segmentation error.** A merge invents connections that the
+  animal does not have; a split divides one neuron's connections between two objects.
+
+## 4. Neurotransmitter prediction
+
+The sign of a connection is not visible in the wiring diagram. Networks trained on EM
+image features at presynaptic sites predict transmitter identity, reported at 87% accuracy
+per synapse, 94% per neuron and 91% per known cell type across a whole-brain dataset
+([Eckstein et al., 2024](https://doi.org/10.1016/j.cell.2024.03.016)). These are
+**predictions**, and VFB labels them as such — see
+[confidence values](/docs/concepts/confidence-value/).
+
+## What this means for the data you query
+
+- **Neuron identity is per-release.** Proofreading continues after publication, so
+  identifiers and counts change between versions; see
+  [connectome versioning](/docs/data/em/versioning/).
+- **Counting across datasets double-counts.** FlyWire, the hemibrain and FAFB (CATMAID)
+  are reconstructions of overlapping tissue — in the first two cases, of the same
+  anatomical region in different animals. [Neuron counts](/docs/concepts/neuron-counts/)
+  works through this in detail.
+- **Cell typing is added, not observed.** The type attached to an EM neuron is an
+  annotation made by matching morphology and connectivity against known types
+  ([Schlegel et al., 2024](https://doi.org/10.1038/s41586-024-07686-5)); see
+  [cell types](/docs/concepts/cell_types/).
+- **The specimen matters.** Each volume is one individual of a particular sex, age and
+  genotype — see [which fly is this?](/about/whichfly/).
+
+## Sources
+
+- Denk W, Horstmann H (2004) Serial block-face scanning electron microscopy to reconstruct three-dimensional tissue nanostructure. *PLoS Biol* 2(11):e329. doi:10.1371/journal.pbio.0020329
+- Saalfeld S et al. (2009) CATMAID: collaborative annotation toolkit for massive amounts of image data. *Bioinformatics* 25:1984–1986. doi:10.1093/bioinformatics/btp266
+- Bock DD et al. (2011) Network anatomy and in vivo physiology of visual cortical neurons. *Nature* 471:177–182. doi:10.1038/nature09802
+- Cardona A et al. (2012) TrakEM2 software for neural circuit reconstruction. *PLoS ONE* 7(6):e38011. doi:10.1371/journal.pone.0038011
+- Hayworth KJ et al. (2015) Ultrastructurally smooth thick partitioning and volume stitching for large-scale connectomics. *Nat Methods* 12:319–322. doi:10.1038/nmeth.3292
+- Schneider-Mizell CM et al. (2016) Quantitative neuroanatomy for connectomics in *Drosophila*. *eLife* 5:e12059. doi:10.7554/eLife.12059
+- Xu CS et al. (2017) Enhanced FIB-SEM systems for large-volume 3D imaging. *eLife* 6:e25916. doi:10.7554/eLife.25916
+- Januszewski M et al. (2018) High-precision automated reconstruction of neurons with flood-filling networks. *Nat Methods* 15:605–610. doi:10.1038/s41592-018-0049-4
+- Zheng Z et al. (2018) A complete electron microscopy volume of the brain of adult *Drosophila melanogaster*. *Cell* 174(3):730–743. doi:10.1016/j.cell.2018.06.019
+- Scheffer LK et al. (2020) A connectome and analysis of the adult *Drosophila* central brain. *eLife* 9:e57443. doi:10.7554/eLife.57443
+- Buhmann J et al. (2021) Automatic detection of synaptic partners in a whole-brain *Drosophila* electron microscopy data set. *Nat Methods* 18:771–774. doi:10.1038/s41592-021-01183-7
+- Dorkenwald S et al. (2022) FlyWire: online community for whole-brain connectomics. *Nat Methods* 19:119–128. doi:10.1038/s41592-021-01330-0
+- Plaza SM et al. (2022) neuPrint: an open access tool for EM connectomics. *Front Neuroinform* 16:896292. doi:10.3389/fninf.2022.896292
+- Eckstein N et al. (2024) Neurotransmitter classification from electron microscopy images at synaptic sites in *Drosophila melanogaster*. *Cell* 187:2574–2594. doi:10.1016/j.cell.2024.03.016
+- Dorkenwald S et al. (2024) Neuronal wiring diagram of an adult brain. *Nature* 634:124–138. doi:10.1038/s41586-024-07558-y
+- Schlegel P et al. (2024) Whole-brain annotation and multi-connectome cell typing of *Drosophila*. *Nature* 634:139–152. doi:10.1038/s41586-024-07686-5

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -104,6 +104,12 @@ mirroring registration, and bridging transforms are used wherever possible to br
 from external templates, or from one VFB template to another, into a common space
 ([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)).
 
+Those bridging transforms are not kept privately. VFB works through **navis-flybrains** and
+its R counterpart **nat.flybrains** so that the registrations are available to everyone and
+consistent between users — the same transform, giving the same answer, whether it is
+applied inside VFB or in someone's own analysis. See
+[bridging registrations](/docs/concepts/bridging/).
+
 The point of all this is comparison at scale: VFB's main adult brain template carries
 almost 100,000 cross-registered images from 64 datasets — EM reconstructions, single
 neurons, lineage clones and expression patterns — in one coordinate space. Every image is

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -36,13 +36,15 @@ The transformation is found in stages of increasing freedom:
    structures into correspondence.
 
 The non-rigid step is what actually does the work, and it is why registration is expensive
-and imperfect. Two toolkits dominate fly registration: **CMTK**, whose B-spline non-rigid
-implementation was developed with fly brains among its target applications
-([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506)), and **ANTs**, whose
-symmetric diffeomorphic model (SyN) guarantees an invertible transformation
-([Avants et al., 2008](https://doi.org/10.1016/j.media.2007.06.004)). The approach was
-established for *Drosophila* olfactory anatomy by
-[Jefferis et al. (2007)](https://doi.org/10.1016/j.cell.2007.01.040).
+and imperfect. Two toolkits dominate fly registration. **CMTK** is the more common; the
+paper usually cited for it describes a parallel implementation of non-rigid registration,
+demonstrated on clinical and other biomedical problems rather than on flies
+([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506)) — it was
+[Jefferis et al. (2007)](https://doi.org/10.1016/j.cell.2007.01.040) who established the
+approach for *Drosophila*, registering brains to a common template to build comparable maps
+of olfactory projections. **ANTs** is the other, whose symmetric diffeomorphic model (SyN)
+yields an invertible transformation
+([Avants et al., 2008](https://doi.org/10.1016/j.media.2007.06.004)).
 
 ## Why templates are built from many brains
 

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -98,7 +98,7 @@ comparison across two bridges is weaker evidence than one within a single space.
 ## What VFB actually does
 
 Most data arrives already registered by the group that produced it. Where it does not, VFB
-registers it with **CMTK, using nine degrees of freedom followed by a non-rigid
+currently registers it with **CMTK, using nine degrees of freedom followed by a non-rigid
 registration**. Data can be moved to one side of the brain by flipping and applying a
 mirroring registration, and bridging transforms are used wherever possible to bring images
 from external templates, or from one VFB template to another, into a common space

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -1,0 +1,110 @@
+---
+title: "Image Registration"
+linkTitle: "Registration"
+weight: 305
+date: 2026-08-18
+categories: ["overview","help"]
+tags: ["Registration","Template","Alignment","CMTK","ANTs","JRC2018"]
+description: >
+  How an image of one fly's brain is warped onto a standard template, why VFB depends on
+  it, and what it costs in accuracy.
+---
+
+No two fly brains are the same shape. Two confocal stacks of the same driver line, from
+two animals, differ in size, orientation and local geometry — enough that voxel *(x, y,
+z)* in one is not the same anatomical place as voxel *(x, y, z)* in the other.
+
+**Registration** is the step that fixes this: computing a spatial transformation that maps
+each sample onto a common [template](/docs/data/templates/). It is the single operation
+that makes VFB possible. Without it, an expression pattern from one lab and a neuron from
+another are two unrelated pictures; with it, they are two objects in one coordinate space
+that can be overlaid, scored for overlap and searched against each other.
+
+## How it works
+
+Registration is driven by a **reference channel** rather than by the signal you care
+about. In fly work that is usually a neuropil counterstain — anti-Bruchpilot (nc82) is the
+standard — which looks broadly the same in every animal and therefore gives the algorithm
+something stable to match. The transformation computed from that channel is then applied
+to the signal channel.
+
+The transformation is found in stages of increasing freedom:
+
+1. **Rigid** — rotate and translate to correct mounting orientation.
+2. **Affine** — add scaling and shear to correct overall size and proportion.
+3. **Non-rigid (deformable)** — a smooth, spatially varying warp that brings individual
+   structures into correspondence.
+
+The non-rigid step is what actually does the work, and it is why registration is expensive
+and imperfect. Two toolkits dominate fly registration: **CMTK**, whose B-spline non-rigid
+implementation was developed with fly brains among its target applications
+([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506)), and **ANTs**, whose
+symmetric diffeomorphic model (SyN) guarantees an invertible transformation
+([Avants et al., 2008](https://doi.org/10.1016/j.media.2007.06.004)). The approach was
+established for *Drosophila* olfactory anatomy by
+[Jefferis et al. (2007)](https://doi.org/10.1016/j.cell.2007.01.040).
+
+## Why templates are built from many brains
+
+Registering to a single individual's brain bakes that individual's idiosyncrasies into
+every result. Modern templates are therefore **averages**, built by groupwise registration
+of many samples so that no one animal dominates.
+
+JRC2018, the current standard, was constructed this way: 36 female and 26 male individuals
+for the sex-specific central brain templates, and 62 individuals — 124 images counting
+left–right flips — for the unisex template
+([Bogovic et al., 2020](https://doi.org/10.1371/journal.pone.0236495)). Earlier standards
+such as JFRC2010 were single representative brains, which is part of why registration onto
+them is less accurate.
+
+The templates VFB uses, and the painted neuropil domains in each, are listed on the
+[Templates](/docs/data/templates/) page.
+
+## Two registrations, not one
+
+It is worth keeping these separate, because they fail differently:
+
+| | Sample registration | [Bridging registration](/docs/concepts/bridging/) |
+|---|---|---|
+| Maps | One animal's image → a template | One template → another template |
+| Computed | Per image, by the data producer | Once, and reused |
+| Driven by | The sample's reference channel | The two templates themselves |
+| Typical failure | Poor stain, damaged tissue, unusual morphology | Accumulated error when chaining transforms |
+
+Data arrives on VFB already registered by the group that produced it, to whichever
+template that group used. Bridging transforms are what let a neuron registered to one
+template be compared against data in another; chaining several compounds the error, so a
+comparison across two bridges is weaker evidence than one within a single space.
+
+## What registration costs you
+
+- **A registered neuron is an estimate.** Its position in template space is where the warp
+  put it, not where it was in its own brain. Fine structures — thin neurites, small
+  boutons — move most.
+- **Accuracy is not uniform.** Registration is generally better in large, well-stained
+  neuropils than at the brain surface, in the optic lobes, or anywhere the sample was
+  torn or compressed during dissection.
+- **Overlap is not contact.** Two registered objects occupying the same template voxels
+  are near each other in a common space. That is a hypothesis about connectivity, not
+  evidence of a synapse; for that you need EM
+  ([connectivity data](/docs/data/connectivity/)).
+- **EM volumes need their own alignment.** Bringing an EM reconstruction into a light
+  microscopy template space is a separate, harder problem than registering one confocal
+  stack to another, and the transforms involved are listed with the
+  [templates](/docs/data/templates/).
+
+## Working with it
+
+Transforms between the common fly template spaces are packaged for programmatic use in
+the natverse ecosystem — `nat.templatebrains` and `navis-flybrains` — described in
+[Bates et al. (2020)](https://doi.org/10.7554/eLife.53350). VFB's own
+[APIs](/docs/apis/) return coordinates in template space, and the
+[bridging registrations](/docs/concepts/bridging/) page shows which conversions exist.
+
+## Sources
+
+- Rohlfing T, Maurer CR (2003) Nonrigid image registration in shared-memory multiprocessor environments with application to brains, breasts, and bees. *IEEE Trans Inf Technol Biomed* 7:16–25. doi:10.1109/TITB.2003.808506
+- Jefferis GSXE et al. (2007) Comprehensive maps of *Drosophila* higher olfactory centers: spatially segregated fruit and pheromone representation. *Cell* 128:1187–1203. doi:10.1016/j.cell.2007.01.040
+- Avants BB et al. (2008) Symmetric diffeomorphic image registration with cross-correlation. *Med Image Anal* 12:26–41. doi:10.1016/j.media.2007.06.004
+- Bates AS et al. (2020) The natverse, a versatile toolbox for combining and analysing neuroanatomical data. *eLife* 9:e53350. doi:10.7554/eLife.53350
+- Bogovic JA et al. (2020) An unbiased template of the *Drosophila* brain and ventral nerve cord. *PLoS ONE* 15(12):e0236495. doi:10.1371/journal.pone.0236495

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -95,6 +95,22 @@ comparison across two bridges is weaker evidence than one within a single space.
   stack to another, and the transforms involved are listed with the
   [templates](/docs/data/templates/).
 
+## What VFB actually does
+
+Most data arrives already registered by the group that produced it. Where it does not, VFB
+registers it with **CMTK, using nine degrees of freedom followed by a non-rigid
+registration**. Data can be moved to one side of the brain by flipping and applying a
+mirroring registration, and bridging transforms are used wherever possible to bring images
+from external templates, or from one VFB template to another, into a common space
+([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)).
+
+The point of all this is comparison at scale: VFB's main adult brain template carries
+almost 100,000 cross-registered images from 64 datasets — EM reconstructions, single
+neurons, lineage clones and expression patterns — in one coordinate space. Every image is
+given a persistent, resolvable VFB URL, which matters because local identifiers from
+source resources are not globally unique; the CATMAID instances VFB hosts have clashing
+neuron IDs between them.
+
 ## Working with it
 
 Transforms between the common fly template spaces are packaged for programmatic use in
@@ -110,3 +126,4 @@ the natverse ecosystem — `nat.templatebrains` and `navis-flybrains` — descri
 - Avants BB et al. (2008) Symmetric diffeomorphic image registration with cross-correlation. *Med Image Anal* 12:26–41. doi:10.1016/j.media.2007.06.004
 - Bates AS et al. (2020) The natverse, a versatile toolbox for combining and analysing neuroanatomical data. *eLife* 9:e53350. doi:10.7554/eLife.53350
 - Bogovic JA et al. (2020) An unbiased template of the *Drosophila* brain and ventral nerve cord. *PLoS ONE* 15(12):e0236495. doi:10.1371/journal.pone.0236495
+- Court R et al. (2023) Virtual Fly Brain — an interactive atlas of the *Drosophila* nervous system. *Front Physiol* 14:1076533. doi:10.3389/fphys.2023.1076533

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -104,11 +104,12 @@ mirroring registration, and bridging transforms are used wherever possible to br
 from external templates, or from one VFB template to another, into a common space
 ([Court et al., 2023](https://doi.org/10.3389/fphys.2023.1076533)).
 
-Those bridging transforms are not kept privately. VFB works through **navis-flybrains** and
-its R counterpart **nat.flybrains** so that the registrations are available to everyone and
-consistent between users — the same transform, giving the same answer, whether it is
-applied inside VFB or in someone's own analysis. See
-[bridging registrations](/docs/concepts/bridging/).
+Those bridging transforms are not kept privately. VFB publishes them through
+[**navis-flybrains**](https://github.com/navis-org/navis-flybrains) and its R counterpart
+[**nat.flybrains**](https://natverse.org/nat.flybrains/index.html), where they are a named
+set retrievable with `flybrains.download_vfb_transforms()`. The point is that the same
+transform gives the same answer whether it runs inside VFB or in someone else's analysis.
+See [bridging registrations](/docs/concepts/bridging/).
 
 The point of all this is comparison at scale: VFB's main adult brain template carries
 almost 100,000 cross-registered images from 64 datasets — EM reconstructions, single
@@ -120,10 +121,13 @@ neuron IDs between them.
 ## Working with it
 
 Transforms between the common fly template spaces are packaged for programmatic use in
-the natverse ecosystem — `nat.templatebrains` and `navis-flybrains` — described in
-[Bates et al. (2020)](https://doi.org/10.7554/eLife.53350). VFB's own
-[APIs](/docs/apis/) return coordinates in template space, and the
-[bridging registrations](/docs/concepts/bridging/) page shows which conversions exist.
+[navis-flybrains](https://github.com/navis-org/navis-flybrains) for Python and the natverse
+packages `nat.templatebrains` / `nat.flybrains` for R
+([Bates et al., 2020](https://doi.org/10.7554/eLife.53350)); the
+[navis transforms tutorial](https://navis-org.github.io/navis/stable/generated/gallery/6_misc/tutorial_misc_01_transforms/)
+covers applying them. VFB's own [APIs](/docs/apis/) return coordinates in template space,
+and the [bridging registrations](/docs/concepts/bridging/) page shows which conversions
+exist and how a route between two spaces is chosen.
 
 ## Sources
 

--- a/content/en/docs/Concepts/splits.md
+++ b/content/en/docs/Concepts/splits.md
@@ -10,6 +10,8 @@ description: >
 
 Split drivers comprise at least two partial transcription factors that can reconstitute an active transcription factor when expressed in the same cell. By using different regulatory regions for each component, functional driver expression can be restricted to the intersection of the expression patterns of these regulatory regions. A wide range of regulatory regions have been combined with transcription factor DNA binding domains (DBDs) and Activation Domains (ADs) to form thousands of distinct constructs, referred to as hemidrivers. Millions of combinations are therefore possible, each targeting some precise subset of the many thousands of neurons in the Drosophila nervous system.
 
+Finding the useful ones is the hard part. The Janelia resource reports 3,060 cell-type-specific split-GAL4 lines for the adult CNS and 1,373 characterised in third-instar larvae, identified by examining over 77,000 split combinations between 2013 and 2023 ([Meissner et al., 2025](https://doi.org/10.7554/eLife.98405)). For the underlying method see [binary expression systems](/docs/concepts/binary-expression/).
+
 <img src="/images/splits_images.png" max-width="50%" alt="A split-GAL4 expression pattern at the intersection of the expression patterns of two hemidrivers.">
 
 Researchers can identify split drivers for neurons of interest from the `Targeting Splits` section of a cell type [Term Info](/docs/website-features/terminfo) page or by using [similarity scores](/docs/tutorials/website/similarityscore/) from a single neuron image. It is also possible to [search](/docs/website-features/search_query) directly for particular hemidrivers and combinations.

--- a/content/en/docs/Concepts/stochastic-labelling.md
+++ b/content/en/docs/Concepts/stochastic-labelling.md
@@ -22,23 +22,28 @@ from, and it is what makes LM morphologies comparable against EM reconstructions
 
 ## The mechanism
 
-All of these methods use site-specific recombination. The FLP recombinase excises or
-swaps DNA between FRT sites
-([Golic and Lindquist, 1989](https://doi.org/10.1016/0092-8674(89)90033-0)). Give FLP only
-a brief window or a weak promoter and it acts in some cells and not others — the
-randomness is the point.
+All of these methods use site-specific recombination. Golic and Lindquist moved the yeast
+FLP recombinase and its FRT target sites into *Drosophila*, put FLP under *hsp70* control,
+and flanked a *white* gene with FRTs: heat shock triggered recombination, read out as
+white patches in the eye, with the frequency of events varying with the severity of the
+heat shock and the pattern of mosaicism with the stage at which it was applied
+([Golic and Lindquist, 1989](https://doi.org/10.1016/0092-8674(89)90033-0)). That is the
+whole basis of the methods below — give FLP only a brief window and it acts in some cells
+and not others. The randomness is the point.
 
 **FLP-out.** A transcription-terminating cassette flanked by FRT sites sits between the
 promoter and the reporter. The reporter is silent until FLP removes the cassette. Because
 excision is stochastic, only some cells in the driver's pattern ever express it.
 
-**MARCM** (Mosaic Analysis with a Repressible Cell Marker) uses mitotic recombination at
-an FRT to produce, from a heterozygous dividing cell, one daughter homozygous for the
-absence of GAL80. Only that daughter and its progeny lose GAL4 repression and become
-labelled ([Lee and Luo, 1999](https://doi.org/10.1016/S0896-6273(00)80701-1)). Because the
-event happens at a cell division, the labelled unit is a **clone** — a neuroblast and its
-progeny — which is why MARCM is the standard method for lineage work, and why VFB holds
-clonal as well as single-cell images.
+**MARCM** (Mosaic Analysis with a Repressible Cell Marker) puts a dominant repressor of a
+cell marker — GAL80 — in *trans* to the mutant gene of interest. Mitotic recombination
+between homologous chromosomes generates homozygous mutant cells, and those cells are
+"exclusively labeled due to loss of the repressor"
+([Lee and Luo, 1999](https://doi.org/10.1016/S0896-6273(00)80701-1)). Because the event
+happens at a cell division, the labelled unit is a **clone**: Lee and Luo used it to
+visualise both "large neuroblast clones and single neuron clones" with membrane-targeted
+GFP. That is why MARCM is the standard method for lineage work, and why VFB holds clonal
+as well as single-cell images.
 
 **MCFO** (MultiColor FlpOut) extends FLP-out with several differently epitope-tagged,
 membrane-targeted reporters, each behind its own excisable cassette. Different cells end

--- a/content/en/docs/Concepts/stochastic-labelling.md
+++ b/content/en/docs/Concepts/stochastic-labelling.md
@@ -1,0 +1,83 @@
+---
+title: "Stochastic Labelling and Clonal Analysis"
+linkTitle: "Stochastic Labelling"
+weight: 315
+date: 2026-08-18
+categories: ["overview","help"]
+tags: ["MCFO","MARCM","FLP-out","clone","single neuron","Expression_pattern"]
+description: >
+  How single neurons and clones are picked out of a driver's whole expression pattern —
+  FLP-out, MARCM and MCFO — and what that means for the single-neuron images on VFB.
+---
+
+A driver line labels a population. Most of the interesting anatomy is in the individual
+neurons inside it, and a confocal stack of fifty overlapping cells will not give you the
+shape of any one of them. Stochastic labelling solves this by making the labelling event
+itself random and rare, so that a small, resolvable subset of the population lights up in
+each animal.
+
+This is where a large fraction of the **single-neuron light microscopy** on VFB comes
+from, and it is what makes LM morphologies comparable against EM reconstructions by
+[NBLAST](/docs/concepts/nblast/).
+
+## The mechanism
+
+All of these methods use site-specific recombination. The FLP recombinase excises or
+swaps DNA between FRT sites
+([Golic and Lindquist, 1989](https://doi.org/10.1016/0092-8674(89)90033-0)). Give FLP only
+a brief window or a weak promoter and it acts in some cells and not others — the
+randomness is the point.
+
+**FLP-out.** A transcription-terminating cassette flanked by FRT sites sits between the
+promoter and the reporter. The reporter is silent until FLP removes the cassette. Because
+excision is stochastic, only some cells in the driver's pattern ever express it.
+
+**MARCM** (Mosaic Analysis with a Repressible Cell Marker) uses mitotic recombination at
+an FRT to produce, from a heterozygous dividing cell, one daughter homozygous for the
+absence of GAL80. Only that daughter and its progeny lose GAL4 repression and become
+labelled ([Lee and Luo, 1999](https://doi.org/10.1016/S0896-6273(00)80701-1)). Because the
+event happens at a cell division, the labelled unit is a **clone** — a neuroblast and its
+progeny — which is why MARCM is the standard method for lineage work, and why VFB holds
+clonal as well as single-cell images.
+
+**MCFO** (MultiColor FlpOut) extends FLP-out with several differently epitope-tagged,
+membrane-targeted reporters, each behind its own excisable cassette. Different cells end
+up with different tag combinations, so neighbouring neurons are separable by colour as
+well as by sparseness ([Nern et al., 2015](https://doi.org/10.1073/pnas.1506763112)). Using
+two recombinases lets the number of labelled cells and the number of colour combinations
+be tuned independently. Most of the Janelia single-neuron imagery on VFB is MCFO.
+
+## Reading a stochastic image on VFB
+
+- **The cell was chosen by chance, not by identity.** A single-neuron image tells you the
+  morphology of one cell that happened to be labelled within a driver's pattern. Which
+  cell type it is, is a downstream judgement — see [cell types](/docs/concepts/cell_types/).
+- **Sparse does not mean single.** An image may contain two or three faintly overlapping
+  cells. VFB records what was segmented; check the image before treating a morphology as
+  one neuron.
+- **A clone is a developmental unit, not a cell type.** MARCM clones group neurons by
+  shared lineage. Neurons in one clone may belong to several types, and one type may be
+  split across clones.
+- **Coverage is biased by the driver.** You can only label stochastically within a pattern
+  that the driver already produces, so cell types with no good driver are
+  under-represented in the LM data regardless of how sparse the labelling is.
+- **It is still one animal.** As with everything else on VFB, comparison across animals is
+  possible because the images are [registered](/docs/concepts/registration/) to a common
+  [template](/docs/data/templates/).
+
+## Where it fits
+
+| Question | Method | On VFB |
+|---|---|---|
+| What does this driver label? | Whole-pattern imaging | [Expression patterns](/docs/concepts/binary-expression/) |
+| Can I get a driver for just this cell type? | Split-GAL4 intersection | [Split driver expression](/docs/concepts/splits/) |
+| What does one of these cells look like? | FLP-out, MCFO | This page |
+| Which cells share a lineage? | MARCM clones | This page |
+| Is this LM neuron the same as that EM neuron? | Morphological comparison | [NBLAST](/docs/concepts/nblast/) |
+
+## Sources
+
+- Golic KG, Lindquist S (1989) The FLP recombinase of yeast catalyzes site-specific recombination in the *Drosophila* genome. *Cell* 59:499–509. doi:10.1016/0092-8674(89)90033-0
+- Lee T, Luo L (1999) Mosaic analysis with a repressible cell marker for studies of gene function in neuronal morphogenesis. *Neuron* 22:451–461. doi:10.1016/S0896-6273(00)80701-1
+- Nern A, Pfeiffer BD, Rubin GM (2015) Optimized tools for multicolor stochastic labeling reveal diverse stereotyped cell arrangements in the fly visual system. *PNAS* 112:E2967–E2976. doi:10.1073/pnas.1506763112
+- Costa M et al. (2016) NBLAST: rapid, sensitive comparison of neuronal structure and construction of neuron family databases. *Neuron* 91:293–311. doi:10.1016/j.neuron.2016.06.012

--- a/content/en/docs/Concepts/transgene.md
+++ b/content/en/docs/Concepts/transgene.md
@@ -12,3 +12,7 @@ description: >
 
 Virtual Fly Brain (VFB) and FlyBase curators record information from the literature about the expression of single transgenes using ontology terms and load this into FlyBase. VFB combines curated expression, genetic and publication data from FlyBase with 3D images of the expression patterns aligned to standard [templates](/docs/data/templates/). These annotated images can then be searched and queried via the [web interface](/docs/website-features/search_query/) or [APIs](/docs/apis/).
 
+This arrangement goes back to the start of the project. VFB has run "a full instance of the FlyBase CHADO Postgres database, kept in sync with the FlyBase update cycle", since its first release, and the traffic is not one-way: the VFB project "extended the annotation of transgene expression in FlyBase for the adult brain to a near comprehensive set of published transgenes" ([Milyaev et al., 2012](https://doi.org/10.1093/bioinformatics/btr677)). Curation done for VFB lands in FlyBase, which is why the transgene record you reach from an image on VFB is the same record a geneticist would cite.
+
+For what a driver line is and how these patterns are produced, see [binary expression systems](/docs/concepts/binary-expression/); for what "expression pattern" means formally on VFB — and why a single-neuron image is a *fragment* of one — see the same page.
+

--- a/content/en/docs/Concepts/transgene.md
+++ b/content/en/docs/Concepts/transgene.md
@@ -12,7 +12,5 @@ description: >
 
 Virtual Fly Brain (VFB) and FlyBase curators record information from the literature about the expression of single transgenes using ontology terms and load this into FlyBase. VFB combines curated expression, genetic and publication data from FlyBase with 3D images of the expression patterns aligned to standard [templates](/docs/data/templates/). These annotated images can then be searched and queried via the [web interface](/docs/website-features/search_query/) or [APIs](/docs/apis/).
 
-This arrangement goes back to the start of the project. VFB has run "a full instance of the FlyBase CHADO Postgres database, kept in sync with the FlyBase update cycle", since its first release, and the traffic is not one-way: the VFB project "extended the annotation of transgene expression in FlyBase for the adult brain to a near comprehensive set of published transgenes" ([Milyaev et al., 2012](https://doi.org/10.1093/bioinformatics/btr677)). Curation done for VFB lands in FlyBase, which is why the transgene record you reach from an image on VFB is the same record a geneticist would cite.
-
 For what a driver line is and how these patterns are produced, see [binary expression systems](/docs/concepts/binary-expression/); for what "expression pattern" means formally on VFB — and why a single-neuron image is a *fragment* of one — see the same page.
 


### PR DESCRIPTION
## What

A new About page, `/about/whichfly/`, answering the question its title asks: which animal
the data on VFB actually came from, and the century of genetics that makes it
interpretable. Plus four new technique pages the docs were assuming without explaining,
and additions to four existing ones.

## The specimens

Every flagship EM volume on VFB is the F1 of a cross between wild-type Canton-S strain G1
and w1118. Genotypes taken from each paper's methods, not from recall:

| Volume | Stage and sex | Age |
|---|---|---|
| FAFB / FlyWire | Adult female | 7 days post-eclosion |
| Hemibrain | Adult female | 5 days post-eclosion |
| MANC | Adult male | 5 days post-eclosion |
| Optic lobe | Adult male | 5 days post-eclosion |
| male-CNS | Adult male | 5 days post-eclosion |
| BANC | Adult female | 5–6 days post-eclosion |
| L1 larval CNS | First-instar female | 6 hours after hatching |

Two findings from those methods sections that are not documented anywhere on the site:

- **The optic lobe and male-CNS connectomes are the same individual fly.** Both papers name
  the specimen `Z0720-07m`, best of 44 preparations screened by X-ray CT; the male-CNS paper
  calls the optic lobe work "an earlier study of the same sample". Consistent with what
  `concepts/neuron-counts` already says about double-counting.
- **The BANC fly was selected for its behaviour** — it "turned right 70% of the time over
  582 choices when walking in an acrylic Y-maze", at the "97th percentile for handedness in
  the population (n = 1,095)". A documented outlier on a measured axis, not a random draw.

## The genotype, from FlyBase

- Canton-S ([FBsn0000274](https://flybase.org/reports/FBsn0000274)) — "selected by C. Bridges",
  who "found that salivary chromosomes were normal"; still distributed by Bloomington (64349)
  and Kyoto (105666).
- w1118 ([FBal0018186](https://flybase.org/reports/FBal0018186)) — loss of function,
  spontaneous, "partial deletion of the w locus" (Hazelrigg et al., 1984).
- P{GawB} ([FBtp0000352](https://flybase.org/reports/FBtp0000352)) — marked with
  mini-white, w[+mW.hs].

Which makes a point the docs never stated: a white+ marker can only be scored in a
white-mutant animal, so driver genotypes read `w[1118];P{w[+mW.hs]=GawB}…` and Morgan's
1910 mutant is still the readout for successful transformation.

## New technique pages

| Page | Why it was missing |
|---|---|
| `concepts/binary-expression/` | GAL4/UAS was explained nowhere, though `splits` and `transgene` both assume it |
| `concepts/stochastic-labelling/` | FLP-out, MARCM and MCFO produce most single-neuron LM data; only mentioned in passing |
| `concepts/registration/` | `bridging` covered template↔template only. Sample→template — the step VFB depends on — had no page |
| `concepts/em-reconstruction/` | `data/em/` lists datasets but not how a volume becomes a connectome |

## Existing pages extended

- **`concepts/bridging/`** — was 53 words and an image. Now describes what the image is: a
  graph whose edges are registrations and whose routes are computed, with the rules that
  govern them (shortest path by weight, invertible edges, purpose-built beating inverted,
  zero-cost aliases, multi-stage CMTK edges, unit-tagged EM spaces). Documents that VFB
  publishes its registrations through navis-flybrains — `flybrains.download_vfb_transforms()`
  — and nat.flybrains, so the same transform gives the same answer for everyone. Sourced to
  the navis and flybrains documentation.
- **`concepts/registration/`** — now describes VFB's actual practice and points at the
  shared transform packages rather than implying VFB keeps a private set.
- **`concepts/cell_types/`** — what actually defines a DAO cell type, using the DL1 adPN
  worked example: state soma location, synaptic terminals and lineage, and a reasoner
  derives the classification.
- **`concepts/splits/`** — the scale of the split-GAL4 effort: 3,060 lines for the adult
  CNS and 1,373 in larvae, from over 77,000 combinations examined.
- **`concepts/FlyLight_tiles/`** — the Meissner resource is published (eLife 13:RP98405);
  citation updated from the preprint.

## Sourcing

Around 80 citations. Every DOI was resolved through the Crossref API and the returned title
checked against the claim it supports; four early candidates resolved to unrelated papers
and were removed before commit. Specimen details come from the papers' own methods text,
FlyBase claims from the record source rather than a summary of it, and the VFB material from
reading Milyaev 2012, Osumi-Sutherland 2012, Costa 2013, Osumi-Sutherland 2014 and
Court 2023 rather than citing them unread.

Where a paper described architecture rather than history, it is quoted as of its date or
omitted — the 2012 description of the FlyBase integration was written and then removed for
exactly this reason.

## Testing

Hugo builds clean, 192 → 198 pages. 918 internal links checked across the new and edited
pages, 0 broken. All external links resolve. Rendered in a browser: no console errors,
tables, superscript genotypes and the bridging graph all display correctly.
