### PR TITLE
Rewrite the publications page as the group's VFB-related work

### DIFF
--- a/content/en/about/publications.md
+++ b/content/en/about/publications.md
@@ -56,6 +56,8 @@ resolved and checked.
   The Drosophila Anatomy Ontology (FBbt): the curated, reasoned classification of fly anatomy that VFB is built around.
 - **A strategy for building neuroanatomy ontologies** — Osumi-Sutherland et al., *Bioinformatics* (2012). [doi:10.1093/bioinformatics/bts113](https://doi.org/10.1093/bioinformatics/bts113)  
   The schema behind the ontology — the relations for soma location, tract, synaptic terminal and lineage that let a reasoner classify neurons from their properties.
+- **Data driven mapping of the Drosophila larval central nervous system** — Wood, *PhD thesis, University of Edinburgh* (2019). [hdl:1842/35918](http://hdl.handle.net/1842/35918)  
+  The work behind VFB's L3 larval template: a CNS template annotated with neuropil domains, a registration pipeline run over more than 22,000 image stacks, ~6,500 extracted whole-cell images, and NBLAST compared against a convolutional-network approach for ranking cell similarity. The registered cells are served through the larval VFB atlas.
 
 ## Connectomes, annotation and cell typing
 
@@ -278,11 +280,13 @@ resolved and checked.
 - **FlyBase: enhancing Drosophila Gene Ontology annotations** — Tweedie et al., *Nucleic Acids Research* (2009). [doi:10.1093/nar/gkn788](https://doi.org/10.1093/nar/gkn788)  
   Gene Ontology (GO) terms are used to describe three attributes of wild-type gene products: their molecular function, the biological processes in which they play a role, and their subcellular location.
 
-## Not published
+## Theses
 
-Some of what VFB serves has no paper to cite. The third-instar (L3) larval CNS template and
-its 255 painted domains are unpublished work by **David Wood and Volker Hartenstein**,
-credited as such in the VFB resource paper. If you use that template, credit it that way.
+Some of what VFB serves was never published as a paper. The third-instar (L3) larval CNS
+template and its 255 painted domains are credited in the VFB resource paper to **David Wood
+and Volker Hartenstein** as unpublished work; the mapping and registration behind it is
+written up in David Wood's Edinburgh PhD thesis, listed above. If you use that template,
+cite the thesis and credit the domains to Wood and Hartenstein.
 
 ---
 

--- a/content/en/about/publications.md
+++ b/content/en/about/publications.md
@@ -1,18 +1,293 @@
 ---
 title: Publications
+linkTitle: Publications
 weight: 900
+date: 2026-08-19
+tags: [VFB,publications,ontology,connectomics,anatomy]
+categories: [acknowledgements,who we are]
+description: >
+  Papers by the Virtual Fly Brain team — the resource itself, the ontologies and
+  anatomical standards behind it, the connectome annotation it integrates, and the
+  imaging and data infrastructure it runs on.
 ---
 
-## Publications
+Work by current and past members of the Virtual Fly Brain team that bears on VFB: the
+resource, the ontologies and nomenclatures it is built from, the connectome annotation and
+cell typing it integrates, the imaging and registration tools it depends on, and the wider
+data-standards work the same people do elsewhere.
 
-For more information on the technology behind the VFB website:
+For how to cite VFB itself, see [how to cite us](/about/citeus/). For work by *other*
+groups that used VFB, see [papers citing VFB](/about/papers-citing-vfb/). Team members are
+listed on [the team page](/about/members/).
 
-- Robert Court, Marta Costa, Clare Pilgrim, Gillian Millburn, Alex Holmes, Alex McLachlan, Aoife Larkin, Nicolas Matentzoglu, Huseyin Kir, Helen Parkinson, Nicolas H. Brown, Cahir J. O'Kane, J. Douglas Armstrong, Gregory S. X. E. Jefferis and David Osumi-Sutherland (2023). [Virtual Fly Brain - An interactive atlas of the Drosophila nervous system](https://dx.doi.org/10.3389/fphys.2023.1076533). Frontiers in Physiology 14.
-- Matteo Cantarelli, Boris Marin, Adrian Quintana, Matt Earnshaw, Robert Court, Padraig Gleeson, Salvador Dura-Bernal, R. Angus Silver, Giovanni Idili (2018). [Geppetto: a reusable modular open platform for exploring neuroscience data and models](https://dx.doi.org/10.1098/rstb.2017.0380). Philosophical Transactions of the Royal Society B: Biological Sciences 373.
-- Hilmar Lapp, James P. Balhoff, Todd J. Vision (2017). [Owlery: A flexible approach for the serving of OWL ontologies](https://doi.org/10.1101/071951). bioRxiv.
-- Milyaev, N., Osumi-Sutherland, D., Reeve, S., Burton, N., Baldock, R. A. and Armstrong, J. D. (2012). [The Virtual Fly Brain browser and query interface](https://dx.doi.org/10.1093/bioinformatics/btr677). Bioinformatics 28, 411-5.
-- Husz ZL, Burton N, Hill B, Milyaev N, Baldock RA:[Web tools for large-scale 3D biological images and atlases](https://dx.doi.org/doi:10.1186/1471-2105-13-122). BMC Bioinformatics 13:122, 2012.
+Descriptions are drawn from each paper's own abstract unless noted. Every DOI has been
+resolved and checked.
 
-For details on the anatomy ontology:
+## Virtual Fly Brain
 
-- Osumi-Sutherland, D., Reeve, S., Mungall, C. J., Neuhaus, F., Ruttenberg, A., Jefferis, G. S. and Armstrong, J. D. (2012). [A strategy for building neuroanatomy ontologies](https://dx.doi.org/doi:10.1093/bioinformatics/bts113). Bioinformatics 28, 1262-1269.
+- **VFB-MCP: Natural-Language Access to Drosophila Neuroscience Grounded by an Expert-Curated Ontology-Led Knowledgebase** — McLachlan et al., *bioRxiv* (2026). [doi:10.64898/2026.06.16.732577](https://doi.org/10.64898/2026.06.16.732577)  
+  An MCP server that puts the VFB knowledgebase behind a natural-language interface, so an LLM can query fly neuroanatomy and connectivity without losing the ontology grounding.
+- **Virtual Fly Brain—An interactive atlas of the Drosophila nervous system** — Court et al., *Frontiers in Physiology* (2023). [doi:10.3389/fphys.2023.1076533](https://doi.org/10.3389/fphys.2023.1076533)  
+  The current VFB resource paper: how curated ontology terms, registered images, connectomics and transcriptomics are integrated behind one query interface.
+- **The Virtual Fly Brain browser and query interface** — Milyaev et al., *Bioinformatics* (2011). [doi:10.1093/bioinformatics/btr677](https://doi.org/10.1093/bioinformatics/btr677)  
+  The original VFB: a browser and query interface over the adult brain, with anatomy queries answered by an OWL reasoner rather than by lookup.
+
+## Anatomy, nomenclature and the Drosophila ontologies
+
+- **The Unified Phenotype Ontology : a framework for cross-species integrative phenomics** — Matentzoglu et al., *GENETICS* (2025). [doi:10.1093/genetics/iyaf027](https://doi.org/10.1093/genetics/iyaf027)  
+  Phenotypic data are critical for understanding biological mechanisms and consequences of genomic variation, and are pivotal for clinical use cases such as disease diagnostics and treatment….
+- **The Human Phenotype Ontology in 2024: phenotypes around the world** — Gargano et al., *Nucleic Acids Research* (2023). [doi:10.1093/nar/gkad1005](https://doi.org/10.1093/nar/gkad1005)  
+  The Human Phenotype Ontology (HPO) is a widely used resource that comprehensively organizes and defines the phenotypic features of human disease, enabling computational inference and supporting….
+- **The Xenopus phenotype ontology: bridging model organism phenotype data to human health and development** — Fisher et al., *BMC Bioinformatics* (2022). [doi:10.1186/s12859-022-04636-8](https://doi.org/10.1186/s12859-022-04636-8)  
+  Results Here we present the Xenopus phenotype ontology (XPO) to annotate phenotypic data from experiments in Xenopus , one of the major vertebrate model organisms used to study gene function in….
+- **Formalizing Insect Morphological Data: A Model-Based, Extensible Insect Anatomy Ontology and Its Potential Applications in Biodiversity Research and Informatics** — Girón et al., *preprint* (2022). [doi:10.20944/preprints202201.0254.v1](https://doi.org/10.20944/preprints202201.0254.v1)  
+  Proposes a Model for Describing Insect Anatomical Structures (MoDIAS) which incorporates structural properties and positional relationships for standardized, consistent, and reproducible….
+- **Planarian Anatomy Ontology: a resource to connect data within and across experimental platforms** — Nowotarski et al., *Development* (2021). [doi:10.1242/dev.196097](https://doi.org/10.1242/dev.196097)  
+  As the planarian research community expands, the need for an interoperable data organization framework for tool building has become increasingly apparent.
+- **A Systematic Nomenclature for the Drosophila Ventral Nerve Cord** — Court et al., *Neuron* (2020). [doi:10.1016/j.neuron.2020.08.005](https://doi.org/10.1016/j.neuron.2020.08.005)  
+  Defines the systematic nomenclature for the adult ventral nerve cord — the naming standard VFB uses for VNC regions and the neurons that innervate them.
+- **The Drosophila anatomy ontology** — Pilgrim et al., *preprint* (2019). [doi:10.7490/f1000research.1116541.1](https://doi.org/10.7490/f1000research.1116541.1)  
+  The Drosophila Anatomy Ontology (DAO) is a queryable store of knowledge about Drosophila anatomy and cell types.
+- **Expansion of the Human Phenotype Ontology (HPO) knowledge base and resources** — Köhler et al., *Nucleic Acids Research* (2018). [doi:10.1093/nar/gky1105](https://doi.org/10.1093/nar/gky1105)  
+  The Human Phenotype Ontology (HPO)-a standardized vocabulary of phenotypic abnormalities associated with 7000+ diseases-is used by thousands of researchers, clinicians, informaticians and….
+- **The Drosophila phenotype ontology** — Osumi-Sutherland et al., *Journal of Biomedical Semantics* (2013). [doi:10.1186/2041-1480-4-30](https://doi.org/10.1186/2041-1480-4-30)  
+  The Drosophila Phenotype Ontology, used to make phenotype descriptions computable alongside the anatomy.
+- **The Drosophila anatomy ontology** — Costa et al., *Journal of Biomedical Semantics* (2013). [doi:10.1186/2041-1480-4-32](https://doi.org/10.1186/2041-1480-4-32)  
+  The Drosophila Anatomy Ontology (FBbt): the curated, reasoned classification of fly anatomy that VFB is built around.
+- **A strategy for building neuroanatomy ontologies** — Osumi-Sutherland et al., *Bioinformatics* (2012). [doi:10.1093/bioinformatics/bts113](https://doi.org/10.1093/bioinformatics/bts113)  
+  The schema behind the ontology — the relations for soma location, tract, synaptic terminal and lineage that let a reasoner classify neurons from their properties.
+
+## Connectomes, annotation and cell typing
+
+- **Distributed control circuits across a brain-and-cord connectome** — Bates et al., *Nature* (2026). [doi:10.1038/s41586-026-10735-w](https://doi.org/10.1038/s41586-026-10735-w)  
+  Reports a densely reconstructed adult fly connectome that unites the brain and ventral nerve cord, and we leverage this resource to investigate principles of neural control.
+- **Organization of circuits linking descending input to motor output in the Drosophila Male Adult Nerve Cord connectome** — Cheong et al., *eLife* (2026). [doi:10.7554/elife.96084](https://doi.org/10.7554/elife.96084)  
+  Presents a first look at the organization of the networks connecting DNs to MNs.
+- **Connectome-driven neural inventory of a complete visual system** — Nern et al., *Nature* (2025). [doi:10.1038/s41586-025-08746-0](https://doi.org/10.1038/s41586-025-08746-0)  
+  Vision provides animals with detailed information about their surroundings and conveys diverse features such as colour, form and movement across the visual scene.
+- **Comparative connectomics of Drosophila descending and ascending neurons** — Stürner et al., *Nature* (2025). [doi:10.1038/s41586-025-08925-z](https://doi.org/10.1038/s41586-025-08925-z)  
+  By integrating three separate electron microscopy (EM) datasets 1–4 , we provide a complete connectomic description of the ANs and DNs of the Drosophila female nervous system and compare them with….
+- **Sexually dimorphic neurons in the Drosophila whole-brain connectome** — Deutsch et al., *bioRxiv* (2025). [doi:10.1101/2025.06.10.658788](https://doi.org/10.1101/2025.06.10.658788)  
+  Sexual dimorphisms in the brain arise from differences in cell number, morphology, and connectivity, and underlie sex-specific behaviors.
+- **Distributed control circuits across a brain-and-cord connectome** — Bates et al., *bioRxiv* (2025). [doi:10.1101/2025.07.31.667571](https://doi.org/10.1101/2025.07.31.667571)  
+  Reports the first densely reconstructed adult fly connectome that unites the brain and ventral nerve cord, and we leverage this resource to investigate principles of neural control.
+- **From Sensory Detection to Motor Action: The Comprehensive Drosophila Taste-Feeding Connectome** — Tastekin et al., *bioRxiv* (2025). [doi:10.1101/2025.08.25.671814](https://doi.org/10.1101/2025.08.25.671814)  
+  Presents the first complete wiring diagram of the male Drosophila adult gustatory system, comprehensively reconstructing gustatory receptor neurons (GRNs) from peripheral organs in a contiguous….
+- **Sexual dimorphism in the complete connectome of the Drosophila male central nervous system** — Berg et al., *bioRxiv* (2025). [doi:10.1101/2025.10.09.680999](https://doi.org/10.1101/2025.10.09.680999)  
+  Presents the connectome of the entire Drosophila male central nervous system.
+- **Transforming descending input into motor output: An analysis of the Drosophila Male Adult Nerve Cord connectome** — Cheong et al., *eLife* (2025). [doi:10.7554/elife.96084.2](https://doi.org/10.7554/elife.96084.2)  
+  Presents a first look at the organization of the VNC networks connecting DNs to MNs based on this new connectome information.
+- **Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster** — Eckstein et al., *Cell* (2024). [doi:10.1016/j.cell.2024.03.016](https://doi.org/10.1016/j.cell.2024.03.016)  
+  High-resolution electron microscopy of nervous systems has enabled the reconstruction of synaptic connectomes.
+- **Neuronal wiring diagram of an adult brain** — Dorkenwald et al., *Nature* (2024). [doi:10.1038/s41586-024-07558-y](https://doi.org/10.1038/s41586-024-07558-y)  
+  Presents a neuronal wiring diagram of a whole brain containing 5 × 10 7 chemical synapses 7 between 139,255 neurons reconstructed from an adult female Drosophila melanogaster 8,9 .
+- **Whole-brain annotation and multi-connectome cell typing of Drosophila** — Schlegel et al., *Nature* (2024). [doi:10.1038/s41586-024-07686-5](https://doi.org/10.1038/s41586-024-07686-5)  
+  Complement the approximately 140,000 neuron FlyWire whole-brain connectome 1 with a systematic and hierarchical annotation of neuronal classes, cell types and developmental units (hemilineages).
+- **Network statistics of the whole-brain connectome of Drosophila** — Lin et al., *Nature* (2024). [doi:10.1038/s41586-024-07968-y](https://doi.org/10.1038/s41586-024-07968-y)  
+  Computed the prevalence of two- and three-node motifs, examined their strengths, related this information to both neurotransmitter composition and cell type annotations 4,5 , and compared these….
+- **The fly connectome reveals a path to the effectome** — Pospisil et al., *Nature* (2024). [doi:10.1038/s41586-024-07982-0](https://doi.org/10.1038/s41586-024-07982-0)  
+  To overcome this limitation, we introduce a combined experimental and statistical strategy for efficiently learning a causal model of the fly brain, which we refer to as the ‘effectome’.
+- **Systematic annotation of a complete adult male Drosophila nerve cord connectome reveals principles of functional organisation** — Marin et al., *eLife* (2024). [doi:10.7554/elife.97766.1](https://doi.org/10.7554/elife.97766.1)  
+  In a companion paper (Takemura et al., 2023), we describe the acquisition of a complete fruit fly nerve cord connectome, the first for an animal that can walk or fly.
+- **A Connectome of the Male Drosophila Ventral Nerve Cord** — Takemura et al., *eLife* (2024). [doi:10.7554/elife.97769.1](https://doi.org/10.7554/elife.97769.1)  
+  Animal behavior is principally expressed through neural control of muscles.
+- **BigNeuron: a resource to benchmark and predict performance of algorithms for automated tracing of neurons in light microscopy datasets** — Manubens-Gil et al., *Nature Methods* (2023). [doi:10.1038/s41592-023-01848-5](https://doi.org/10.1038/s41592-023-01848-5)  
+  Reports generated gold standard manual annotations for a subset of the available imaging datasets and quantified tracing quality for 35 automatic tracing algorithms.
+- **A Connectome of the Male Drosophila Ventral Nerve Cord** — Takemura et al., *bioRxiv* (2023). [doi:10.1101/2023.06.05.543757](https://doi.org/10.1101/2023.06.05.543757)  
+  Animal behavior is principally expressed through neural control of muscles.
+- **Connectomics and the neural basis of behaviour** — Galili, Jefferis & Costa, *Current Opinion in Insect Science* (2022). [doi:10.1016/j.cois.2022.100968](https://doi.org/10.1016/j.cois.2022.100968)  
+  Methods to acquire and process synaptic-resolution electron-microscopy datasets have progressed very rapidly, allowing production and annotation of larger, more complete connectomes.
+- **Neurodevelopment: Comparative connectomics and the study of circuit assembly** — Donà & Jefferis, *Current Biology* (2021). [doi:10.1016/j.cub.2021.03.053](https://doi.org/10.1016/j.cub.2021.03.053)  
+  This work paves the way for the use of comparative connectomics to understand general principles governing the development of wiring specificity.
+- **Cell type ontologies of the Human Cell Atlas** — Osumi-Sutherland et al., *Nature Cell Biology* (2021). [doi:10.1038/s41556-021-00787-7](https://doi.org/10.1038/s41556-021-00787-7)  
+  Massive single-cell profiling efforts have accelerated our discovery of the cellular composition of the human body while at the same time raising the need to formalize this new knowledge.
+- **Anatomical structures, cell types and biomarkers of the Human Reference Atlas** — Börner et al., *Nature Cell Biology* (2021). [doi:10.1038/s41556-021-00788-6](https://doi.org/10.1038/s41556-021-00788-6)  
+  This Perspective presents collaborative work by members of 16 international consortia on two essential and interlinked parts of the HRA: (1) three-dimensional representations of anatomy that are….
+- **Automatic detection of synaptic partners in a whole-brain Drosophila electron microscopy data set** — Buhmann et al., *Nature Methods* (2021). [doi:10.1038/s41592-021-01183-7](https://doi.org/10.1038/s41592-021-01183-7)  
+  Develop an automatic method for synaptic partner identification in insect brains and use it to predict synaptic partners in a whole-brain electron microscopy dataset of the fruit fly.
+- **Anatomical Structures, Cell Types, and Biomarkers Tables Plus 3D Reference Organs in Support of a Human Reference Atlas** — Börner et al., *bioRxiv* (2021). [doi:10.1101/2021.05.31.446440](https://doi.org/10.1101/2021.05.31.446440)  
+  Abstract This paper reviews efforts across 16 international consortia to construct human anatomical structures, cell types, and biomarkers (ASCT+B) tables and three-dimensional reference organs in….
+- **Information flow, cell types and stereotypy in a full olfactory connectome** — Schlegel et al., *eLife* (2021). [doi:10.7554/elife.66018](https://doi.org/10.7554/elife.66018)  
+  Using this data set, we provide a complete description of the Drosophila olfactory system, covering all first, second and lateral horn-associated third-order neurons.
+- **Connectomics Analysis Reveals First-, Second-, and Third-Order Thermosensory and Hygrosensory Neurons in the Adult Drosophila Brain** — Marin et al., *Current Biology* (2020). [doi:10.1016/j.cub.2020.06.028](https://doi.org/10.1016/j.cub.2020.06.028)  
+  Presents the first connectome of a thermo- and hygrosensory neuropil, the lateral accessory calyx (lACA), by reconstructing neurons downstream of heating- and cooling-responsive VP PNs.
+- **Complete Connectomic Reconstruction of Olfactory Projection Neurons in the Fly Brain** — Bates et al., *Current Biology* (2020). [doi:10.1016/j.cub.2020.06.042](https://doi.org/10.1016/j.cub.2020.06.042)  
+  To understand how these building blocks form whole circuits, we must distil these broad classes into neuronal cell types and describe their network connectivity.
+- **A connectome and analysis of the adult Drosophila central brain** — Scheffer et al., *eLife* (2020). [doi:10.7554/elife.57443](https://doi.org/10.7554/elife.57443)  
+  Summarize new methods and present the circuitry of a large fraction of the brain of the fruit fly Drosophila melanogaster .
+- **The connectome of the adult Drosophila mushroom body provides insights into function** — Li et al., *eLife* (2020). [doi:10.7554/elife.62576](https://doi.org/10.7554/elife.62576)  
+  Provides insights into the circuitry used to integrate MB outputs, connectivity between the MB and the central complex and inputs to DANs, including feedback from MBONs.
+- **Neuronal cell types in the fly: single-cell anatomy meets single-cell genomics** — Bates et al., *Current Opinion in Neurobiology* (2019). [doi:10.1016/j.conb.2018.12.012](https://doi.org/10.1016/j.conb.2018.12.012)  
+  At around 150 000 neurons, the adult Drosophila melanogaster central nervous system is one of the largest species, for which a complete cellular catalogue is imminent.
+- **A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster** — Zheng et al., *Cell* (2018). [doi:10.1016/j.cell.2018.06.019](https://doi.org/10.1016/j.cell.2018.06.019)  
+  Develops a custom high-throughput EM platform and imaged the entire brain of an adult female fly at synaptic resolution.
+- **Cell type discovery using single-cell transcriptomics: implications for ontological representation** — Aevermann et al., *Human Molecular Genetics* (2018). [doi:10.1093/hmg/ddy100](https://doi.org/10.1093/hmg/ddy100)  
+  Cells are fundamental function units of multicellular organisms, with different cell types playing distinct physiological roles in the body.
+- **Learning from connectomics on the fly** — Schlegel, Costa & Jefferis, *Current Opinion in Insect Science* (2017). [doi:10.1016/j.cois.2017.09.011](https://doi.org/10.1016/j.cois.2017.09.011)  
+  Parallels between invertebrates and vertebrates in nervous system development, organisation and circuits are powerful reasons to use insects to study the mechanistic basis of behaviour.
+- **Genetically targeted 3D visualisation of Drosophila neurons under Electron Microscopy and X-Ray Microscopy using miniSOG** — Ng et al., *Scientific Reports* (2016). [doi:10.1038/srep38863](https://doi.org/10.1038/srep38863)  
+  Develops genetically-encoded, electron-dense markers using miniSOG.
+
+## Imaging, registration and analysis tools
+
+- **A layered standards framework for integrating single-cell and spatial omics data into brain cell atlases** — Ray et al., *bioRxiv* (2026). [doi:10.64898/2026.04.30.722039](https://doi.org/10.64898/2026.04.30.722039)  
+  The BRAIN Initiative Cell Atlas Network (BICAN) is generating large-scale multimodal datasets to profile cell types in the human, non-human primate, and mouse brain.
+- **A Developmental Atlas of the Drosophila Nerve Cord Uncovers a Global Temporal Code for Neuronal Identity** — Cachero et al., *bioRxiv* (2025). [doi:10.1101/2025.07.16.664682](https://doi.org/10.1101/2025.07.16.664682)  
+  Presents a high-resolution developmental transcriptional atlas for the Drosophila melanogaster nerve cord, the central hub for sensory-motor circuits.
+- **Cross-species consensus atlas of the primate basal ganglia** — Johansen et al., *bioRxiv* (2025). [doi:10.64898/2025.12.15.694496](https://doi.org/10.64898/2025.12.15.694496)  
+  Presents a multiomic consensus atlas of 1.8 million nuclei from human, macaque, and marmoset spanning eight BG structures.
+- **Specimen, biological structure, and spatial ontologies in support of a Human Reference Atlas** — Herr et al., *Scientific Data* (2023). [doi:10.1038/s41597-023-01993-8](https://doi.org/10.1038/s41597-023-01993-8)  
+  This paper introduces the Common Coordinate Framework (CCF) Ontology v2.0.1 that interlinks specimen, biological structure, and spatial data, together with the CCF API that makes the HRA….
+- **Expression Atlas update: insights from sequencing data at both bulk and single cell level** — George et al., *Nucleic Acids Research* (2023). [doi:10.1093/nar/gkad1021](https://doi.org/10.1093/nar/gkad1021)  
+  Expression Atlas (www.ebi.ac.uk/gxa) and its newest counterpart the Single Cell Expression Atlas (www.ebi.ac.uk/gxa/sc) are EMBL-EBI’s knowledgebases for gene and protein expression and….
+- **Specimen, Biological Structure, and Spatial Ontologies in Support of a Human Reference Atlas** — Herr et al., *bioRxiv* (2022). [doi:10.1101/2022.09.08.507220](https://doi.org/10.1101/2022.09.08.507220)  
+  This paper introduces the Common Coordinate Framework Ontology (CCFO) v2.0.1 that interlinks specimen, biological structure, and spatial data together with the CCF API which makes the HRA….
+- **Fly Cell Atlas: A single-nucleus transcriptomic atlas of the adult fruit fly** — Li et al., *Science* (2022). [doi:10.1126/science.abk2432](https://doi.org/10.1126/science.abk2432)  
+  Presents a single-cell atlas of the adult fly, Tabula Drosophilae , that includes 580,000 nuclei from 15 individually dissected sexed tissues as well as the entire head and body, annotated to….
+- **Expression Atlas update: gene and protein expression in multiple species** — Moreno et al., *Nucleic Acids Research* (2021). [doi:10.1093/nar/gkab1030](https://doi.org/10.1093/nar/gkab1030)  
+  The EMBL-EBI Expression Atlas is an added value knowledge base that enables researchers to answer the question of where (tissue, organism part, developmental stage, cell type) and under which….
+- **The natverse, a versatile toolbox for combining and analysing neuroanatomical data** — Bates et al., *eLife* (2020). [doi:10.7554/elife.53350](https://doi.org/10.7554/elife.53350)  
+  The natverse: R tooling for reading, transforming and analysing neuroanatomical data, including from the CATMAID instances VFB hosts.
+- **Geppetto: a reusable modular open platform for exploring neuroscience data and models** — Cantarelli et al., *Philosophical Transactions of the Royal Society B: Biological Sciences* (2018). [doi:10.1098/rstb.2017.0380](https://doi.org/10.1098/rstb.2017.0380)  
+  Geppetto, the open visualisation platform that powers VFB’s 3D browser.
+- **Automatic Segmentation of Drosophila Neural Compartments Using GAL4 Expression Data Reveals Novel Visual Pathways** — Panser et al., *Current Biology* (2016). [doi:10.1016/j.cub.2016.05.052](https://doi.org/10.1016/j.cub.2016.05.052)  
+  Identifying distinct anatomical structures within the brain and developing genetic tools to target them are fundamental steps for understanding brain function.
+- **Characterization of the Drosophila Atlastin Interactome Reveals VCP as a Functionally Related Interactor** — O'Sullivan, Dräger & O'Kane, *Journal of Genetics and Genomics* (2013). [doi:10.1016/j.jgg.2013.04.008](https://doi.org/10.1016/j.jgg.2013.04.008)  
+  At least 25 genes, many involved in trafficking, localisation or shaping of membrane organelles, have been identified as causative genes for the neurodegenerative disorder hereditary spastic….
+- **Clonal Analysis of Olfaction in Drosophila: Image Registration** — Ostrovsky, Cachero & Jefferis, *Cold Spring Harbor Protocols* (2013). [doi:10.1101/pdb.prot071738](https://doi.org/10.1101/pdb.prot071738)  
+  Clonal analysis with the MARCM (mosaic analysis with a repressible cell marker) system can be used for studying cell lineage, development, and anatomy in the Drosophila olfactory system and other….
+- **Web tools for large-scale 3D biological images and atlases** — Husz et al., *BMC Bioinformatics* (2012). [doi:10.1186/1471-2105-13-122](https://doi.org/10.1186/1471-2105-13-122)  
+  The Woolz-based image server and web tools underlying VFB’s original tiled 3D image delivery.
+- **A Mutual Information Approach to Automate Identification of Neuronal Clusters in Drosophila Brain Images** — Masse et al., *Frontiers in Neuroinformatics* (2012). [doi:10.3389/fninf.2012.00021](https://doi.org/10.3389/fninf.2012.00021)  
+  Mapping neural circuits can be accomplished by labeling a small number of neural structures per brain, and then combining these structures across multiple brains.
+- **The DIADEM Data Sets: Representative Light Microscopy Images of Neuronal Morphology to Advance Automation of Digital Reconstructions** — Brown et al., *Neuroinformatics* (2011). [doi:10.1007/s12021-010-9095-5](https://doi.org/10.1007/s12021-010-9095-5)  
+  The comprehensive characterization of neuronal morphology requires tracing extensive axonal and dendritic arbors imaged with light microscopy into digital reconstructions.
+
+## Ontologies, standards and data infrastructure
+
+- **The Cell Ontology in the age of single-cell omics** — Tan et al., *Scientific Data* (2026). [doi:10.1038/s41597-026-07173-8](https://doi.org/10.1038/s41597-026-07173-8)  
+  Describes the wide variety of uses of CL in these platforms and tools and detail ongoing work to improve and extend CL content including the addition of transcriptomic types, working closely with….
+- **scFAIR Consortium: a decentralized hub for single-cell RNA-Seq data standardization and unification** — Gardeux et al., *bioRxiv* (2026). [doi:10.64898/2026.06.05.730084](https://doi.org/10.64898/2026.06.05.730084)  
+  The rapid accumulation of single-cell RNA-Seq (scRNA-seq) data across multiple repositories presents major challenges for data accessibility, integration, and reproducibility.
+- **Suggestions for extending the FAIR Principles based on a linguistic perspective on semantic interoperability** — Vogt et al., *Scientific Data* (2025). [doi:10.1038/s41597-025-05011-x](https://doi.org/10.1038/s41597-025-05011-x)  
+  FAIR (meta)data presuppose their successful communication between machines and humans while preserving meaning and reference.
+- **OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem** — McLaughlin et al., *Bioinformatics* (2025). [doi:10.1093/bioinformatics/btaf279](https://doi.org/10.1093/bioinformatics/btaf279)  
+  Summary The Ontology Lookup Service (OLS) is an open source search engine for ontologies which is used extensively in the bioinformatics and chemistry communities to annotate biological and….
+- **A change language for ontologies and knowledge graphs** — Hegde et al., *Database* (2025). [doi:10.1093/database/baae133](https://doi.org/10.1093/database/baae133)  
+  This language serves two purposes: a curator can use it to request desired changes, and it can also be used to describe changes that have already happened, corresponding to the concepts of “apply….
+- **An open source knowledge graph ecosystem for the life sciences** — Callahan et al., *Scientific Data* (2024). [doi:10.1038/s41597-024-03171-w](https://doi.org/10.1038/s41597-024-03171-w)  
+  Translational research requires data at multiple scales of biological organization.
+- **Structured Prompt Interrogation and Recursive Extraction of Semantics (SPIRES): a method for populating knowledge bases using zero-shot learning** — Caufield et al., *Bioinformatics* (2024). [doi:10.1093/bioinformatics/btae104](https://doi.org/10.1093/bioinformatics/btae104)  
+  Results Here we present Structured Prompt Interrogation and Recursive Extraction of Semantics (SPIRES), a Knowledge Extraction approach that relies on the ability of Large Language Models (LLMs)….
+- **FlyBase: updates to the Drosophila genes and genomes database** — Öztürk-Çolak et al., *GENETICS* (2024). [doi:10.1093/genetics/iyad211](https://doi.org/10.1093/genetics/iyad211)  
+  In this article, we describe the latest developments and updates to FlyBase.
+- **Dynamic Retrieval Augmented Generation of Ontologies using Artificial Intelligence (DRAGON-AI)** — Toro et al., *Journal of Biomedical Semantics* (2024). [doi:10.1186/s13326-024-00320-3](https://doi.org/10.1186/s13326-024-00320-3)  
+  Presents Dynamic Retrieval Augmented Generation of Ontologies using AI (DRAGON-AI), an ontology generation method employing Large Language Models (LLMs) and Retrieval Augmented Generation (RAG).
+- **The Ontology of Biological Attributes (OBA)—computational traits for the life sciences** — Stefancsik et al., *Mammalian Genome* (2023). [doi:10.1007/s00335-023-09992-1](https://doi.org/10.1007/s00335-023-09992-1)  
+  Existing phenotype ontologies were originally developed to represent phenotypes that manifest as a character state in relation to a wild-type or other reference.
+- **The Medical Action Ontology: A tool for annotating and analyzing treatments and clinical management of human disease** — Carmody et al., *Med* (2023). [doi:10.1016/j.medj.2023.10.003](https://doi.org/10.1016/j.medj.2023.10.003)  
+  Background Navigating the clinical literature to determine the optimal clinical management for rare diseases presents significant challenges.
+- **Brain Data Standards - A method for building data-driven cell-type ontologies** — Tan et al., *Scientific Data* (2023). [doi:10.1038/s41597-022-01886-2](https://doi.org/10.1038/s41597-022-01886-2)  
+  Describes a generally applicable schema that solves these problems and its application in a semi-automated pipeline to build a data-linked extension to the Cell Ontology representing cell types in….
+- **KG-Hub—building and exchanging biological knowledge graphs** — Caufield et al., *Bioinformatics* (2023). [doi:10.1093/bioinformatics/btad418](https://doi.org/10.1093/bioinformatics/btad418)  
+  Results Here we present KG-Hub, a platform that enables standardized construction, exchange, and reuse of KGs.
+- **Formalizing Invertebrate Morphological Data: A Descriptive Model for Cuticle-Based Skeleto-Muscular Systems, an Ontology for Insect Anatomy, and their Potential Applications in Biodiversity Research and Informatics** — Girón et al., *Systematic Biology* (2023). [doi:10.1093/sysbio/syad025](https://doi.org/10.1093/sysbio/syad025)  
+  Proposes a Model for Describing Cuticular Anatomical Structures (MoDCAS) which incorporates structural properties and positional relationships for standardized, consistent, and reproducible….
+- **The Ontology of Biological Attributes (OBA) - Computational Traits for the Life Sciences** — Stefancsik et al., *bioRxiv* (2023). [doi:10.1101/2023.01.26.525742](https://doi.org/10.1101/2023.01.26.525742)  
+  Existing phenotype ontologies were originally developed to represent phenotypes that manifest as a character state in relation to a wild-type or other reference.
+- **The Environmental Conditions, Treatments, and Exposures Ontology (ECTO): connecting toxicology and exposure to human health and beyond** — Chan et al., *Journal of Biomedical Semantics* (2023). [doi:10.1186/s13326-023-00283-x](https://doi.org/10.1186/s13326-023-00283-x)  
+  In this manuscript we present the Environmental Conditions, Treatments, and Exposures Ontology (ECTO), a species-agnostic ontology focused on exposure events that occur as a result of natural and….
+- **A Simple Standard for Sharing Ontological Mappings (SSSOM)** — Matentzoglu et al., *Database* (2022). [doi:10.1093/database/baac035](https://doi.org/10.1093/database/baac035)  
+  Despite progress in the development of standards for describing and exchanging scientific information, the lack of easy-to-use standards for mapping between different representations of the same….
+- **Ontology Development Kit: a toolkit for building, maintaining and standardizing biomedical ontologies** — Matentzoglu et al., *Database* (2022). [doi:10.1093/database/baac087](https://doi.org/10.1093/database/baac087)  
+  Provides an overview of how the ODK works, show how it is used in practice and describe how we envision it driving standardization efforts in our community.
+- **FlyBase: a guided tour of highlighted features** — Gramates et al., *Genetics* (2022). [doi:10.1093/genetics/iyac035](https://doi.org/10.1093/genetics/iyac035)  
+  Emphasize the dedicated reports and tools we have constructed to meet the specialized needs of fly researchers but also to facilitate use by other research communities.
+- **The NHGRI-EBI GWAS Catalog: knowledgebase and deposition resource** — Sollis et al., *Nucleic Acids Research* (2022). [doi:10.1093/nar/gkac1010](https://doi.org/10.1093/nar/gkac1010)  
+  The NHGRI-EBI GWAS Catalog (www.ebi.ac.uk/gwas) is a FAIR knowledgebase providing detailed, structured, standardised and interoperable genome-wide association study (GWAS) data to &amp;gt;200 000….
+- **A knowledge-intensive adaptive business process management framework** — Kir & Erdogan, *Information Systems* (2021). [doi:10.1016/j.is.2020.101639](https://doi.org/10.1016/j.is.2020.101639)
+- **OBO Foundry in 2021: operationalizing open data principles to evaluate ontologies** — Jackson et al., *Database* (2021). [doi:10.1093/database/baab069](https://doi.org/10.1093/database/baab069)  
+  Shows how we have addressed this by formally encoding the OBO principles as operational rules and implementing a suite of automated validation checks and a dashboard for objectively evaluating….
+- **OBO Foundry in 2021: Operationalizing Open Data Principles to Evaluate Ontologies** — Jackson et al., *bioRxiv* (2021). [doi:10.1101/2021.06.01.446587](https://doi.org/10.1101/2021.06.01.446587)  
+  Shows how we have addressed this by formally encoding the OBO principles as operational rules and implementing a suite of automated validation checks and a dashboard for objectively evaluating….
+- **Brain Data Standards - A method for building data-driven cell-type ontologies** — Tan et al., *bioRxiv* (2021). [doi:10.1101/2021.10.10.463703](https://doi.org/10.1101/2021.10.10.463703)  
+  Describes the construction and application of a semi-automated, data-linked extension to the Cell Ontology that represents cell types in the Primary Motor Cortex of humans, mice and marmosets.
+- **A comparative study of methods for a priori prediction of MCQ difficulty** — Kurdi et al., *Semantic Web* (2021). [doi:10.3233/sw-200390](https://doi.org/10.3233/sw-200390)  
+  Analyse and compare two ontology-based measures for difficulty prediction of multiple choice questions, as well as comparing each measure with expert prediction (by 15 experts) against the exam….
+- **Building a pipeline to solicit expert knowledge from the community to aid gene summary curation** — Antonazzo et al., *Database* (2020). [doi:10.1093/database/baz152](https://doi.org/10.1093/database/baz152)  
+  Describes how we solicited help from the research community to generate manually written summaries of D.
+- **FlyBase: updates to theDrosophila melanogasterknowledge base** — Larkin et al., *Nucleic Acids Research* (2020). [doi:10.1093/nar/gkaa1026](https://doi.org/10.1093/nar/gkaa1026)  
+  Describes the introduction of several new features at FlyBase, including Pathway Reports, paralog information, disease models based on orthology, customizable tables within reports and overview….
+- **KG-COVID-19: A Framework to Produce Customized Knowledge Graphs for COVID-19 Response** — Reese et al., *preprint* (2020). [doi:10.2139/ssrn.3681978](https://doi.org/10.2139/ssrn.3681978)  
+  This KG framework can also be applied to other problems in which siloed biomedical data must be quickly integrated for different research applications, including future….
+- **A systematic survey of temporal requirements of bio-health ontologies** — Leo et al., *Semantic Web* (2020). [doi:10.3233/sw-190357](https://doi.org/10.3233/sw-190357)
+- **Ontology-Based Generation of Medical, Multi-term MCQs** — Leo et al., *International Journal of Artificial Intelligence in Education* (2019). [doi:10.1007/s40593-018-00172-w](https://doi.org/10.1007/s40593-018-00172-w)
+- **SynGO: An Evidence-Based, Expert-Curated Knowledge Base for the Synapse** — Koopmans et al., *Neuron* (2019). [doi:10.1016/j.neuron.2019.05.002](https://doi.org/10.1016/j.neuron.2019.05.002)  
+  Using 2,922 annotations for 1,112 genes, we show that synaptic genes are exceptionally well conserved and less tolerant to mutations than other genes.
+- **Measuring expert performance at manually classifying domain entities under upper ontology classes** — Stevens et al., *Journal of Web Semantics* (2019). [doi:10.1016/j.websem.2018.08.004](https://doi.org/10.1016/j.websem.2018.08.004)
+- **Comparing ontology authoring workflows with Protégé: In the laboratory, in the tutorial and in the ‘wild’** — Vigo et al., *Journal of Web Semantics* (2019). [doi:10.1016/j.websem.2018.09.004](https://doi.org/10.1016/j.websem.2018.09.004)
+- **Gene Ontology Causal Activity Modeling (GO-CAM) moves beyond GO annotations to structured descriptions of biological functions and systems** — Thomas et al., *Nature Genetics* (2019). [doi:10.1038/s41588-019-0500-1](https://doi.org/10.1038/s41588-019-0500-1)
+- **Representing glycophenotypes: semantic unification of glycobiology resources for disease discovery** — Gourdine et al., *Database* (2019). [doi:10.1093/database/baz114](https://doi.org/10.1093/database/baz114)  
+  Shows how semantically structuring knowledge about the annotation of glycophenotypes could enhance disease diagnosis, and propose a solution to integrate glycophenotypes and related diseases into….
+- **Inference Inspector: Improving the verification of ontology authoring actions** — Matentzoglu et al., *Journal of Web Semantics* (2018). [doi:10.1016/j.websem.2017.09.004](https://doi.org/10.1016/j.websem.2017.09.004)
+- **FlyBase 2.0: the next generation** — Thurmond et al., *Nucleic Acids Research* (2018). [doi:10.1093/nar/gky1003](https://doi.org/10.1093/nar/gky1003)  
+  FlyBase (flybase.org) is a knowledge base that supports the community of researchers that use the fruit fly, Drosophila melanogaster, as a model organism.
+- **Improving Interpretation of Cardiac Phenotypes and Enhancing Discovery With Expanded Knowledge in the Gene Ontology** — Lovering et al., *Circulation: Genomic and Precision Medicine* (2018). [doi:10.1161/circgen.117.001813](https://doi.org/10.1161/circgen.117.001813)  
+  Methods and Results: In this study, we created a computational resource to facilitate genetic studies of cardiac physiology by integrating literature curation with attention to an improved and….
+- **MIRO: guidelines for minimum information for the reporting of an ontology** — Matentzoglu et al., *Journal of Biomedical Semantics* (2018). [doi:10.1186/s13326-017-0172-7](https://doi.org/10.1186/s13326-017-0172-7)  
+  Background Creation and use of ontologies has become a mainstream activity in many disciplines, in particular, the biomedical domain.
+- **Using OWL reasoning to support the generation of novel gene sets for enrichment analysis** — Osumi-Sutherland et al., *Journal of Biomedical Semantics* (2018). [doi:10.1186/s13326-018-0175-z](https://doi.org/10.1186/s13326-018-0175-z)  
+  Background The Gene Ontology (GO) consists of over 40,000 terms for biological processes, cell components and gene product activities linked into a graph structure by over 90,000 relationships.
+- **The OWL Reasoner Evaluation (ORE) 2015 Competition Report** — Parsia et al., *Journal of Automated Reasoning* (2017). [doi:10.1007/s10817-017-9406-8](https://doi.org/10.1007/s10817-017-9406-8)  
+  Discuss the design, execution and results of the 2015 competition with particular attention to lessons learned for benchmarking, comparative experiments, and future competitions.
+- **OWL Reasoning: Subsumption Test Hardness and Modularity** — Matentzoglu, Parsia & Sattler, *Journal of Automated Reasoning* (2017). [doi:10.1007/s10817-017-9414-8](https://doi.org/10.1007/s10817-017-9414-8)  
+  Presents sound evidence that, while the impact of subsumption testing is significant only for a small number of ontologies across a popular collection of 330 ontologies (BioPortal), modularity has….
+- **Cell ontology in an age of data-driven cell classification** — Osumi-Sutherland, *BMC Bioinformatics* (2017). [doi:10.1186/s12859-017-1980-6](https://doi.org/10.1186/s12859-017-1980-6)  
+  Background Data-driven cell classification is becoming common and is now being implemented on a massive scale by projects such as the Human Cell Atlas.
+- **Dead simple OWL design patterns** — Osumi-Sutherland et al., *Journal of Biomedical Semantics* (2017). [doi:10.1186/s13326-017-0126-0](https://doi.org/10.1186/s13326-017-0126-0)  
+  Results Here we describe a system, Dead Simple OWL Design Patterns (DOS-DPs), which fulfills these requirements, illustrating the system with examples from the Gene Ontology.
+- **Bacterial Virus Ontology; Coordinating across Databases** — Hulo et al., *Viruses* (2017). [doi:10.3390/v9060126](https://doi.org/10.3390/v9060126)  
+  Bacterial viruses, also called bacteriophages, display a great genetic diversity and utilize unique processes for infecting and reproducing within a host cell.
+- **The OWL Reasoner Evaluation (ORE) 2015 Resources** — Parsia et al., *Lecture Notes in Computer Science* (2016). [doi:10.1007/978-3-319-46547-0_17](https://doi.org/10.1007/978-3-319-46547-0_17)
+- **NBLAST: Rapid, Sensitive Comparison of Neuronal Structure and Construction of Neuron Family Databases** — Costa et al., *Neuron* (2016). [doi:10.1016/j.neuron.2016.06.012](https://doi.org/10.1016/j.neuron.2016.06.012)  
+  NBLAST: a fast, sensitive measure of morphological similarity between neurons, and the basis of VFB’s “similar neurons” queries.
+- **PhenoImageShare: an image annotation and query infrastructure** — Adebayo et al., *Journal of Biomedical Semantics* (2016). [doi:10.1186/s13326-016-0072-2](https://doi.org/10.1186/s13326-016-0072-2)  
+  Background High throughput imaging is now available to many groups and it is possible to generate a large quantity of high quality images quickly.
+- **The Cell Ontology 2016: enhanced content, modularization, and ontology interoperability** — Diehl et al., *Journal of Biomedical Semantics* (2016). [doi:10.1186/s13326-016-0088-7](https://doi.org/10.1186/s13326-016-0088-7)  
+  Background The Cell Ontology (CL) is an OBO Foundry candidate ontology covering the domain of canonical, natural biological cell types.
+- **FlyBase portals to human disease research using Drosophila models** — Millburn et al., *Disease Models & Mechanisms* (2016). [doi:10.1242/dmm.023317](https://doi.org/10.1242/dmm.023317)  
+  FlyBase has recently introduced Human Disease Model Reports, each of which presents background information on a specific disease, a tabulation of related disease subtypes, and summaries of….
+- **Guidelines for the functional annotation of microRNAs using the Gene Ontology** — Huntley et al., *RNA* (2016). [doi:10.1261/rna.055301.115](https://doi.org/10.1261/rna.055301.115)  
+  Describes the key aspects of the work, including development of the Gene Ontology to represent this data, standards for describing the data, and guidelines to support curators making these….
+- **A Multi-reasoner, Justification-Based Approach to Reasoner Correctness** — Lee et al., *Lecture Notes in Computer Science* (2015). [doi:10.1007/978-3-319-25010-6_26](https://doi.org/10.1007/978-3-319-25010-6_26)
+- **FlyBase: establishing a Gene Group resource for Drosophila melanogaster** — Attrill et al., *Nucleic Acids Research* (2015). [doi:10.1093/nar/gkv1046](https://doi.org/10.1093/nar/gkv1046)  
+  Many publications describe sets of genes or gene products that share a common biology.
+- **Representing virus-host interactions and other multi-organism processes in the Gene Ontology** — Foulger et al., *BMC Microbiology* (2015). [doi:10.1186/s12866-015-0481-x](https://doi.org/10.1186/s12866-015-0481-x)  
+  Recognising this, we have worked closely with annotation groups to test and optimize the GO classes, and we describe here a set of annotation guidelines that allow the controlled description of….
+- **Use of OWL within the Gene Ontology** — Mungall, Dietze & Osumi-Sutherland, *bioRxiv* (2014). [doi:10.1101/010090](https://doi.org/10.1101/010090)  
+  Outline some of the lesser known features of the GO, describe the GO development process, and our prognosis for future development in terms of the OWL representation.
+- **Nose to tail, roots to shoots: spatial descriptors for phenotypic diversity in the Biological Spatial Ontology** — Dahdul et al., *Journal of Biomedical Semantics* (2014). [doi:10.1186/2041-1480-5-34](https://doi.org/10.1186/2041-1480-5-34)  
+  Develops the Biological Spatial Ontology (BSPO) to standardize the description of spatial and topological relationships across taxa to enable the discovery of comparable phenotypes.
+- **TermGenie – a web-application for pattern-based ontology class generation** — Dietze et al., *Journal of Biomedical Semantics* (2014). [doi:10.1186/2041-1480-5-48](https://doi.org/10.1186/2041-1480-5-48)  
+  Background Biological ontologies are continually growing and improving from requests for new classes (terms) by biocurators.
+- **A Snapshot of the OWL Web** — Matentzoglu, Bail & Parsia, *Lecture Notes in Computer Science* (2013). [doi:10.1007/978-3-642-41335-3_21](https://doi.org/10.1007/978-3-642-41335-3_21)
+- **Directly e-mailing authors of newly published papers encourages community curation** — Bunt et al., *Database* (2012). [doi:10.1093/database/bas024](https://doi.org/10.1093/database/bas024)  
+  Reports recent improvements to the triaging process used by FlyBase.
+- **BrainTrap: a database of 3D protein expression patterns in the Drosophila brain** — Knowles-Barley, Longair & Armstrong, *Database* (2010). [doi:10.1093/database/baq005](https://doi.org/10.1093/database/baq005)  
+  Presents BrainTrap, available at http://fruitfly.inf.ed.ac.uk/braintrap, an online database of 3D confocal datasets showing reporter gene expression and protein localization in the adult brain of….
+- **FlyBase: enhancing Drosophila Gene Ontology annotations** — Tweedie et al., *Nucleic Acids Research* (2009). [doi:10.1093/nar/gkn788](https://doi.org/10.1093/nar/gkn788)  
+  Gene Ontology (GO) terms are used to describe three attributes of wild-type gene products: their molecular function, the biological processes in which they play a role, and their subcellular location.
+
+## Not published
+
+Some of what VFB serves has no paper to cite. The third-instar (L3) larval CNS template and
+its 255 painted domains are unpublished work by **David Wood and Volker Hartenstein**,
+credited as such in the VFB resource paper. If you use that template, credit it that way.
+
+---
+
+*This page lists work by the team. It is assembled from ORCID records and the DOIs cited
+across this site, filtered to work related to VFB and its data, so it is not a complete
+bibliography for any individual — primary research by team members outside VFB's scope is
+deliberately not listed. If something is missing that should be here, please
+[get in touch](/about/contactus/).*


### PR DESCRIPTION
## What

Rewrites `/about/publications/` from six entries to 126, covering work by current and past
team members that bears on VFB.

## How it was assembled

- Every work on ORCID for the team members who have one — Osumi-Sutherland (84), Jefferis
  (89), O'Kane (94), Matentzoglu (38), Millburn (26), Staudt (16), Pilgrim (13), Larkin (7),
  Kir (6), McLachlan (4).
- Every DOI cited anywhere on this site.
- Filtered to papers where Crossref confirms a team member as an author: 275.
- Then to work related to VFB and its data: 126.

Every DOI on the page was resolved and checked against its record.

## Themes

| Section | n |
|---|---|
| Virtual Fly Brain | 3 |
| Anatomy, nomenclature and the Drosophila ontologies | 12 |
| Connectomes, annotation and cell typing | 34 |
| Imaging, registration and analysis tools | 16 |
| Ontologies, standards and data infrastructure | 61 |

## The L3 larval template

VFB's L3 template has no paper — the resource paper credits it to David Wood and Volker
Hartenstein as unpublished. The mapping and registration behind it is written up in David
Wood's Edinburgh PhD thesis, *Data driven mapping of the Drosophila larval central nervous
system* (2019, hdl:1842/35918), which is now listed and cited. A short "Theses" section
tells users to cite the thesis and credit the painted domains to Wood and Hartenstein.

## What is deliberately not here

91 papers classified as primary fly neurobiology by team members, and 60 with no bearing on
VFB (Mondo, Monarch, EBI annual reports, zebrafish antibodies). This is a page about work
related to VFB, not a full bibliography for any individual — the page says so. Widening it
is a one-line change to the filter if that is wanted.

## Descriptions

Each entry carries a one-line description drawn from the paper's own abstract and
normalised. The eleven that matter most — the VFB papers, FBbt, the phenotype ontology, the
schema paper, NBLAST, natverse, Geppetto, Husz — are hand-written, because the extracted
lines for those read poorly.

## Note

ORCID name search could not identify records for Robert Court, Marta Costa, Douglas
Armstrong, Nick Brown, Nestor Milyaev, Helen Parkinson, Alex Holmes or Simon Reeve; their
work is included via Crossref author matching. If those ORCIDs exist, adding them would
improve coverage.

## Testing

Builds clean. 126 DOIs and one handle resolved and checked. Rendered in a browser: six
sections, correct heading structure, no console errors.
