### PR TITLE
Correct the FANC source publication citation

### DIFF
--- a/content/en/hosted/fanc-catmaid.md
+++ b/content/en/hosted/fanc-catmaid.md
@@ -21,7 +21,7 @@ This resource provides access to both the original FANC dataset and template-ali
 
 The data is from the research published in:
 
-Fushiki A, et al. (2021) A circuit mechanism for the propagation of waves of muscle contraction in Drosophila. Cell, 184(3), 759-774.e20. https://doi.org/10.1016/j.cell.2020.12.013
+Phelps JS, Hildebrand DGC, Graham BJ, et al. (2021) Reconstruction of motor control circuits in adult Drosophila using automated transmission electron microscopy. Cell, 184(3), 759-774.e18. https://doi.org/10.1016/j.cell.2020.12.013
 
 see: https://www.lee.hms.harvard.edu/resources
 
@@ -57,7 +57,7 @@ Note: Both views (original and aligned) can be accessed through the same API usi
 When using this data, please cite:
 
 1. The FANC dataset:
-   Fushiki A, et al. (2021) A circuit mechanism for the propagation of waves of muscle contraction in Drosophila. Cell, 184(3), 759-774.e20. https://doi.org/10.1016/j.cell.2020.12.013
+   Phelps JS, Hildebrand DGC, Graham BJ, et al. (2021) Reconstruction of motor control circuits in adult Drosophila using automated transmission electron microscopy. Cell, 184(3), 759-774.e18. https://doi.org/10.1016/j.cell.2020.12.013
 
 2. The CATMAID platform:
    Saalfeld S, Cardona A, Hartenstein V, Tomančák P (2009) CATMAID: collaborative annotation toolkit for massive amounts of image data. Bioinformatics 25(15): 1984-1986. https://doi.org/10.1093/bioinformatics/btp266


### PR DESCRIPTION
`content/en/hosted/fanc-catmaid.md` cited the FANC dataset as Fushiki et al.,
"A circuit mechanism for the propagation of waves of muscle contraction in
Drosophila" — a larval paper (eLife 2016) — while carrying the correct Cell
volume, issue and DOI for the FANC paper. Only the title and first author were
wrong, so the error sat next to a DOI that resolves to the right paper.

**What changed**

Both occurrences (Source Publication, Citation Guidelines) now read:

> Phelps JS, Hildebrand DGC, Graham BJ, et al. (2021) Reconstruction of motor
> control circuits in adult Drosophila using automated transmission electron
> microscopy. Cell, 184(3), 759-774.e18. https://doi.org/10.1016/j.cell.2020.12.013

The elocation is also corrected from `.e20` to `.e18` to match Crossref.

**How to test**

Verified against Crossref: `curl https://api.crossref.org/works/10.1016/j.cell.2020.12.013`
returns title "Reconstruction of motor control circuits in adult Drosophila
using automated transmission electron microscopy", Cell 184(3), 759-774.e18,
first author Jasper S. Phelps.

**Follow-ups**

None for this page. `content/en/docs/Data/EM/_index.md` already cites Phelps et
al. against the same DOI, so the site is internally consistent after this. The
Fushiki citation on `content/en/hosted/l1em-catmaid.md` is correct (2016) and
untouched.
