### PR TITLE
Trail the NeuroFly 2026 self-led workshop in the front-page notice box

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -17,6 +17,25 @@ description = "Welcome to Virtual Fly Brain (VFB) - an interactive tool for neur
 	<p class="lead mt-5">A hub for Drosophila melanogaster neural anatomy, imaging data & connectomics.</p>
 
 			<div id="contributeBox" class="notice">
+				<i class="fas fa-graduation-cap" aria-hidden="true"></i>
+				<div>
+					<p>
+						<strong>Our NeuroFly 2026 self-led workshop is live:
+						<a href="https://workshop.virtualflybrain.org" target="_blank" rel="noopener">workshop.virtualflybrain.org</a>.</strong>
+						Seven hands-on sessions on finding, bridging and analysing neurons across every connectome on VFB, plus
+						imaging and transcriptomic data — in Python, R, VFB Chat, our MCP tool, or the 3D browser. Most routes
+						need no installation, and you can work through it at your own pace, before, during or after the conference.
+					</p>
+					<p>
+						Attending <a href="{{< relref "/blog/news/neurofly2026.md" >}}">NeuroFly 2026</a> in Cologne, 7–11
+						September? Come and find us at our table for a live demo, help with the workshop, or to talk through
+						anything VFB — we'd welcome your questions and feedback.
+					</p>
+				</div>
+			</div>
+
+			<!-- FlyBase funding appeal — parked during NeuroFly 2026; restore after the conference.
+			<div id="contributeBox" class="notice">
 				<i class="fas fa-circle-exclamation" aria-hidden="true"></i>
 				<div>
 					<p>
@@ -36,6 +55,8 @@ description = "Welcome to Virtual Fly Brain (VFB) - an interactive tool for neur
 					<p>Virtual Fly Brain's own funding is unaffected, and we remain grateful to Wellcome for their continued support.</p>
 				</div>
 			</div>
+			-->
+
 
 	{{< blocks/link-down color="info" >}}
 </div>


### PR DESCRIPTION
The front-page notice box now announces the self-led workshop:

> **Our NeuroFly 2026 self-led workshop is live: [workshop.virtualflybrain.org](https://workshop.virtualflybrain.org).** Seven hands-on sessions on finding, bridging and analysing neurons across every connectome on VFB, plus imaging and transcriptomic data — in Python, R, VFB Chat, our MCP tool, or the 3D browser. Most routes need no installation, and you can work through it at your own pace, before, during or after the conference.
>
> Attending [NeuroFly 2026](https://www.virtualflybrain.org/blog/2026/08/30/vfb-will-be-giving-a-talk-and-live-demos-at-neurofly-2026/) in Cologne, 7–11 September? Come and find us at our table for a live demo, help with the workshop, or to talk through anything VFB — we'd welcome your questions and feedback.

The FlyBase funding appeal is kept commented out in place so it can be restored after the conference. The news-article link uses `relref`, so it tracks the post's permalink. Icon switches to a graduation cap; same `.notice` styling.

Tested with a local Hugo 0.164.0 extended build: clean, link resolves, FlyBase block renders only as an HTML comment.
