### PR TITLE
Add a /search/ page that takes a query string

### DIFF
--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,6 +1,9 @@
 ---
-title: Search Results
+title: Search
+linkTitle: Search
 layout: search
-
+noindex: true
+description: >
+  Search Virtual Fly Brain — documentation pages, and neurons, brain regions and
+  expression patterns from the anatomy ontology.
 ---
-

--- a/themes/vfb-nova/assets/css/palette.css
+++ b/themes/vfb-nova/assets/css/palette.css
@@ -137,3 +137,54 @@
   margin-top: var(--sp-2);
 }
 .palette__results li:first-child.palette__group { border-top: 0; margin-top: 0; }
+
+/* ==========================================================================
+   /search/ — the standalone search page.
+   Reuses the palette's result rows, but as page content rather than a dialog:
+   no scroll cap, no card chrome.
+   ========================================================================== */
+
+.searchpage__form {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: .75rem;
+  align-items: center;
+  padding: .5rem .9rem;
+  margin: 1.25rem 0 .5rem;
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  background: var(--elev-1);
+}
+.searchpage__form:focus-within { border-color: var(--brand); }
+.searchpage__form i { color: var(--muted); }
+.searchpage__form input {
+  border: 0;
+  background: none;
+  color: var(--text);
+  font: inherit;
+  font-size: 1.05rem;
+  padding: .55rem 0;
+  min-width: 0;
+}
+.searchpage__form input:focus { outline: none; }
+.searchpage__form input::-webkit-search-cancel-button { filter: grayscale(1); }
+
+.searchpage__status {
+  margin: .25rem 0 0;
+  color: var(--muted);
+  font-size: .9rem;
+  min-height: 1.2em;
+}
+
+.searchpage__results {
+  padding: .25rem 0;
+  max-height: none;        /* it is the page, not a dropdown */
+  overflow: visible;
+}
+.searchpage__results li a { padding: .7rem .6rem; }
+
+.searchpage__note {
+  margin-top: 1.5rem;
+  color: var(--muted);
+  font-size: .92rem;
+}

--- a/themes/vfb-nova/assets/js/app.js
+++ b/themes/vfb-nova/assets/js/app.js
@@ -129,19 +129,17 @@
     targets.forEach((t) => spy.observe(t));
   }
 
-  /* --- command palette ----------------------------------------------------- */
-  const pal = $('.palette');
-  if (!pal) return;
-  const input = $('#palette-input');
-  const list = $('#palette-results');
-  const indexURL = pal.dataset.index;
-  const solrURL = pal.dataset.solr;
-  const browserURL = pal.dataset.browser;
+  /* --- search engine -------------------------------------------------------
+     Shared by the ⌘K palette and the standalone /search/ page. Config comes
+     from whichever element is on the page; both carry the same data-*. */
+  const cfgEl = $('.palette') || $('#search-page');
+  if (!cfgEl) return;
+  const indexURL = cfgEl.dataset.index;
+  const solrURL = cfgEl.dataset.solr;
+  const browserURL = cfgEl.dataset.browser;
   let docs = null;
-  let sel = 0;
   let seq = 0;            /* guards against out-of-order SOLR responses */
   let termCtl = null;     /* aborts the in-flight SOLR request when typing */
-  let termTimer = null;
 
   const ICONS = {
     docs: 'fa-book', blog: 'fa-newspaper', about: 'fa-circle-info',
@@ -281,7 +279,7 @@
       }).join('');
   }
 
-  function render(q) {
+  function render(q, list, selectFirst) {
     const items = (docs || [])
       .map((d) => ({ d, s: score(d, q) }))
       .filter((x) => x.s < 99)
@@ -313,7 +311,7 @@
 
     const mine = ++seq;
     list.innerHTML = pagesHTML || '<li class="palette__empty">Searching anatomy terms…</li>';
-    markFirst();
+    if (selectFirst) markFirst(list);
 
     fetchTerms(q, mine).then((terms) => {
       if (mine !== seq) return;
@@ -323,15 +321,22 @@
         return;
       }
       list.innerHTML = th ? strongHTML + th + weakHTML : pagesHTML;
-      markFirst();
+      if (selectFirst) markFirst(list);
+      list.dispatchEvent(new CustomEvent('vfb:results'));
     });
   }
 
