### PR TITLE
Give partner logos their own plate so they survive dark mode

### DIFF
--- a/content/en/about/collaborators.md
+++ b/content/en/about/collaborators.md
@@ -5,7 +5,7 @@ weight: 500
 
 ## Collaborators
 
-  <a href="http://www.hgu.mrc.ac.uk/"><img src="https://v2.virtualflybrain.org/images/vfb/project/logos/mrchguLogo.png" alt="mrchguLogo.png" width="300" /></a>
+  <a href="http://www.hgu.mrc.ac.uk/"><img src="https://v2.virtualflybrain.org/images/vfb/project/logos/mrchguLogo.png" alt="mrchguLogo.png" class="logo-plate" width="300" /></a>
 
   **The IIP3D server, Woolz software and client-side tools* are developed by**
   MRC Human Genetics Unit (MRC HGU): Richard Baldock, Nick Burton, Bill Hill, Zsolt Husz

--- a/content/en/about/members.md
+++ b/content/en/about/members.md
@@ -49,15 +49,15 @@ MetaCell collaborates with Virtual Fly Brain on the development and enhancement 
 ---
 <!--- width set to 55 here to prevent bunching onto same line -->
 <a href='https://www.anc.ed.ac.uk/index.php?option=com_content&task=view&id=12&Itemid=68' target='_blank'>
-  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/InformaticsLogo.gif' style="max-width: 55%"/>
+  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/InformaticsLogo.gif' class="logo-plate" style="max-width: 55%"/>
 </a>
 
 <a href='https://www.gen.cam.ac.uk/' target='_blank'>
-  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/CUnibig.png' style="max-width: 55%"/>
+  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/CUnibig.png' class="logo-plate" style="max-width: 55%"/>
 </a>
 
 <a href='https://www.sanger.ac.uk/' target='_blank'>
-  <img src='https://virtualflybrain.org/images/logo-sanger-blue.svg' style="max-width: 55%"/>
+  <img src='https://virtualflybrain.org/images/logo-sanger-blue.svg' class="logo-plate" style="max-width: 55%"/>
 </a>  
 
 <a href='http://www2.mrc-lmb.cam.ac.uk/' target='_blank'>
@@ -65,11 +65,11 @@ MetaCell collaborates with Virtual Fly Brain on the development and enhancement 
 </a>  
 
 <a href='https://www.ebi.ac.uk/' target='_blank'>
-  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/EMBL_EBI_logo_180pixels_RGB.png' style="max-width: 55%"/>
+  <img src='https://v2.virtualflybrain.org/images/vfb/project/logos/EMBL_EBI_logo_180pixels_RGB.png' class="logo-plate" style="max-width: 55%"/>
 </a>  
 
 <a href='https://www.metacell.us/' target='_blank'>
-  <img src='https://github.com/tarelli/bucket/raw/master/MetaCellLogoWhite300ppi.png' style="max-width: 55%"/>
+  <img src='https://github.com/tarelli/bucket/raw/master/MetaCellLogoWhite300ppi.png' class="logo-plate logo-plate--dark" style="max-width: 55%"/>
 </a>
 
 ---

--- a/themes/vfb-nova/assets/css/prose.css
+++ b/themes/vfb-nova/assets/css/prose.css
@@ -109,6 +109,27 @@
   display: block;
   margin: var(--sp-5) auto;
 }
+
+/* Partner, funder and collaborator logos.
+
+   Most are supplied as transparent PNG/SVG drawn in dark ink for a white page.
+   The default plate above is var(--elev-1), which is #0d1322 in the dark theme
+   — the theme's default — so those logos vanish into it. .logo-plate gives them
+   a white plate in both themes: a logo's colours are set by its owner's brand
+   guidelines and do not follow the site theme, so the plate must not either.
+
+   .logo-plate--dark is the exception for artwork drawn in white ink, which a
+   white plate would erase. Both plate colours are literals rather than theme
+   tokens on purpose: var(--elev-1) is #fff in the light theme, which would
+   erase a white-ink logo there exactly as the dark theme erases a dark-ink one.
+   A logo that ships its own opaque background needs neither class. */
+.prose img.logo-plate {
+  background: #fff;
+  padding: var(--sp-3);
+}
+.prose img.logo-plate--dark {
+  background: #0d1322;
+}
 .prose figure { margin: var(--sp-6) 0; }
 .prose figcaption {
   font-size: .84rem;


### PR DESCRIPTION
The theme defaults to dark and `.prose img` plates every image with
`var(--elev-1)`, which is `#0d1322` there. Most partner logos are transparent
artwork drawn in dark ink for a white page, so on `/about/members/` and
`/about/collaborators/` they were dark-on-near-black.

**What changed**

A `.logo-plate` class in `prose.css`, applied to the five logos that need it.
Measured rather than guessed — transparency and ink luminance sampled per file:

| Logo | Transparent | Dark ink | Plate |
|---|---|---|---|
| Informatics (GIF) | 71% | 87% | white |
| Cambridge | 70% | 92% | white |
| Sanger (SVG) | — | single `#2E3B87` fill | white |
| EMBL-EBI | 76% | 44% | white |
| MRC HGU (collaborators) | 19% | 88% | white |
| MRC LMB | 0% | ships its own taupe background | none |
| MetaCell | 74% | white ink | `.logo-plate--dark` |

MRC LMB gets no class, so it keeps its own background with no frame around it.
MetaCell is the one logo that already worked — white ink on transparent — so a
white plate would erase it.

Both plate colours are literals rather than theme tokens. Using `var(--elev-1)`
for the dark plate looked right until the light theme, where that token is `#fff`
and the MetaCell wordmark disappeared exactly as the dark-ink logos had. A logo's
colours are fixed by its owner's brand guidelines, so the plate behind it must not
follow the site theme either.

**How to test**

`hugo server`, open `/about/members/` and `/about/collaborators/`, toggle the
theme. Verified by screenshotting both pages in both themes from a local build:
all seven logos legible in each.

**Follow-ups**

The MetaCell file is served from `github.com/tarelli/bucket`, a personal repo
outside VFB's control — that logo breaks if the repo moves. Four of the others
come from `v2.virtualflybrain.org` rather than this site's `static/`; only the
Sanger SVG is in this repo.

The ontology blog pages hard-code `background: #000000` inline on their OLS and
FlyBase logos, which is wrong in the light theme. Same class would fix them, but
each needs the same per-logo check first, so they're untouched here.
