### PR TITLE
Document the public anonymous API token on each CATMAID page

### DIFF
--- a/content/en/hosted/abd1-5-catmaid.md
+++ b/content/en/hosted/abd1-5-catmaid.md
@@ -87,6 +87,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://abd1.5.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+ce6984c9d4d00a40d3173a9aad3924afe6612c43
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://abd1.5.catmaid.virtualflybrain.org/1/skeleton/neuronnames \
+  -H "X-Authorization: Token ce6984c9d4d00a40d3173a9aad3924afe6612c43" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite the relevant research:

--- a/content/en/hosted/fafb-catmaid.md
+++ b/content/en/hosted/fafb-catmaid.md
@@ -71,6 +71,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://fafb.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+3ca85fe2f8351ae8f4550f050ab8c0815d53f576
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://fafb.catmaid.virtualflybrain.org/1/skeleton/neuronnames \
+  -H "X-Authorization: Token 3ca85fe2f8351ae8f4550f050ab8c0815d53f576" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite:

--- a/content/en/hosted/fanc-catmaid.md
+++ b/content/en/hosted/fanc-catmaid.md
@@ -50,6 +50,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://fanc.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+7ebf1358497a96845d6aa7b4d0fbd01538fb69c2
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://fanc.catmaid.virtualflybrain.org/1/skeleton/neuronnames \
+  -H "X-Authorization: Token 7ebf1358497a96845d6aa7b4d0fbd01538fb69c2" \
+  --data "skids[0]=16"
+```
+
+
 Note: Both views (original and aligned) can be accessed through the same API using different project IDs (pid).
 
 ## Citation Guidelines

--- a/content/en/hosted/iav-robo-catmaid.md
+++ b/content/en/hosted/iav-robo-catmaid.md
@@ -56,6 +56,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://iav-robo.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+ce6984c9d4d00a40d3173a9aad3924afe6612c43
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://iav-robo.catmaid.virtualflybrain.org/2/skeleton/neuronnames \
+  -H "X-Authorization: Token ce6984c9d4d00a40d3173a9aad3924afe6612c43" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite both:

--- a/content/en/hosted/iav-tnt-catmaid.md
+++ b/content/en/hosted/iav-tnt-catmaid.md
@@ -51,6 +51,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://iav-tnt.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+ce6984c9d4d00a40d3173a9aad3924afe6612c43
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://iav-tnt.catmaid.virtualflybrain.org/4/skeleton/neuronnames \
+  -H "X-Authorization: Token ce6984c9d4d00a40d3173a9aad3924afe6612c43" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite both:

--- a/content/en/hosted/l1em-catmaid.md
+++ b/content/en/hosted/l1em-catmaid.md
@@ -72,6 +72,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://l1em.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+4c1c9c60d4864c41ebc79f42ba99014a9e912f49
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://l1em.catmaid.virtualflybrain.org/1/skeleton/neuronnames \
+  -H "X-Authorization: Token 4c1c9c60d4864c41ebc79f42ba99014a9e912f49" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite:

--- a/content/en/hosted/l3vnc-catmaid.md
+++ b/content/en/hosted/l3vnc-catmaid.md
@@ -39,6 +39,34 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://l3vnc.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+ce6984c9d4d00a40d3173a9aad3924afe6612c43
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://l3vnc.catmaid.virtualflybrain.org/2/skeleton/neuronnames \
+  -H "X-Authorization: Token ce6984c9d4d00a40d3173a9aad3924afe6612c43" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite:

--- a/content/en/hosted/larva1099-catmaid.md
+++ b/content/en/hosted/larva1099-catmaid.md
@@ -38,6 +38,34 @@ This CATMAID instance enables:
 - Neuron-name search
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://larva1099.catmaid.virtualflybrain.org/apis/
 
+### Public API token
+
+Read-only access to this instance is open to everyone, but most of CATMAID's query
+endpoints are POST rather than GET, and POST requests are subject to a CSRF check.
+Command-line and server-side clients (pymaid, curl, scripts) can satisfy that check by
+requesting a page first and replaying the cookie they are given. Code running in a
+browser cannot: it can neither read a cookie belonging to another site nor set a
+`Referer` header. Browser-based tools should therefore authenticate as the anonymous
+user, using this token:
+
+```
+b0cbcf16d84f2b820673471445e3d64d04797d06
+```
+
+**This token is published deliberately and is not a secret.** It authenticates as
+`AnonymousUser`, whose only permission on this project is `can_browse`, so it grants
+exactly the read access this page already offers to everyone and nothing further.
+Write requests made with it are refused by the server.
+
+Send it in either the `X-Authorization` or the `Authorization` header:
+
+```bash
+curl -X POST https://larva1099.catmaid.virtualflybrain.org/1/skeleton/neuronnames \
+  -H "X-Authorization: Token b0cbcf16d84f2b820673471445e3d64d04797d06" \
+  --data "skids[0]=16"
+```
+
+
 ## Citation Guidelines
 
 When using this data, please cite:


### PR DESCRIPTION
CATMAID's query endpoints are mostly POST, and POST is CSRF-checked. Server-side
clients (pymaid, curl, scripts) satisfy that check by fetching a page and replaying
the cookie, but a browser can neither read another site's cookie nor set a Referer,
so browser-based tools had no route to the read-only API these instances already
expose.

Each instance's existing AnonymousUser token is now documented beside the existing
/apis/ link, on all eight hosted CATMAID pages.

These tokens are not new and are not secrets. They already existed (most since 2020),
and they authenticate as AnonymousUser, whose only project permission is can_browse
— exactly the read access these pages already offer to everyone. Writes made with
them are refused server-side by CATMAID's can_annotate_with_token gate. Verified per
instance: read with token 200, read without token 403, write with token 403.

Raised by Philipp Schlegel while adding CATMAID as a data source to coda
(https://navis-org.github.io/coda/).