-  function markFirst() {
+  function markFirst(list) {
     const first = list.querySelector('li.res');
     if (first) first.classList.add('is-sel');
     sel = 0;
   }
+
+  /* --- the palette itself --------------------------------------------------- */
+  const pal = $('.palette');
+  const input = pal ? $('#palette-input') : null;
+  const list = pal ? $('#palette-results') : null;
+  let sel = 0;
 
   function recent() {
     list.innerHTML = (docs || []).filter((d) => d.pinned).slice(0, 8).map((d, i) =>
@@ -355,6 +360,7 @@
     document.body.style.overflow = '';
   }
 
+  if (pal) {
   $$('.js-search').forEach((b) => b.addEventListener('click', open));
   pal.addEventListener('click', (e) => { if (e.target === pal) close(); });
   $('.js-close-palette')?.addEventListener('click', close);
@@ -362,7 +368,7 @@
   input.addEventListener('input', () => {
     const q = input.value.trim().toLowerCase();
     if (!q) return recent();
-    render(q);
+    render(q, list, true);
   });
 
   function move(step) {
@@ -391,4 +397,56 @@
       }
     }
   });
+  }   /* end palette */
+
+  /* --- the /search/ page ---------------------------------------------------
+     A real URL that takes a query string, so an external search engine — or a
+     link, or a bookmark — can hand VFB a term: /search/?q=medulla. Same engine
+     and same ranking as the palette; the difference is that this one is a page
+     you can land on. */
+  const page = $('#search-page');
+  if (page) {
+    const pInput = $('#search-input');
+    const pList = $('#search-results');
+    const pStatus = $('#search-status');
+    const getQ = () => new URLSearchParams(window.location.search).get('q') || '';
+
+    function announce(q) {
+      if (!q) { pStatus.textContent = ''; return; }
+      const n = pList.querySelectorAll('li.res').length;
+      pStatus.textContent = n
+        ? n + ' result' + (n === 1 ? '' : 's') + ' for “' + q + '”'
+        : 'No results for “' + q + '”';
+    }
+
+    async function run(q, push) {
+      pInput.value = q;
+      if (push) {
+        const u = q ? '?q=' + encodeURIComponent(q) : window.location.pathname;
+        history.replaceState(null, '', u);
+      }
+      if (!q) {
+        pList.innerHTML = '';
+        pStatus.textContent = '';
+        return;
+      }
+      document.title = q + ' — Search | Virtual Fly Brain';
+      await load();
+      render(q.toLowerCase(), pList, false);
+      announce(q);
+    }
+
+    pList.addEventListener('vfb:results', () => announce(pInput.value.trim()));
+
+    $('#search-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      run(pInput.value.trim(), true);
+    });
+
+    window.addEventListener('popstate', () => run(getQ(), false));
+
+    const initial = getQ();
+    if (initial) run(initial, false);
+    else pInput.focus();
+  }
 })();

--- a/themes/vfb-nova/layouts/_default/search.html
+++ b/themes/vfb-nova/layouts/_default/search.html
@@ -1,0 +1,57 @@
+{{/*
+  /search/ — a search page with a real query string, so anything outside the
+  site can hand VFB a term: /search/?q=medulla.
+
+  This is what the WebSite/SearchAction JSON-LD on the home page points at, and
+  it is also a usable landing page in its own right: a form that works with the
+  keyboard, results that link to documentation pages, and anatomy terms that
+  open in the 3D browser.
+
+  Results are noindex — they are generated per query and there is nothing here
+  for a crawler to keep. `follow` so the links out are still crawled.
+*/}}
+{{ define "main" }}
+{{- $browser := index (split .Site.Params.app_url "?") 0 -}}
+<div class="page">
+  <div class="wrap wrap--narrow">
+    {{ partial "breadcrumb.html" . }}
+
+    <header class="page__header">
+      <h1>{{ .Title }}</h1>
+      {{ with .Description }}<p class="lede">{{ . }}</p>{{ end }}
+    </header>
+
+    <div id="search-page"
+         data-index="{{ "/index.json" | relURL }}"
+         data-solr="https://solr.virtualflybrain.org/solr/ontology/select"
+         data-browser="{{ $browser }}">
+
+      <form id="search-form" class="searchpage__form" action="{{ "/search/" | relURL }}" method="get" role="search">
+        <label class="visually-hidden" for="search-input">Search Virtual Fly Brain</label>
+        <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
+        <input id="search-input" name="q" type="search" autocomplete="off" spellcheck="false"
+               placeholder="Search VFB — pages, neurons, brain regions…"
+               value="{{ .Params.q }}">
+        <button class="btn btn--primary" type="submit">Search</button>
+      </form>
+
+      <p id="search-status" class="searchpage__status" role="status" aria-live="polite"></p>
+
+      <ul class="palette__results searchpage__results" id="search-results"></ul>
+
+      <noscript>
+        <p class="searchpage__note">Site search needs JavaScript. You can still browse the
+          <a href="{{ "/docs/" | relURL }}">documentation</a>, or search anatomy directly in the
+          <a href="{{ .Site.Params.app_url }}" target="_blank" rel="noopener">3D browser</a>.</p>
+      </noscript>
+
+      <p class="searchpage__note">
+        Documentation pages open here. Anatomy terms — neurons, brain regions, expression
+        patterns — open in the
+        <a href="{{ .Site.Params.app_url }}" target="_blank" rel="noopener">3D browser</a>,
+        which is where that data lives.
+      </p>
+    </div>
+  </div>
+</div>
+{{ end }}

