### PR TITLE
Add the Heinze quote to the papers-citing-vfb page

### DIFF
--- a/content/en/about/papers-citing-vfb.md
+++ b/content/en/about/papers-citing-vfb.md
@@ -341,7 +341,9 @@ Last author: Benoit Petit-Demoulière, University of Strasbourg, France
 
 ### Heinze S et al. — *eLife (2021)*
 
-Described VFB as the main repository for Drosophila anatomical data and the model for what a unified insect-neuroscience platform should provide.
+Described VFB as the main repository for Drosophila anatomical data and the model for what a unified insect-neuroscience platform should provide. This is the paper introducing the Insect Brain Database, with which VFB cross-links across species.
+
+> "…the main site to locate GAL4 driver lines, single-cell morphologies, and synaptic connectivity data."
 
 Heinze S, El Jundi B, Berg BG, Homberg U, Menzel R, Pfeiffer K, Hensgen R, Zittrell F, Dacke M, Warrant E, Pfuhl G, Rybak J, Tedore K. eLife (2021). [doi:10.7554/eLife.65376](https://doi.org/10.7554/eLife.65376)
 Last author: Kevin Tedore, Lund University, Sweden


### PR DESCRIPTION
The Heinze et al. 2021 eLife entry under Honourable mentions carried a paraphrase but not the quotation itself. This adds the source's own characterisation of VFB, and a line noting that the paper introduces the Insect Brain Database, which VFB cross-links with across species.

No other entry on the page carries a quote, so this is a deliberate departure from the house style — this is the strongest third-party description of VFB's role on the page and it comes from a collaborating resource, which seemed worth quoting directly rather than summarising.
