### PR TITLE
Surface dataset caveats and the machine-readable instance list

### DIFF
--- a/content/en/hosted/_index.md
+++ b/content/en/hosted/_index.md
@@ -23,3 +23,10 @@ remaining public copy.
 served from. The larva1099 eFIB-SEM volume is the most recent of these.
 
 Each site has its own page below, with what it contains, how to open it and how to cite it.
+
+### Programmatic access
+
+A machine-readable list of the CATMAID instances below — URLs, project IDs and the
+public read-only API tokens — is published at
+[`/data/EM/catmaid.json`](https://virtualflybrain.org/data/EM/catmaid.json) for tools
+that connect to them.

--- a/content/en/hosted/abd1-5-catmaid.md
+++ b/content/en/hosted/abd1-5-catmaid.md
@@ -10,6 +10,14 @@ The ABD1.5 CATMAID instance is hosted and maintained by Virtual Fly Brain (VFB) 
 
 This resource provides wild-type reference data for the abdominal nerve cord of first instar Drosophila larvae, serving as a baseline for comparative connectomics studies. Virtual Fly Brain ensures its long-term availability to the research community.
 
+## Data status
+
+This volume is not being actively worked on. It contains **all** reconstructions
+regardless of publication status, completeness or correctness, so neurons found here
+should not be assumed to be finished or reviewed. The `papers` annotation marks the
+subset published in Valdes-Aleman et al. (2021), where this volume is referred to as
+Control-2; Control-1 is the [L1EM instance](/hosted/l1em-catmaid/), also hosted by VFB.
+
 ## Source Publications
 
 This dataset contains neuron reconstructions from multiple foundational connectomics studies:
@@ -19,6 +27,8 @@ This dataset contains neuron reconstructions from multiple foundational connecto
 2. Schneider-Mizell CM, Gerhard S, Longair M, Kazimiers T, Li F, Zwart MF, et al. (2016). Quantitative neuroanatomy for connectomics in Drosophila. eLife, 5, e12059. https://doi.org/10.7554/eLife.12059
 
 3. Valdes-Aleman J, Fetter RD, Sales EC, Heckman EL, Venkatasubramanian L, Doe CQ, et al. (2021). Comparative Connectomics Reveals How Partner Identity, Location, and Activity Specify Synaptic Connectivity in the Drosophila Motor System. Neuron, 109(1), 105-120.e7. https://doi.org/10.1016/j.neuron.2020.10.004
+
+4. Saalfeld S, Fetter R, Cardona A, Tomancak P (2012). Elastic volume reconstruction from series of ultra-thin microscopy sections. Nature Methods, 9(7), 717-720. https://doi.org/10.1038/nmeth.2072
 
 ## Dataset Contents
 
@@ -128,7 +138,10 @@ When using this data, please cite the relevant research:
 3. For quantitative neuroanatomy methodology:
    Schneider-Mizell CM, et al. (2016). Quantitative neuroanatomy for connectomics in Drosophila. eLife, 5, e12059. https://doi.org/10.7554/eLife.12059
 
-4. The CATMAID platform:
+4. For the volume reconstruction and alignment method:
+   Saalfeld S, Fetter R, Cardona A, Tomancak P (2012). Elastic volume reconstruction from series of ultra-thin microscopy sections. Nature Methods, 9(7), 717-720. https://doi.org/10.1038/nmeth.2072
+
+5. The CATMAID platform:
    Saalfeld S, Cardona A, Hartenstein V, Tomančák P (2009) CATMAID: collaborative annotation toolkit for massive amounts of image data. Bioinformatics 25(15): 1984-1986. https://doi.org/10.1093/bioinformatics/btp266
 
 ## Maintenance & Support

--- a/content/en/hosted/l3vnc-catmaid.md
+++ b/content/en/hosted/l3vnc-catmaid.md
@@ -23,6 +23,14 @@ The viewer provides access to:
 - Synaptic connectivity information
 - Associated metadata and annotations
 
+### Image stack
+
+Scale levels 0 and 1 of the image stack are incomplete, missing roughly 72% and 30% of
+slices respectively. This is a property of the source export rather than a fault in the
+viewer. Because the original imaging is at very high resolution, browsing and
+reconstruction at scale level 2 (or an upscaling of it) is unaffected, and scale level 2
+is the recommended working resolution for this volume.
+
 ## Features
 
 This CATMAID instance enables:


### PR DESCRIPTION
Three things carried over from the 2021 Cardona-lab export README under `/data/EM/`,
which were not reflected anywhere user-facing.

**abd1.5** — the volume is not actively worked on and holds every reconstruction
regardless of publication status, completeness or correctness. Worth stating, since
neurons found there should not be assumed reviewed. Also notes the `papers` annotation
as the published subset and the Control-2 relationship to L1EM, and adds the missing
Saalfeld et al. 2012 elastic volume reconstruction citation (10.1038/nmeth.2072), which
the README lists as a source publication but the page omitted.

**l3vnc** — scale levels 0 and 1 are missing roughly 72% and 30% of slices. A user
zooming to full resolution would otherwise reasonably conclude the instance is broken;
scale level 2 is the working resolution.

**hosted index** — links the machine-readable instance list now published at
https://virtualflybrain.org/data/EM/catmaid.json

Follow-up to #459. Both link targets verified live.
