### PR TITLE
Promote the VFBquery/CATMAID pass-through API as the recommended access path

### DIFF
--- a/content/en/docs/APIs/CATMAID.md
+++ b/content/en/docs/APIs/CATMAID.md
@@ -1,0 +1,78 @@
+---
+title: "CATMAID API (VFB Pass-through)"
+linkTitle: "CATMAID API"
+weight: 10
+date: 2026-08-30
+description: >
+  The fastest and simplest way to pull data out of VFB's hosted CATMAID instances — accepts VFB ids as well as native skeleton ids (skids), needs no token or CSRF handshake, and is cached for speed.
+---
+
+VFB hosts several [CATMAID](https://catmaid.readthedocs.io/) instances (FAFB, FANC, L1EM, Larva1099, and others — see [Hosted Sites](/hosted/)). Each one has its own native CATMAID API, but for most uses **the recommended way to pull data out of any of them is VFB's CATMAID pass-through**, served at:
+
+```
+https://v3-cached.virtualflybrain.org/catmaid/{instance}/{command}
+```
+
+It sits in front of the same instances and forwards to their native API, but resolves two problems that come up as soon as you try to use CATMAID data alongside the rest of VFB: it takes VFB ids directly, and it needs no CSRF cookie, referrer or per-instance token to read data. If you already have a `VFB_...` id from a term-info page or a VFBconnect query, you can hand it straight to the pass-through — no separate lookup step to find the matching skeleton id first.
+
+## Why use it instead of calling CATMAID directly
+
+- **VFB ids and skids, mixed freely.** Pass a list containing both forms — e.g. `VFB_001011rj` alongside a native skid such as `16` — or a comma-separated string of either, and the pass-through resolves VFB ids to skids internally via VFB's knowledge base before forwarding the call.
+- **No token, no CSRF cookie.** CATMAID's own read API is open, but most of its query endpoints are POST and subject to a CSRF check that a plain `curl`/`requests` call has to work around (see the per-instance "Public API token" sections under [Hosted Sites](/hosted/)). The pass-through is a plain JSON GET/POST API with none of that to handle.
+- **GET or POST.** Every command works as `GET .../catmaid/{instance}/{command}?param=value`; the same parameters can go in a POST body instead (JSON object, or form-encoded) — the only way to send an id list too long for a URL.
+- **Cached.** Responses are served from a cache tuned for repeat queries, so the same query is fast on every call after the first.
+- **VFB-registered SWC.** The `swc` command accepts `aligned={template}` to fetch the skeleton already transformed into one of VFB's registered template spaces — something the native CATMAID API doesn't offer, since template registration is VFB's own addition.
+- **One consistent response envelope** across every hosted instance and command, so client code doesn't need per-instance branching.
+
+## Interactive docs and the full command list
+
+The command catalogue changes as commands are added, so it isn't duplicated here. The authoritative, always-current reference is the interactive docs page itself:
+
+- **[https://v3-cached.virtualflybrain.org/](https://v3-cached.virtualflybrain.org/)** — browsable docs for every command, with a "Run" button to try a call directly.
+- **`https://v3-cached.virtualflybrain.org/docs.json`** — the same catalogue as machine-readable JSON, for generating clients or checking parameters programmatically.
+
+## Basic usage
+
+```bash
+# Native skid
+curl "https://v3-cached.virtualflybrain.org/catmaid/fafb/annotations_for_skeletons?ids=16"
+
+# VFB id instead — resolved to a skid internally before the call is forwarded
+curl "https://v3-cached.virtualflybrain.org/catmaid/fafb/annotations_for_skeletons?ids=VFB_001011rj"
+
+# A long id list, or a mix of VFB ids and skids, goes in the POST body instead of the query string
+curl -X POST "https://v3-cached.virtualflybrain.org/catmaid/fafb/annotations_for_skeletons" \
+  -H "Content-Type: application/json" \
+  -d '{"ids": ["VFB_001011rj", 16]}'
+```
+
+`{instance}` is one of the ids from the [Hosted Sites](/hosted/) list (`fafb`, `fanc`, `l1em`, `larva1099`, `abd1.5`, `iav-robo`, `iav-tnt`, `l3vnc`) — the same machine-readable list is published at [`/data/EM/catmaid.json`](https://virtualflybrain.org/data/EM/catmaid.json). `{command}` is any command shown on the docs page, e.g. `annotations_for_skeletons`, `connectivity`, `skeleton_ids`, `swc`. Where an instance hosts more than one CATMAID project (FANC does), pass `project` as a query parameter to pick a project other than the default.
+
+## Response format
+
+Every call returns a JSON object wrapping CATMAID's own response alongside the id resolution VFB did on your behalf:
+
+```json
+{
+  "instance": "fafb",
+  "project_id": 1,
+  "command": "annotations_for_skeletons",
+  "xref_db": "catmaid_fafb",
+  "id_map": {"VFB_001011rj": "2856545"},
+  "unmatched": [],
+  "result": { }
+}
+```
+
+- `id_map` — `{vfb_id: skid}` for every VFB id in your request that resolved to a skeleton on this instance.
+- `unmatched` — VFB ids in your request that had no skeleton on this instance (not every VFB anatomy term has a CATMAID reconstruction).
+- `result` — CATMAID's own response for `command`, unchanged.
+- `reverse_map` — included on commands that return skids as keys or values, mapping them back to VFB ids where one exists.
+
+## Direct access to the underlying CATMAID instance
+
+The pass-through covers read access; for tracing, editing, or anything the pass-through's command list doesn't cover, use the instance's own native CATMAID API directly. Each hosted instance documents this under its own page, with the base API URL, a link to [CATMAID's own API documentation](https://catmaid.readthedocs.io/en/stable/api.html), and the public read-only token needed for browser-based tools:
+
+- [Hosted Sites](/hosted/) — one page per instance (FAFB, FANC, L1EM, Larva1099, and others), each with its "Public API token" section.
+
+Tools that already speak CATMAID's native API directly — [pymaid](/docs/tutorials/apis/pymaid/), [navis](/docs/tutorials/apis/navis/) — continue to work unchanged against those native endpoints; the pass-through is an additional, simpler option for scripts and services that just need data by id, not a replacement for them.

--- a/content/en/docs/APIs/CATMAID.md
+++ b/content/en/docs/APIs/CATMAID.md
@@ -1,13 +1,13 @@
 ---
 title: "CATMAID API (VFB Pass-through)"
 linkTitle: "CATMAID API"
-weight: 10
+weight: 7
 date: 2026-08-30
 description: >
   The fastest and simplest way to pull data out of VFB's hosted CATMAID instances — accepts VFB ids as well as native skeleton ids (skids), needs no token or CSRF handshake, and is cached for speed.
 ---
 
-VFB hosts several [CATMAID](https://catmaid.readthedocs.io/) instances (FAFB, FANC, L1EM, Larva1099, and others — see [Hosted Sites](/hosted/)). Each one has its own native CATMAID API, but for most uses **the recommended way to pull data out of any of them is VFB's CATMAID pass-through**, served at:
+VFB hosts several [CATMAID](https://catmaid.readthedocs.io/) instances (FAFB, FANC, L1EM, Larva1099, and others — see [Hosted Sites](/hosted/)). Each one has its own native CATMAID API, but for most uses **the recommended way to pull data out of any of them is VFB's CATMAID pass-through**, one part of the wider [VFBquery API](/docs/apis/vfbquery/), served at:
 
 ```
 https://v3-cached.virtualflybrain.org/catmaid/{instance}/{command}

--- a/content/en/docs/APIs/VFBquery.md
+++ b/content/en/docs/APIs/VFBquery.md
@@ -1,0 +1,63 @@
+---
+title: "VFBquery API"
+linkTitle: "VFBquery API"
+weight: 6
+date: 2026-08-30
+description: >
+  VFB's general-purpose query API — term information, search, connectivity, cross-references, FlyBase stocks and combinations, and the CATMAID pass-through — all as simple read-only JSON calls.
+---
+
+VFBquery is the query service behind most of what the VFB website itself does — the term information panel, the search box, the hierarchy browser, connectivity queries, stock lookups — exposed as a plain JSON HTTP API anyone can call directly. It's the same recommended entry point as the [CATMAID pass-through](/docs/apis/catmaid/), which is one part of this service:
+
+```
+https://v3-cached.virtualflybrain.org/
+```
+
+Every endpoint is a read-only GET (the CATMAID pass-through also accepts POST — see its own page) returning JSON, with no API key or account needed.
+
+## Interactive docs and the full spec
+
+As with the CATMAID pass-through, the endpoint list changes over time, so it isn't duplicated in full here. The authoritative, always-current reference is the service itself:
+
+- **[https://v3-cached.virtualflybrain.org/](https://v3-cached.virtualflybrain.org/)** — browsable docs for every endpoint, with a "Run" button to try a call directly.
+- **`https://v3-cached.virtualflybrain.org/docs.json`** — the same catalogue as machine-readable JSON.
+
+What follows is a guided tour of the main groups of endpoints, to help you find the right one.
+
+## Term information
+
+- **`/get_term_info?id=FBbt_00003748`** — the full report behind the website's term information panel for one VFB or FBbt id: metadata, synonyms, relationships, aligned images, cross-references, and the list of named queries that can be run from the term.
+- **`/run_query?id=FBbt_00003748&query_type=ListAllAvailableImages`** — runs one of the named query types listed in a term's `/get_term_info` response (e.g. `ListAllAvailableImages`), in the website's own row format. Supports `offset`/`limit` paging.
+- **`/get_hierarchy?id=FBbt_00005801&max_depth=1`** — the hierarchy browser's tree: follows one relationship (`part_of` or `subclass_of`) from a term, upward, downward, or both.
+
+## Search and identifiers
+
+- **`/search?query=medulla&limit=10`** — the same ranked free-text search the website uses. `filter_types`/`exclude_types`/`boost_types`/`demote_types` narrow or re-rank by type.
+- **`/facets`** — the vocabulary of type names `/search`'s type parameters accept.
+- **`/xref?id=VFB_001011rj`** — cross-reference lookup in either direction: `id=` for VFB id → external accessions, or `accession=` (optionally with `db=`) for external id → VFB.
+- **`/combine?expr=calyx AND lh&calyx=...&lh=...`** — set algebra (AND/OR/NOT/XOR and friends) over two or more named query results, compared on term id, with every step traced in the response.
+
+## Connectivity
+
+- **`/list_connectome_datasets`** — the connectome datasets `/query_connectivity` can draw on.
+- **`/query_connectivity?upstream_type=LPLC2&downstream_type=giant fiber neuron`** — synaptic connectivity from one neuron type (or any subclass) to another, summed across the connectomes. Types can be given as labels, synonyms or FBbt ids.
+
+## FlyBase stocks and combinations
+
+- **`/resolve_entity?query=dpp`** — free-text resolver for a gene, allele or transgene name, returning candidate FlyBase feature ids.
+- **`/find_stocks?id=FBgn0000490`** — stock-centre holdings for a resolved feature id.
+- **`/resolve_combination?query=GMR37H08-ZpGAL4DBD in attP2`** — resolver for split-GAL4 hemidriver combinations, returning FBco ids.
+- **`/find_combo_publications?id=FBco0000052`** — publications using a resolved combination.
+
+## CATMAID pass-through
+
+`/catmaid`, `/catmaid/{instance}` and `/catmaid/{instance}/{command}` proxy VFB's hosted CATMAID instances, converting between VFB ids and native skeleton ids (skids) along the way. This is documented in full, with worked examples, on its own page: **[CATMAID API](/docs/apis/catmaid/)**.
+
+## Service
+
+- **`/health`** — a plain `OK` liveness check.
+- **`/status`** — queue depth, cache hit/miss counts and worker utilisation.
+
+## force_refresh and caching
+
+`v3-cached.virtualflybrain.org` caches responses for speed. Most endpoints that reflect fast-changing data accept `force_refresh=true` to bypass the cache for that one call — see the individual endpoint's parameters on the [interactive docs page](https://v3-cached.virtualflybrain.org/).

--- a/content/en/docs/APIs/_index.md
+++ b/content/en/docs/APIs/_index.md
@@ -19,7 +19,7 @@ VFB provides access to its data through several APIs and databases. The core dat
 - **VFB MCP Server**: [https://vfb3-mcp.virtualflybrain.org](https://vfb3-mcp.virtualflybrain.org) - Model Context Protocol server that lets Claude, GitHub Copilot, and other MCP-compatible assistants explore VFB data through natural language. See the [MCP Server documentation](/docs/apis/mcp/) to connect a client.
 
 **For Programmatic Access:**
-- **CATMAID pass-through API** (recommended for CATMAID/connectomics data): [https://v3-cached.virtualflybrain.org/](https://v3-cached.virtualflybrain.org/) - the fastest and simplest way to pull data out of VFB's hosted CATMAID instances (FAFB, FANC, L1EM and others). Takes VFB ids as well as native skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at the link above. See the [CATMAID API reference](/docs/apis/catmaid/).
+- **VFBquery API** (recommended): [https://v3-cached.virtualflybrain.org/](https://v3-cached.virtualflybrain.org/) - the fastest and simplest way to pull data out of VFB directly over HTTP: term information, search, connectivity, cross-references, FlyBase stocks and combinations, and a [CATMAID pass-through](/docs/apis/catmaid/) that takes VFB ids as well as native skeleton ids (skids). No token, API key or account needed, and documented interactively at the link above. See the [VFBquery API reference](/docs/apis/vfbquery/).
 - **VFBconnect Library**: [https://vfb-connect.readthedocs.io/](https://vfb-connect.readthedocs.io/) - Python library that provides high-level access to VFB data and queries. See also: [VFB API Tutorial](/docs/tutorials/apis/vfb_api_overview/)
 
 **For LLMs and AI assistants:**

--- a/content/en/docs/APIs/_index.md
+++ b/content/en/docs/APIs/_index.md
@@ -19,6 +19,7 @@ VFB provides access to its data through several APIs and databases. The core dat
 - **VFB MCP Server**: [https://vfb3-mcp.virtualflybrain.org](https://vfb3-mcp.virtualflybrain.org) - Model Context Protocol server that lets Claude, GitHub Copilot, and other MCP-compatible assistants explore VFB data through natural language. See the [MCP Server documentation](/docs/apis/mcp/) to connect a client.
 
 **For Programmatic Access:**
+- **CATMAID pass-through API** (recommended for CATMAID/connectomics data): [https://v3-cached.virtualflybrain.org/](https://v3-cached.virtualflybrain.org/) - the fastest and simplest way to pull data out of VFB's hosted CATMAID instances (FAFB, FANC, L1EM and others). Takes VFB ids as well as native skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at the link above. See the [CATMAID API reference](/docs/apis/catmaid/).
 - **VFBconnect Library**: [https://vfb-connect.readthedocs.io/](https://vfb-connect.readthedocs.io/) - Python library that provides high-level access to VFB data and queries. See also: [VFB API Tutorial](/docs/tutorials/apis/vfb_api_overview/)
 
 **For LLMs and AI assistants:**

--- a/content/en/hosted/abd1-5-catmaid.md
+++ b/content/en/hosted/abd1-5-catmaid.md
@@ -97,6 +97,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://abd1.5.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/abd1.5/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/fafb-catmaid.md
+++ b/content/en/hosted/fafb-catmaid.md
@@ -71,6 +71,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://fafb.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/fafb/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/fanc-catmaid.md
+++ b/content/en/hosted/fanc-catmaid.md
@@ -50,6 +50,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://fanc.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/fanc/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/iav-robo-catmaid.md
+++ b/content/en/hosted/iav-robo-catmaid.md
@@ -56,6 +56,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://iav-robo.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/iav-robo/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/iav-tnt-catmaid.md
+++ b/content/en/hosted/iav-tnt-catmaid.md
@@ -51,6 +51,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://iav-tnt.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/iav-tnt/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/l1em-catmaid.md
+++ b/content/en/hosted/l1em-catmaid.md
@@ -72,6 +72,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://l1em.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/l1em/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/l3vnc-catmaid.md
+++ b/content/en/hosted/l3vnc-catmaid.md
@@ -47,6 +47,21 @@ This CATMAID instance enables:
 - Skeleton visualization options
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://l3vnc.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/l3vnc/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query

--- a/content/en/hosted/larva1099-catmaid.md
+++ b/content/en/hosted/larva1099-catmaid.md
@@ -38,6 +38,21 @@ This CATMAID instance enables:
 - Neuron-name search
 - API access for programmatic data retrieval (documentation: https://catmaid.readthedocs.io/en/stable/api.html): https://larva1099.catmaid.virtualflybrain.org/apis/
 
+### Recommended: VFB pass-through API
+
+For most uses, the fastest and simplest way to pull data out of this instance is VFB's
+CATMAID pass-through, `v3-cached.virtualflybrain.org` — it takes VFB ids as well as native
+skeleton ids (skids), needs no token or CSRF cookie, and is documented interactively at
+[v3-cached.virtualflybrain.org](https://v3-cached.virtualflybrain.org/):
+
+```bash
+curl "https://v3-cached.virtualflybrain.org/catmaid/larva1099/annotations_for_skeletons?ids=16"
+```
+
+See the [CATMAID API](/docs/apis/catmaid/) page for the full command list, VFB-id/skid
+resolution, and response format. The direct, native CATMAID API below remains available for
+anything the pass-through's command list doesn't cover.
+
 ### Public API token
 
 Read-only access to this instance is open to everyone, but most of CATMAID's query


### PR DESCRIPTION
## Summary

Reworks the API docs so the VFBquery pass-through at `v3-cached.virtualflybrain.org` is presented as the primary, recommended way to pull data programmatically out of VFB, with the direct/native APIs kept as secondary reference material rather than removed.

- Adds a **VFBquery API** reference page (`/docs/apis/vfbquery/`) covering term information, search, connectivity, cross-references, and FlyBase stocks/combinations — sourced directly from the live service's own `/docs.json` spec.
- Adds a **CATMAID API** reference page (`/docs/apis/catmaid/`) documenting the CATMAID pass-through specifically: VFB-id/skid resolution, GET+POST, the response envelope, and worked examples verified against the live service.
- Reorders the APIs section so AI assistants (MCP), then VFBquery, then CATMAID sit ahead of the low-level direct-database pages (PDB/KB/Owlery/SOLR).
- Updates the APIs index page's "Programmatic Access" section to lead with VFBquery/CATMAID pass-through instead of VFBconnect.
- Adds a "Recommended: VFB pass-through API" section to each of the 8 hosted CATMAID instance pages (FAFB, FANC, L1EM, Larva1099, abd1.5, iav-robo, iav-tnt, l3vnc), pointing to the pass-through ahead of the existing native-API/token documentation, which is unchanged below it.

## Test plan

- [x] `hugo --minify` builds the full site with no warnings or errors
- [x] Every new internal link (`/docs/apis/vfbquery/`, `/docs/apis/catmaid/`) resolves in the built output
- [x] All example API calls in both new pages verified against the live `v3-cached.virtualflybrain.org` service