--- a/themes/vfb-nova/layouts/partials/head.html
+++ b/themes/vfb-nova/layouts/partials/head.html
@@ -13,6 +13,9 @@
 {{ else }}{{ $desc = .Site.Params.description }}{{ end }}
 {{ $desc = $desc | plainify | chomp }}
 <meta name="description" content="{{ $desc }}">
+{{/* Search results are generated per query: nothing for a crawler to keep, but
+     the links out are still worth following. Set `noindex: true` in front matter. */}}
+{{ if .Params.noindex }}<meta name="robots" content="noindex,follow">{{ end }}
 {{ with .Params.canonicalUrl }}<link rel="canonical" href="{{ . }}">{{ else }}<link rel="canonical" href="{{ .Permalink }}">{{ end }}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
@@ -38,6 +41,28 @@
     } catch (e) {}
   })();
 </script>
+
+{{/* Sitelinks searchbox: lets an external search engine hand a query straight to
+     /search/?q=… rather than only linking at the home page. Home page only —
+     Google expects one WebSite node per site. */}}
+{{ if .IsHome }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "{{ .Site.Title }}",
+  "url": "{{ .Site.BaseURL }}",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "{{ .Site.BaseURL }}search/?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+{{ end }}
 
 {{ partialCached "head-assets.html" . }}
 


### PR DESCRIPTION
## What

`/search/?q=medulla` — a search page with a real query string, so an external search
engine, a link or a bookmark can hand VFB a term.

Same engine as the ⌘K palette: same doc scoring, same SOLR query, same exact-match
promotion. Documentation pages open on the site; anatomy terms open in the 3D browser.

## It also fixes a live empty page

`content/en/search.md` has carried `layout: search` for some time, but the theme has no
`search.html`. It fell through to `single.html` and rendered an empty page — a "Search
Results" heading, no input, no results, and prev/next links to unrelated pages. It is in
the sitemap.

## Sitelinks searchbox

`WebSite` JSON-LD with a `SearchAction` on the home page, targeting
`{baseURL}search/?q={search_term_string}`, so Google can offer a search box for the site
and send queries straight in.

Note for future editors: Hugo's minifier re-encodes `application/ld+json`, so piping
values through `jsonify` double-escapes them. The values are written as plain quoted
strings for that reason.

## Indexing

Result pages are `noindex,follow` via a new `noindex` front-matter flag in `head.html` —
nothing for a crawler to keep per query, but the links out are still worth following.

## Implementation

`app.js` is refactored rather than duplicated: the index load, doc scoring, SOLR fetch,
exact-match promotion and result rendering now sit above the palette-specific code, and
`render()` takes its container. The palette and the search page are two consumers of one
engine, so ranking cannot drift between them.

## Testing

Live SOLR via headless Chromium. `?q=medulla` (10 results, medulla first), `?q=solr api`
(docs first, then terms), `?q=zzznothing` (empty state), no query (focused input). Form
submit updates the URL to `?q=mushroom%20body`; term links carry the correct `?id=FBbt_…`
and `target=_blank`. Palette verified still working on ordinary pages and on `/search/`
itself. JSON-LD parsed from the built output. No console errors.
