### PR TITLE
Link the hosted CATMAID instances from the EM data page

### DIFF
--- a/content/en/about/funding.md
+++ b/content/en/about/funding.md
@@ -45,7 +45,7 @@ description: "Virtual Fly Brain has been supported by grants from multiple UK re
 - Grant supporting Marta Costa's research: "Neuroinformatic identification of new types of neuron in the Drosophila brain" (October 2012 - September 2013)
 
 **Wellcome Trust - Cambridge Protein Trap Project**
-- Supporting [BrainTrap](https://virtualflybrain.org/about/hosted/braintrap/) database development
+- Supporting [BrainTrap](/hosted/braintrap/) database development
 - Recipients: Kathryn Lilley, Steve Russell, Daniel St. Johnson
 
 ## Institutional Partners

--- a/content/en/docs/Data/EM/_index.md
+++ b/content/en/docs/Data/EM/_index.md
@@ -21,15 +21,15 @@ The table below summarises EM datasets that have been integrated into VFB, inclu
 
 | Dataset | VFB symbol | Version in VFB | Anatomy | Reconstruction | Resource(s) | Original Publication |
 |---|---|---|---|---|---|---|
-| BANC | `BANC` | v626 | Full CNS (adult female) | Dense | Codex | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
-| male-CNS | `mc` | v0.9 | Full CNS (adult male) | Dense | NeuPrint; Codex | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
-| Optic-lobe | `ol` | v1.0.1 | Optic lobe (adult male) | Dense | NeuPrint; Codex | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
-| FAFB (FlyWire) | `fw` | v783 | Full brain (adult female) | Dense | Codex | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
-| MANC | `mv` | v1.2.1 | Full VNC (adult male) | Dense | NeuPrint; Codex | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
-| Hemibrain | `hb` | v1.2.1 | Partial brain (adult female) | Dense | NeuPrint | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
-| FAFB (CATMAID) | `fafb` | — | Full brain (adult female) | Sparse | CATMAID | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
-| L1 CNS (CATMAID) | `l1em` | — | Full CNS (female larva) | Sparse | CATMAID | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
-| FANC | — | — | Full VNS (adult female) | Sparse | CATMAID | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013) |
+| BANC | `BANC` | v626 | Full CNS (adult female) | Dense | [Codex](https://codex.flywire.ai/) | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
+| male-CNS | `mc` | v0.9 | Full CNS (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
+| Optic-lobe | `ol` | v1.0.1 | Optic lobe (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
+| FAFB (FlyWire) | `fw` | v783 | Full brain (adult female) | Dense | [Codex](https://codex.flywire.ai/) | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
+| MANC | `mv` | v1.2.1 | Full VNC (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
+| Hemibrain | `hb` | v1.2.1 | Partial brain (adult female) | Dense | [NeuPrint](https://neuprint.janelia.org/) | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
+| FAFB (CATMAID) | `fafb` | — | Full brain (adult female) | Sparse | [CATMAID (VFB)](/hosted/fafb-catmaid/) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
+| L1 CNS (CATMAID) | `l1em` | — | Full CNS (female larva) | Sparse | [CATMAID (VFB)](/hosted/l1em-catmaid/) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
+| FANC | — | — | Full VNS (adult female) | Sparse | [CATMAID (VFB)](/hosted/fanc-catmaid/) | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013) |
 
 A neuron count, and often a neuron's identifier, is a property of a **release** rather than of a
 dataset. The versions above are what VFB currently holds; see
@@ -43,4 +43,32 @@ and which datasets to exclude.
 
 ## Datasets Hosted by VFB
 
-Virtual Fly Brain (VFB) hosts several CATMAID instances for exploring connectomic reconstruction data. These datasets provide access to neuroanatomical data from various Drosophila electron microscopy projects. Each instance has its own page under [sites hosted by VFB](/hosted/).
+VFB runs the public CATMAID instances below. Several are archives of resources whose original
+hosts have gone offline, and for some VFB is the only remaining public copy; others are served
+here because VFB is where the dataset is published from. Each instance has its own page under
+[sites hosted by VFB](/hosted/), giving what it contains, how to open it and how to cite it.
+
+Hosting an instance is not the same as integrating its neurons. Only the datasets marked below
+are registered in the VFB knowledge base and reachable from a VFB search, term page or API call;
+for the rest, the CATMAID instance is the way in.
+
+| Instance | Anatomy | In the VFB knowledge base | Original publication |
+|---|---|---|---|
+| [FAFB CATMAID](/hosted/fafb-catmaid/) | Full brain (adult female) | Neurons and connectivity (`fafb`) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019); [FAFB project](https://flyconnecto.me/) |
+| [L1EM CATMAID](/hosted/l1em-catmaid/) | Full CNS (first instar larva) | Neurons and connectivity (`l1em`) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Winding et al. (2023)](https://doi.org/10.1126/science.add9330) |
+| [FANC CATMAID](/hosted/fanc-catmaid/) | Full VNS (adult female) | Neurons only — no connectivity | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013); [Lee lab resources](https://www.lee.hms.harvard.edu/resources) |
+| [ABD1.5 CATMAID](/hosted/abd1-5-catmaid/) | Abdominal segments A2–A3 (first instar larva), wild type | No | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Schneider-Mizell et al. (2016)](https://doi.org/10.7554/eLife.12059); [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [IAV-ROBO CATMAID](/hosted/iav-robo-catmaid/) | Abdominal segments A1–A2 (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [IAV-TNT CATMAID](/hosted/iav-tnt-catmaid/) | Full CNS (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [L3VNC CATMAID](/hosted/l3vnc-catmaid/) | Ventral nerve cord (third instar larva) | No | [Gerhard et al. (2017)](https://doi.org/10.7554/eLife.29089) |
+| [Larva1099 CATMAID](/hosted/larva1099-catmaid/) | Full CNS (first instar larva), eFIB-SEM | No | [Randel et al. (2026)](https://doi.org/10.1101/2025.09.25.678485) |
+
+The IAV-ROBO and IAV-TNT volumes were imaged from animals whose circuits had been altered
+experimentally — a misexpression and a synaptic-silencing manipulation respectively — rather than
+from wild-type animals. Their neurons carry projections that the manipulation moved, so they do
+not correspond to the wild-type anatomy the Drosophila Anatomy Ontology describes and are
+deliberately not registered as VFB individuals. Comparing them against the wild-type ABD1.5
+reference is the point of the dataset; use the CATMAID instances directly to do it.
+
+VFB also hosts two non-CATMAID resources: [BrainTrap](/hosted/braintrap/), a database of 3D
+protein-trap expression patterns, and the [FLYBRAIN Neuron Database](/hosted/flybrainndb/).

--- a/content/en/docs/Data/EM/_index.md
+++ b/content/en/docs/Data/EM/_index.md
@@ -21,12 +21,12 @@ The table below summarises EM datasets that have been integrated into VFB, inclu
 
 | Dataset | VFB symbol | Version in VFB | Anatomy | Reconstruction | Resource(s) | Original Publication |
 |---|---|---|---|---|---|---|
-| BANC | `BANC` | v626 | Full CNS (adult female) | Dense | [Codex](https://codex.flywire.ai/) | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
-| male-CNS | `mc` | v0.9 | Full CNS (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
-| Optic-lobe | `ol` | v1.0.1 | Optic lobe (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
-| FAFB (FlyWire) | `fw` | v783 | Full brain (adult female) | Dense | [Codex](https://codex.flywire.ai/) | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
-| MANC | `mv` | v1.2.1 | Full VNC (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/); [Codex](https://codex.flywire.ai/) | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
-| Hemibrain | `hb` | v1.2.1 | Partial brain (adult female) | Dense | [NeuPrint](https://neuprint.janelia.org/) | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
+| BANC | `BANC` | v626 | Full CNS (adult female) | Dense | [Codex](https://codex.flywire.ai/?dataset=banc&data_version=626) | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
+| male-CNS | `mc` | v0.9 | Full CNS (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=male-cns%3Av0.9&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
+| Optic-lobe | `ol` | v1.0.1 | Optic lobe (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=optic-lobe%3Av1.0.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
+| FAFB (FlyWire) | `fw` | v783 | Full brain (adult female) | Dense | [Codex](https://codex.flywire.ai/?data_version=783) | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
+| MANC | `mv` | v1.2.1 | Full VNC (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=manc%3Av1.2.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
+| Hemibrain | `hb` | v1.2.1 | Partial brain (adult female) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=hemibrain%3Av1.2.1&qt=findneurons) | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
 | FAFB (CATMAID) | `fafb` | — | Full brain (adult female) | Sparse | [CATMAID (VFB)](/hosted/fafb-catmaid/) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
 | L1 CNS (CATMAID) | `l1em` | — | Full CNS (female larva) | Sparse | [CATMAID (VFB)](/hosted/l1em-catmaid/) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
 | FANC | — | — | Full VNS (adult female) | Sparse | [CATMAID (VFB)](/hosted/fanc-catmaid/) | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013) |


### PR DESCRIPTION
Nothing in `content/` linked to an individual page under `/hosted/`. The EM data
page named CATMAID as a plain string in the Resource(s) column and pointed at the
`/hosted/` index, so a reader looking at the FANC row had no route to the FANC
instance, its access URLs or its citation. The only deep link to a hosted page
anywhere on the site was in `about/funding.md`, and it was a 404.

**What changed**

`Resource(s)` in the comparison table now links: Codex and NeuPrint to their own
sites, and the three CATMAID rows to the VFB page for that instance.

"Datasets Hosted by VFB" is now a table of all eight CATMAID instances, each
linked to its page and to the original publication DOI. The publication links are
the ones VFB holds against the dataset term, so the page agrees with the
knowledge base. Two non-CATMAID hosted resources (BrainTrap, FLYBRAIN NDB) are
linked in a closing line, so all ten hosted pages now have an inbound link.

The table also records whether an instance's neurons are in the VFB knowledge
base, which hosting alone does not imply:

- FAFB and L1EM — neurons and connectivity (`fafb`, `l1em`)
- FANC — neurons only; FANC is not a connectome in VFB
- ABD1.5, IAV-ROBO, IAV-TNT, L3VNC, Larva1099 — hosted only

IAV-ROBO and IAV-TNT get a note of their own. Those volumes were imaged from
animals whose circuits had been altered experimentally — a misexpression and a
synaptic-silencing manipulation — rather than from wild-type animals. Their
projections do not correspond to the wild-type anatomy the DAO describes, so the
neurons are deliberately not registered as VFB individuals, and the CATMAID
instance is the way in. Comparing them against the wild-type ABD1.5 reference is
the point of the dataset.

`funding.md` linked BrainTrap at `/about/hosted/braintrap/`, which has no alias
and no redirect. Corrected to `/hosted/braintrap/`.

**How to test**

`hugo v0.164.0-extended` build: all ten `/hosted/` pages resolve, no broken
internal links on either edited page. Note the FLYBRAIN NDB page is
`/hosted/flybrainndb/`, not `/hosted/flybrainNDB/` — Hugo lowercases the path.

**Follow-ups**

Not done here, deliberately: Larva1099, ABD1.5, IAV-ROBO, IAV-TNT and L3VNC have
no row in the "Integrated Datasets" comparison table. That table is about what is
integrated, so leaving them out is arguably correct — worth a decision rather
than a silent fix.
