### PR TITLE
Publish an OpenSearch description so browsers can search VFB

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -44,8 +44,23 @@ timeZone = "Europe/London"
   blog = "/:section/:year/:month/:day/:slug/"
 
 [outputs]
-  home = ["HTML", "RSS", "JSON"]
+  home = ["HTML", "RSS", "JSON", "OpenSearch"]
   section = ["HTML", "RSS"]
+
+# OpenSearch description, served at /opensearch.xml. Chrome, Edge and Firefox
+# discover it from the <link rel="search"> in the page head and register the
+# site as a search engine, so a user can type the domain, press Tab, and query
+# VFB from the address bar. This is the mechanism that still works: Google
+# retired the sitelinks search box on 21 November 2024, so the WebSite/
+# SearchAction JSON-LD no longer renders a search box in Google results.
+[mediaTypes."application/opensearchdescription+xml"]
+  suffixes = ["xml"]
+
+[outputFormats.OpenSearch]
+  mediaType   = "application/opensearchdescription+xml"
+  baseName    = "opensearch"
+  isPlainText = false
+  rel         = "search"
 
 # The section RSS feeds would otherwise include every page in the section —
 # for an ontology section that is the whole generated term corpus in one XML

--- a/themes/vfb-nova/layouts/index.opensearch.xml
+++ b/themes/vfb-nova/layouts/index.opensearch.xml
@@ -1,0 +1,12 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  {{- /* ShortName is capped at 16 characters by the OpenSearch spec. */}}
+  <ShortName>VirtualFlyBrain</ShortName>
+  <LongName>{{ .Site.Title }}</LongName>
+  <Description>Search Drosophila neurons, brain regions, expression patterns and documentation on Virtual Fly Brain.</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">{{ "favicons/favicon.ico" | absURL }}</Image>
+  <Url type="text/html" method="get" template="{{ .Site.BaseURL }}search/?q={searchTerms}"/>
+  <moz:SearchForm>{{ .Site.BaseURL }}search/</moz:SearchForm>
+</OpenSearchDescription>

--- a/themes/vfb-nova/layouts/partials/head.html
+++ b/themes/vfb-nova/layouts/partials/head.html
@@ -28,6 +28,11 @@
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta name="twitter:card" content="summary_large_image">
 
+{{/* Let the browser register VFB as a searchable site: type the domain, Tab,
+     then query. Emitted on every page so any landing page is enough. */}}
+<link rel="search" type="application/opensearchdescription+xml"
+      title="{{ .Site.Title }}" href="{{ "/opensearch.xml" | absURL }}">
+
 <link rel="icon" href="/favicons/favicon.ico">
 
 {{/* Theme is applied before first paint so there is no light-to-dark flash. */}}


### PR DESCRIPTION
## What

Publishes an OpenSearch description at `/opensearch.xml` and links it from every page, so
Chrome, Edge and Firefox can register VFB as a search engine. A user types the domain,
presses Tab, and queries VFB from the address bar.

## Why this, and a correction to #446

#446 added `WebSite`/`SearchAction` JSON-LD for Google's sitelinks search box. **Google
retired that feature on 21 November 2024**, globally, in all languages — so the markup no
longer renders a search box in Google results. Google's guidance is to leave it in place:
"there's no need to [remove it]. Unsupported structured data like this won't cause issues
in Search, and won't trigger errors in Search Console reports." It stays, and other
consumers may still read it, but it is not what gets a query sent to us.

OpenSearch is the mechanism that still works, and it works at the browser rather than at
the search engine.

## Implementation

- A Hugo custom output format, so the URL template is built from `baseURL` rather than
  hardcoded. `/opensearch.xml` is generated as part of the home page's outputs.
- `<link rel="search">` is emitted on **every** page rather than only the home page, so
  whichever page a visitor lands on is enough for the browser to register the site.
- URL template: `{baseURL}search/?q={searchTerms}`.

## Validated

- Parses as XML; `{searchTerms}` present in the template.
- `ShortName` is 15 characters — the OpenSearch spec caps it at 16, which is why it reads
  `VirtualFlyBrain` with `Virtual Fly Brain` as the `LongName`.
- `rel="search"` present on the home page, `/search/` and a docs page.
- Builds clean, 198 → 199 pages.

## Known limitation

nginx serves `.xml` as `text/xml` from its default `mime.types`, not
`application/opensearchdescription+xml`. Chrome and Edge go by the `type` attribute on the
`<link>` so discovery works regardless; Firefox has historically been stricter. Fixing it
properly is a one-line `types { application/opensearchdescription+xml xml; }` in the
nginx image, which is worth batching with the next image release rather than cutting one
for this alone.
