### PR TITLE
Add developmental stage to every dataset table, and a datasets-by-stage page

### DIFF
--- a/content/en/docs/Data/EM/_index.md
+++ b/content/en/docs/Data/EM/_index.md
@@ -19,17 +19,17 @@ contribute one, and how to handle reconstructions that cover the same tissue.
 
 The table below summarises EM datasets that have been integrated into VFB, including the portion of the organism covered (`Anatomy`), the resource(s) where the original data can be found, The level of reconstruction (sparse or dense) and the original publication for the dataset.
 
-| Dataset | VFB symbol | Version in VFB | Anatomy | Reconstruction | Resource(s) | Original Publication |
-|---|---|---|---|---|---|---|
-| BANC | `BANC` | v626 | Full CNS (adult female) | Dense | [Codex](https://codex.flywire.ai/?dataset=banc&data_version=626) | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
-| male-CNS | `mc` | v0.9 | Full CNS (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=male-cns%3Av0.9&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
-| Optic-lobe | `ol` | v1.0.1 | Optic lobe (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=optic-lobe%3Av1.0.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
-| FAFB (FlyWire) | `fw` | v783 | Full brain (adult female) | Dense | [Codex](https://codex.flywire.ai/?data_version=783) | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
-| MANC | `mv` | v1.2.1 | Full VNC (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=manc%3Av1.2.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
-| Hemibrain | `hb` | v1.2.1 | Partial brain (adult female) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=hemibrain%3Av1.2.1&qt=findneurons) | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
-| FAFB (CATMAID) | `fafb` | — | Full brain (adult female) | Sparse | [CATMAID (VFB)](/hosted/fafb-catmaid/) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
-| L1 CNS (CATMAID) | `l1em` | — | Full CNS (female larva) | Sparse | [CATMAID (VFB)](/hosted/l1em-catmaid/) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
-| FANC | — | — | Full VNS (adult female) | Sparse | [CATMAID (VFB)](/hosted/fanc-catmaid/) | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013) |
+| Dataset | VFB symbol | Version in VFB | Stage | Anatomy | Reconstruction | Resource(s) | Original Publication |
+|---|---|---|---|---|---|---|---|
+| BANC | `BANC` | v626 | Adult | Full CNS (adult female) | Dense | [Codex](https://codex.flywire.ai/?dataset=banc&data_version=626) | [Bates et al. (2025)](https://doi.org/10.1101/2025.07.31.667571), published as [Bates et al. (2026)](https://doi.org/10.1038/s41586-026-10735-w) |
+| male-CNS | `mc` | v0.9 | Adult | Full CNS (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=male-cns%3Av0.9&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Berg et al. (2025)](https://doi.org/10.1101/2025.10.09.680999) |
+| Optic-lobe | `ol` | v1.0.1 | Adult | Optic lobe (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=optic-lobe%3Av1.0.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Nern et al. (2025)](https://doi.org/10.1038/s41586-025-08746-0) |
+| FAFB (FlyWire) | `fw` | v783 | Adult | Full brain (adult female) | Dense | [Codex](https://codex.flywire.ai/?data_version=783) | [Dorkenwald et al. (2024)](https://doi.org/10.1038/s41586-024-07558-y); [Schlegel et al. (2024)](https://doi.org/10.1038/s41586-024-07686-5) |
+| MANC | `mv` | v1.2.1 | Adult | Full VNC (adult male) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=manc%3Av1.2.1&qt=findneurons); [Codex](https://codex.flywire.ai/) | [Takemura et al. (2024)](https://doi.org/10.7554/eLife.97769.1) |
+| Hemibrain | `hb` | v1.2.1 | Adult | Partial brain (adult female) | Dense | [NeuPrint](https://neuprint.janelia.org/?dataset=hemibrain%3Av1.2.1&qt=findneurons) | [Scheffer et al. (2020)](https://doi.org/10.7554/eLife.57443) |
+| FAFB (CATMAID) | `fafb` | — | Adult | Full brain (adult female) | Sparse | [CATMAID (VFB)](/hosted/fafb-catmaid/) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019) |
+| L1 CNS (CATMAID) | `l1em` | — | L1 larva | Full CNS (female larva) | Sparse | [CATMAID (VFB)](/hosted/l1em-catmaid/) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297) |
+| FANC | — | — | Adult | Full VNS (adult female) | Sparse | [CATMAID (VFB)](/hosted/fanc-catmaid/) | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013) |
 
 A neuron count, and often a neuron's identifier, is a property of a **release** rather than of a
 dataset. The versions above are what VFB currently holds; see
@@ -52,16 +52,16 @@ Hosting an instance is not the same as integrating its neurons. Only the dataset
 are registered in the VFB knowledge base and reachable from a VFB search, term page or API call;
 for the rest, the CATMAID instance is the way in.
 
-| Instance | Anatomy | In the VFB knowledge base | Original publication |
-|---|---|---|---|
-| [FAFB CATMAID](/hosted/fafb-catmaid/) | Full brain (adult female) | Neurons and connectivity (`fafb`) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019); [FAFB project](https://flyconnecto.me/) |
-| [L1EM CATMAID](/hosted/l1em-catmaid/) | Full CNS (first instar larva) | Neurons and connectivity (`l1em`) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Winding et al. (2023)](https://doi.org/10.1126/science.add9330) |
-| [FANC CATMAID](/hosted/fanc-catmaid/) | Full VNS (adult female) | Neurons only — no connectivity | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013); [Lee lab resources](https://www.lee.hms.harvard.edu/resources) |
-| [ABD1.5 CATMAID](/hosted/abd1-5-catmaid/) | Abdominal segments A2–A3 (first instar larva), wild type | No | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Schneider-Mizell et al. (2016)](https://doi.org/10.7554/eLife.12059); [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
-| [IAV-ROBO CATMAID](/hosted/iav-robo-catmaid/) | Abdominal segments A1–A2 (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
-| [IAV-TNT CATMAID](/hosted/iav-tnt-catmaid/) | Full CNS (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
-| [L3VNC CATMAID](/hosted/l3vnc-catmaid/) | Ventral nerve cord (third instar larva) | No | [Gerhard et al. (2017)](https://doi.org/10.7554/eLife.29089) |
-| [Larva1099 CATMAID](/hosted/larva1099-catmaid/) | Full CNS (first instar larva), eFIB-SEM | No | [Randel et al. (2026)](https://doi.org/10.1101/2025.09.25.678485) |
+| Instance | Stage | Anatomy | In the VFB knowledge base | Original publication |
+|---|---|---|---|---|
+| [FAFB CATMAID](/hosted/fafb-catmaid/) | Adult | Full brain (adult female) | Neurons and connectivity (`fafb`) | [Zheng et al. (2018)](https://doi.org/10.1016/j.cell.2018.06.019); [FAFB project](https://flyconnecto.me/) |
+| [L1EM CATMAID](/hosted/l1em-catmaid/) | L1 larva | Full CNS (first instar larva) | Neurons and connectivity (`l1em`) | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Winding et al. (2023)](https://doi.org/10.1126/science.add9330) |
+| [FANC CATMAID](/hosted/fanc-catmaid/) | Adult | Full VNS (adult female) | Neurons only — no connectivity | [Phelps et al. (2021)](https://doi.org/10.1016/j.cell.2020.12.013); [Lee lab resources](https://www.lee.hms.harvard.edu/resources) |
+| [ABD1.5 CATMAID](/hosted/abd1-5-catmaid/) | L1 larva | Abdominal segments A2–A3 (first instar larva), wild type | No | [Ohyama et al. (2015)](https://doi.org/10.1038/nature14297); [Schneider-Mizell et al. (2016)](https://doi.org/10.7554/eLife.12059); [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [IAV-ROBO CATMAID](/hosted/iav-robo-catmaid/) | L1 larva | Abdominal segments A1–A2 (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [IAV-TNT CATMAID](/hosted/iav-tnt-catmaid/) | L1 larva | Full CNS (first instar larva), altered genotype | No — see note below | [Valdes-Aleman et al. (2021)](https://doi.org/10.1016/j.neuron.2020.10.004) |
+| [L3VNC CATMAID](/hosted/l3vnc-catmaid/) | L3 larva | Ventral nerve cord (third instar larva) | No | [Gerhard et al. (2017)](https://doi.org/10.7554/eLife.29089) |
+| [Larva1099 CATMAID](/hosted/larva1099-catmaid/) | L1 larva | Full CNS (first instar larva), eFIB-SEM | No | [Randel et al. (2026)](https://doi.org/10.1101/2025.09.25.678485) |
 
 The IAV-ROBO and IAV-TNT volumes were imaged from animals whose circuits had been altered
 experimentally — a misexpression and a synaptic-silencing manipulation respectively — rather than

--- a/content/en/docs/Data/LM/_index.md
+++ b/content/en/docs/Data/LM/_index.md
@@ -29,11 +29,11 @@ clone picked out of that pattern.
 
 | Kind | What one image is | Typical use |
 |---|---|---|
-| Driver expression pattern | The full pattern of a GAL4 or LexA line in a CNS | Find a reagent that covers your region of interest, and see what else it hits |
-| Split-GAL4 combination | The pattern of an AD/DBD hemidriver pair | Find a reagent specific enough to target one cell type |
-| Expression pattern fragment | A segmented part of a driver's pattern | Compare a driver against a neuron or region without the rest of the pattern in the way |
-| Single neuron | One neuron isolated by stochastic labelling (MCFO, FLP-out) or by single-cell clonal analysis | Get a morphology to compare against EM or by [NBLAST](/docs/website-features/) |
-| Clone or lineage | A neuroblast clone or a *fru*-positive clone | Work with developmental units rather than single cells |
+| [Driver expression pattern](/docs/concepts/binary-expression/) | The full pattern of a GAL4 or LexA line in a CNS | Find a reagent that covers your region of interest, and see what else it hits |
+| [Split-GAL4 combination](/docs/concepts/splits/) | The pattern of an AD/DBD hemidriver pair | Find a reagent specific enough to target one cell type |
+| [Expression pattern fragment](/docs/concepts/binary-expression/) | A segmented part of a driver's pattern | Compare a driver against a neuron or region without the rest of the pattern in the way |
+| [Single neuron](/docs/concepts/stochastic-labelling/) | One neuron isolated by stochastic labelling (MCFO, FLP-out) or by single-cell clonal analysis | Get a morphology to compare against EM or by [NBLAST](/docs/website-features/) |
+| [Clone or lineage](/docs/concepts/stochastic-labelling/) | A neuroblast clone or a *fru*-positive clone | Work with developmental units rather than single cells |
 | Painted domain | A neuropil region drawn onto a template | Anatomical reference; see [Templates](/docs/data/templates/) |
 
 Every one of these is registered to a template, so a single-neuron image from one study

--- a/content/en/docs/Data/LM/braintrap/index.md
+++ b/content/en/docs/Data/LM/braintrap/index.md
@@ -19,9 +19,9 @@ The original collection is browsable at
 
 ## Datasets
 
-| Dataset | Contents | Records in VFB |
-|---|---|---|
-| [Knowles_Barley2010](https://virtualflybrain.org/reports/Knowles_Barley2010) | BrainTrap lines (Knowles-Barley2010) | 501 |
+| Dataset | Stage | Contents | Records in VFB |
+|---|---|---|---|
+| [Knowles_Barley2010](https://virtualflybrain.org/reports/Knowles_Barley2010) | Adult | BrainTrap lines (Knowles-Barley2010) | 501 |
 
 Records are the individuals VFB holds from each dataset. Citations are on each dataset's
 own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/LM/flycircuit/index.md
+++ b/content/en/docs/Data/LM/flycircuit/index.md
@@ -20,9 +20,9 @@ the raw and unsegmented data live.
 
 ## Datasets
 
-| Dataset | Contents | Records in VFB |
-|---|---|---|
-| [Chiang2010](https://virtualflybrain.org/reports/Chiang2010) | FlyCircuit 1.0 - single neurons (Chiang2010) | 16,127 |
+| Dataset | Stage | Contents | Records in VFB |
+|---|---|---|---|
+| [Chiang2010](https://virtualflybrain.org/reports/Chiang2010) | Adult | FlyCircuit 1.0 - single neurons (Chiang2010) | 16,127 |
 
 Records are the individuals VFB holds from each dataset. Citations are on each dataset's
 own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/LM/flylight/index.md
+++ b/content/en/docs/Data/LM/flylight/index.md
@@ -40,67 +40,67 @@ kinds: the Generation 1 GMR enhancer-fragment collection with its MCFO single-ne
 derivatives, the per-paper split-GAL4 sets characterised in individual publications, and
 larval material from the Truman flip-out collection.
 
-| Dataset | Contents | Records in VFB |
-|---|---|---|
-| [Gen1MCFOTirian2017](https://virtualflybrain.org/reports/Gen1MCFOTirian2017) | MCFO images of VT-GAL4 lines from Tirian et al., 2017 | 16,965 |
-| [Gen1MCFOJenett2012](https://virtualflybrain.org/reports/Gen1MCFOJenett2012) | MCFO images of GMR-GAL4 lines from Jenett et al., 2012 | 15,861 |
-| [FlyLightGen1Set2019](https://virtualflybrain.org/reports/FlyLightGen1Set2019) | FlyLight - Gen1 GAL4/LexA collection (exported 2019) | 13,587 |
-| [TrumanWood2018](https://virtualflybrain.org/reports/TrumanWood2018) | Truman Larval Flip-Out Collection | 12,238 |
-| [Jenett2012](https://virtualflybrain.org/reports/Jenett2012) | FlyLight - GMR GAL4 collection (Jenett2012) | 3,469 |
-| [SplitShuai2023](https://virtualflybrain.org/reports/SplitShuai2023) | Split-GAL4 lines from Shuai et al., 2023 | 2,819 |
-| [Aso2014](https://virtualflybrain.org/reports/Aso2014) | MBONs and split-GAL4 lines that target them (Aso2014) | 2,685 |
-| [SplitSterne2021](https://virtualflybrain.org/reports/SplitSterne2021) | Split-GAL4 lines from Sterne et al., 2021 | 1,490 |
-| [SplitMeissner2024](https://virtualflybrain.org/reports/SplitMeissner2024) | Split-GAL4 lines from Meissner et al., 2024 | 864 |
-| [Namiki2018](https://virtualflybrain.org/reports/Namiki2018) | split-GAL4 lines for descending neurons (Namiki2018) | 390 |
-| [Wu2016](https://virtualflybrain.org/reports/Wu2016) | split-GAL4 lines for LC VPNs (Wu2016) | 334 |
-| [Dolan2019](https://virtualflybrain.org/reports/Dolan2019) | GAL4 Split expression patterns from Dolan et al. 2019 | 308 |
-| [Wolff2018](https://virtualflybrain.org/reports/Wolff2018) | Splits targetting CX neurons, Wolff2018 | 213 |
-| [Gen1MCFODionne2018](https://virtualflybrain.org/reports/Gen1MCFODionne2018) | MCFO images of GMR-GAL4 lines from Dionne et al., 2018 | 151 |
-| [FlyLight2019LateralHorn2019](https://virtualflybrain.org/reports/FlyLight2019LateralHorn2019) | FlyLight split-GAL4 lines for Lateral Horn | 131 |
-| [FlyLight2019Namiki2018](https://virtualflybrain.org/reports/FlyLight2019Namiki2018) | split-GAL4 lines for descending neurons (Namiki2018) | 128 |
-| [SplitDavis2020](https://virtualflybrain.org/reports/SplitDavis2020) | Split-GAL4 lines from Davis et al., 2020 | 100 |
-| [Robie2017](https://virtualflybrain.org/reports/Robie2017) | split-GAL4 lines for  EB neurons (Robie2017) | 82 |
-| [SplitWang2020a](https://virtualflybrain.org/reports/SplitWang2020a) | Split-GAL4 lines from Wang et al., 2020a | 70 |
-| [SplitSchretter2020](https://virtualflybrain.org/reports/SplitSchretter2020) | Split-GAL4 lines from Schretter et al., 2020 | 61 |
-| [SplitBogovic2020](https://virtualflybrain.org/reports/SplitBogovic2020) | Split-GAL4 lines from Bogovic et al., 2020 | 52 |
-| [SplitEhrhardt2023](https://virtualflybrain.org/reports/SplitEhrhardt2023) | Split-GAL4 lines from Ehrhardt et al., 2023 | 33 |
-| [FlyLight2019Strother2017](https://virtualflybrain.org/reports/FlyLight2019Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 32 |
-| [AsoRubin2016](https://virtualflybrain.org/reports/AsoRubin2016) | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 30 |
-| [FlyLight2019Wolff2018](https://virtualflybrain.org/reports/FlyLight2019Wolff2018) | Splits targetting CX neurons, Wolff2018 | 21 |
-| [SplitVogt2016](https://virtualflybrain.org/reports/SplitVogt2016) | Split-GAL4 lines from Vogt et al., 2016 | 21 |
-| [Strother2017](https://virtualflybrain.org/reports/Strother2017) | Splits targetting the visual motion pathway, Strother2017 | 20 |
-| [Klapoetke2017](https://virtualflybrain.org/reports/Klapoetke2017) | Split-GAL4 lines from Klapoetke et al. 2017 | 17 |
-| [SplitMinegishi2023](https://virtualflybrain.org/reports/SplitMinegishi2023) | Split-GAL4 lines from Minegishi et al., 2023 | 16 |
-| [SplitMontague2019](https://virtualflybrain.org/reports/SplitMontague2019) | Split-GAL4 lines from Montague et al., 2019 | 15 |
-| [SplitSitaraman2015](https://virtualflybrain.org/reports/SplitSitaraman2015) | Split-GAL4 lines from Sitaraman et al., 2015 | 14 |
-| [FlyLight2019Wu2016](https://virtualflybrain.org/reports/FlyLight2019Wu2016) | split-GAL4 lines for LC VPNs (Wu2016) | 13 |
-| [SplitCheong2023](https://virtualflybrain.org/reports/SplitCheong2023) | Split-GAL4 lines from Cheong et al., 2023 | 10 |
-| [SplitFeng2020](https://virtualflybrain.org/reports/SplitFeng2020) | Split-GAL4 lines from Feng et al., 2020 | 10 |
-| [SplitTurner_Evans2020](https://virtualflybrain.org/reports/SplitTurner_Evans2020) | Split-GAL4 lines from Turner-Evans et al., 2020 | 9 |
-| [SplitBaker2022](https://virtualflybrain.org/reports/SplitBaker2022) | Split-GAL4 lines from Baker et al., 2022 | 8 |
-| [SplitJovanic2019](https://virtualflybrain.org/reports/SplitJovanic2019) | Split-GAL4 lines from Jovanic et al., 2019 | 8 |
-| [SplitRubin2024](https://virtualflybrain.org/reports/SplitRubin2024) | Split-GAL4 lines from Rubin et al., 2024 | 8 |
-| [SplitMorimoto2020](https://virtualflybrain.org/reports/SplitMorimoto2020) | Split-GAL4 lines from Morimoto et al., 2020 | 7 |
-| [SplitNamiki2022](https://virtualflybrain.org/reports/SplitNamiki2022) | Split-GAL4 lines from Namiki et al., 2022 | 7 |
-| [Hampel2015](https://virtualflybrain.org/reports/Hampel2015) | Grooming neurons and drivers (Hampel 2015) | 6 |
-| [SplitKind2021](https://virtualflybrain.org/reports/SplitKind2021) | Split-GAL4 lines from Kind et al., 2021 | 6 |
-| [SplitIsaacson2023](https://virtualflybrain.org/reports/SplitIsaacson2023) | Split-GAL4 lines from Isaacson et al., 2023 | 5 |
-| [SplitWang2020b](https://virtualflybrain.org/reports/SplitWang2020b) | Split-GAL4 lines from Wang et al., 2020b | 5 |
-| [Gen1MCFOPfeiffer2010](https://virtualflybrain.org/reports/Gen1MCFOPfeiffer2010) | MCFO images of GMR-GAL4 lines from Pfeiffer et al., 2010 | 4 |
-| [SplitGao2019](https://virtualflybrain.org/reports/SplitGao2019) | Split-GAL4 lines from Gao et al., 2019 | 4 |
-| [SplitKlapoetke2022](https://virtualflybrain.org/reports/SplitKlapoetke2022) | Split-GAL4 lines from Klapoetke et al., 2022 | 4 |
-| [SplitZhao2023](https://virtualflybrain.org/reports/SplitZhao2023) | Split-GAL4 lines from Zhao et al., 2023 | 4 |
-| [SplitGiraldo2018](https://virtualflybrain.org/reports/SplitGiraldo2018) | Split-GAL4 lines from Giraldo et al., 2018 | 3 |
-| [SplitMasek2015](https://virtualflybrain.org/reports/SplitMasek2015) | Split-GAL4 lines from Masek et al., 2015 | 3 |
-| [SplitXie2021](https://virtualflybrain.org/reports/SplitXie2021) | Split-GAL4 lines from Xie et al., 2021 | 3 |
-| [SplitYamagata2015](https://virtualflybrain.org/reports/SplitYamagata2015) | Split-GAL4 lines from Yamagata et al., 2015 | 3 |
-| [SplitLongden2023](https://virtualflybrain.org/reports/SplitLongden2023) | Split-GAL4 lines from Longden et al., 2023 | 2 |
-| [SplitSchlichting2019](https://virtualflybrain.org/reports/SplitSchlichting2019) | Split-GAL4 lines from Schlichting et al., 2019 | 2 |
-| [TrumanWood2018public](https://virtualflybrain.org/reports/TrumanWood2018public) | Truman Larval Flip-Out Collection | 2 |
-| [FlyLight2019AsoRubin2016](https://virtualflybrain.org/reports/FlyLight2019AsoRubin2016) | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 1 |
-| [FlyLight2019Klapoetke2017](https://virtualflybrain.org/reports/FlyLight2019Klapoetke2017) | Split-GAL4 lines from Klapoetke et al. 2017 | 1 |
-| [FlyLight2019Robie2017](https://virtualflybrain.org/reports/FlyLight2019Robie2017) | split-GAL4 lines for EB neurons (Robie2017) | 1 |
-| [SplitTurner_Evans2017](https://virtualflybrain.org/reports/SplitTurner_Evans2017) | Split-GAL4 lines from Turner-Evans et al., 2017 | 1 |
+| Dataset | Stage | Contents | Records in VFB |
+|---|---|---|---|
+| [Gen1MCFOTirian2017](https://virtualflybrain.org/reports/Gen1MCFOTirian2017) | Adult | MCFO images of VT-GAL4 lines from Tirian et al., 2017 | 16,965 |
+| [Gen1MCFOJenett2012](https://virtualflybrain.org/reports/Gen1MCFOJenett2012) | Adult | MCFO images of GMR-GAL4 lines from Jenett et al., 2012 | 15,861 |
+| [FlyLightGen1Set2019](https://virtualflybrain.org/reports/FlyLightGen1Set2019) | Adult | FlyLight - Gen1 GAL4/LexA collection (exported 2019) | 13,587 |
+| [TrumanWood2018](https://virtualflybrain.org/reports/TrumanWood2018) | L3 larva | Truman Larval Flip-Out Collection | 12,238 |
+| [Jenett2012](https://virtualflybrain.org/reports/Jenett2012) | Adult | FlyLight - GMR GAL4 collection (Jenett2012) | 3,469 |
+| [SplitShuai2023](https://virtualflybrain.org/reports/SplitShuai2023) | Adult | Split-GAL4 lines from Shuai et al., 2023 | 2,819 |
+| [Aso2014](https://virtualflybrain.org/reports/Aso2014) | Adult | MBONs and split-GAL4 lines that target them (Aso2014) | 2,685 |
+| [SplitSterne2021](https://virtualflybrain.org/reports/SplitSterne2021) | Adult | Split-GAL4 lines from Sterne et al., 2021 | 1,490 |
+| [SplitMeissner2024](https://virtualflybrain.org/reports/SplitMeissner2024) | L3 larva | Split-GAL4 lines from Meissner et al., 2024 | 864 |
+| [Namiki2018](https://virtualflybrain.org/reports/Namiki2018) | Adult | split-GAL4 lines for descending neurons (Namiki2018) | 390 |
+| [Wu2016](https://virtualflybrain.org/reports/Wu2016) | Adult | split-GAL4 lines for LC VPNs (Wu2016) | 334 |
+| [Dolan2019](https://virtualflybrain.org/reports/Dolan2019) | Adult | GAL4 Split expression patterns from Dolan et al. 2019 | 308 |
+| [Wolff2018](https://virtualflybrain.org/reports/Wolff2018) | Adult | Splits targetting CX neurons, Wolff2018 | 213 |
+| [Gen1MCFODionne2018](https://virtualflybrain.org/reports/Gen1MCFODionne2018) | Adult | MCFO images of GMR-GAL4 lines from Dionne et al., 2018 | 151 |
+| [FlyLight2019LateralHorn2019](https://virtualflybrain.org/reports/FlyLight2019LateralHorn2019) | Adult | FlyLight split-GAL4 lines for Lateral Horn | 131 |
+| [FlyLight2019Namiki2018](https://virtualflybrain.org/reports/FlyLight2019Namiki2018) | Adult | split-GAL4 lines for descending neurons (Namiki2018) | 128 |
+| [SplitDavis2020](https://virtualflybrain.org/reports/SplitDavis2020) | Adult | Split-GAL4 lines from Davis et al., 2020 | 100 |
+| [Robie2017](https://virtualflybrain.org/reports/Robie2017) | Adult | split-GAL4 lines for  EB neurons (Robie2017) | 82 |
+| [SplitWang2020a](https://virtualflybrain.org/reports/SplitWang2020a) | Adult | Split-GAL4 lines from Wang et al., 2020a | 70 |
+| [SplitSchretter2020](https://virtualflybrain.org/reports/SplitSchretter2020) | Adult | Split-GAL4 lines from Schretter et al., 2020 | 61 |
+| [SplitBogovic2020](https://virtualflybrain.org/reports/SplitBogovic2020) | Adult | Split-GAL4 lines from Bogovic et al., 2020 | 52 |
+| [SplitEhrhardt2023](https://virtualflybrain.org/reports/SplitEhrhardt2023) | Adult | Split-GAL4 lines from Ehrhardt et al., 2023 | 33 |
+| [FlyLight2019Strother2017](https://virtualflybrain.org/reports/FlyLight2019Strother2017) | Adult | Splits targetting the visual motion pathway, Strother2017 | 32 |
+| [AsoRubin2016](https://virtualflybrain.org/reports/AsoRubin2016) | Adult | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 30 |
+| [FlyLight2019Wolff2018](https://virtualflybrain.org/reports/FlyLight2019Wolff2018) | Adult | Splits targetting CX neurons, Wolff2018 | 21 |
+| [SplitVogt2016](https://virtualflybrain.org/reports/SplitVogt2016) | Adult | Split-GAL4 lines from Vogt et al., 2016 | 21 |
+| [Strother2017](https://virtualflybrain.org/reports/Strother2017) | Adult | Splits targetting the visual motion pathway, Strother2017 | 20 |
+| [Klapoetke2017](https://virtualflybrain.org/reports/Klapoetke2017) | Adult | Split-GAL4 lines from Klapoetke et al. 2017 | 17 |
+| [SplitMinegishi2023](https://virtualflybrain.org/reports/SplitMinegishi2023) | Adult | Split-GAL4 lines from Minegishi et al., 2023 | 16 |
+| [SplitMontague2019](https://virtualflybrain.org/reports/SplitMontague2019) | Adult | Split-GAL4 lines from Montague et al., 2019 | 15 |
+| [SplitSitaraman2015](https://virtualflybrain.org/reports/SplitSitaraman2015) | Adult | Split-GAL4 lines from Sitaraman et al., 2015 | 14 |
+| [FlyLight2019Wu2016](https://virtualflybrain.org/reports/FlyLight2019Wu2016) | Adult | split-GAL4 lines for LC VPNs (Wu2016) | 13 |
+| [SplitCheong2023](https://virtualflybrain.org/reports/SplitCheong2023) | Adult | Split-GAL4 lines from Cheong et al., 2023 | 10 |
+| [SplitFeng2020](https://virtualflybrain.org/reports/SplitFeng2020) | Adult | Split-GAL4 lines from Feng et al., 2020 | 10 |
+| [SplitTurner_Evans2020](https://virtualflybrain.org/reports/SplitTurner_Evans2020) | Adult | Split-GAL4 lines from Turner-Evans et al., 2020 | 9 |
+| [SplitBaker2022](https://virtualflybrain.org/reports/SplitBaker2022) | Adult | Split-GAL4 lines from Baker et al., 2022 | 8 |
+| [SplitJovanic2019](https://virtualflybrain.org/reports/SplitJovanic2019) | Larva | Split-GAL4 lines from Jovanic et al., 2019 | 8 |
+| [SplitRubin2024](https://virtualflybrain.org/reports/SplitRubin2024) | Adult | Split-GAL4 lines from Rubin et al., 2024 | 8 |
+| [SplitMorimoto2020](https://virtualflybrain.org/reports/SplitMorimoto2020) | Adult | Split-GAL4 lines from Morimoto et al., 2020 | 7 |
+| [SplitNamiki2022](https://virtualflybrain.org/reports/SplitNamiki2022) | Adult | Split-GAL4 lines from Namiki et al., 2022 | 7 |
+| [Hampel2015](https://virtualflybrain.org/reports/Hampel2015) | Adult | Grooming neurons and drivers (Hampel 2015) | 6 |
+| [SplitKind2021](https://virtualflybrain.org/reports/SplitKind2021) | Adult | Split-GAL4 lines from Kind et al., 2021 | 6 |
+| [SplitIsaacson2023](https://virtualflybrain.org/reports/SplitIsaacson2023) | Adult | Split-GAL4 lines from Isaacson et al., 2023 | 5 |
+| [SplitWang2020b](https://virtualflybrain.org/reports/SplitWang2020b) | Adult | Split-GAL4 lines from Wang et al., 2020b | 5 |
+| [Gen1MCFOPfeiffer2010](https://virtualflybrain.org/reports/Gen1MCFOPfeiffer2010) | Adult | MCFO images of GMR-GAL4 lines from Pfeiffer et al., 2010 | 4 |
+| [SplitGao2019](https://virtualflybrain.org/reports/SplitGao2019) | Adult | Split-GAL4 lines from Gao et al., 2019 | 4 |
+| [SplitKlapoetke2022](https://virtualflybrain.org/reports/SplitKlapoetke2022) | Adult | Split-GAL4 lines from Klapoetke et al., 2022 | 4 |
+| [SplitZhao2023](https://virtualflybrain.org/reports/SplitZhao2023) | Adult | Split-GAL4 lines from Zhao et al., 2023 | 4 |
+| [SplitGiraldo2018](https://virtualflybrain.org/reports/SplitGiraldo2018) | Adult | Split-GAL4 lines from Giraldo et al., 2018 | 3 |
+| [SplitMasek2015](https://virtualflybrain.org/reports/SplitMasek2015) | Adult | Split-GAL4 lines from Masek et al., 2015 | 3 |
+| [SplitXie2021](https://virtualflybrain.org/reports/SplitXie2021) | Adult | Split-GAL4 lines from Xie et al., 2021 | 3 |
+| [SplitYamagata2015](https://virtualflybrain.org/reports/SplitYamagata2015) | Adult | Split-GAL4 lines from Yamagata et al., 2015 | 3 |
+| [SplitLongden2023](https://virtualflybrain.org/reports/SplitLongden2023) | Adult | Split-GAL4 lines from Longden et al., 2023 | 2 |
+| [SplitSchlichting2019](https://virtualflybrain.org/reports/SplitSchlichting2019) | Adult | Split-GAL4 lines from Schlichting et al., 2019 | 2 |
+| [TrumanWood2018public](https://virtualflybrain.org/reports/TrumanWood2018public) | L3 larva | Truman Larval Flip-Out Collection | 2 |
+| [FlyLight2019AsoRubin2016](https://virtualflybrain.org/reports/FlyLight2019AsoRubin2016) | Adult | split-GAL4 lines for dopaminergic neurons (AsoRubin2016) | 1 |
+| [FlyLight2019Klapoetke2017](https://virtualflybrain.org/reports/FlyLight2019Klapoetke2017) | Adult | Split-GAL4 lines from Klapoetke et al. 2017 | 1 |
+| [FlyLight2019Robie2017](https://virtualflybrain.org/reports/FlyLight2019Robie2017) | Adult | split-GAL4 lines for EB neurons (Robie2017) | 1 |
+| [SplitTurner_Evans2017](https://virtualflybrain.org/reports/SplitTurner_Evans2017) | Adult | Split-GAL4 lines from Turner-Evans et al., 2017 | 1 |
 
 Records are the individuals VFB holds from each dataset — whole expression patterns,
 fragments and single neurons.

--- a/content/en/docs/Data/LM/labs/index.md
+++ b/content/en/docs/Data/LM/labs/index.md
@@ -16,20 +16,20 @@ cited paper, given below alongside it.
 
 ## Datasets
 
-| Dataset | Contents | Imaging source | Paper | Records |
-|---|---|---|---|---|
-| [Lee_Lineage2020](https://virtualflybrain.org/reports/Lee_Lineage2020) | central brain neurons by lineage, Lee2020 | Tzumin Lee lab, Janelia Research Campus | Lee et al., 2020, *eLife* | 462 |
-| [Cachero2010](https://virtualflybrain.org/reports/Cachero2010) | Adult Brain fru clones (Cachero2010) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Cachero et al., 2010, *Curr. Biol.* | 119 |
-| [Kohl2013](https://virtualflybrain.org/reports/Kohl2013) | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Kohl et al., 2013, *Cell* | 111 |
-| [Ito2013](https://virtualflybrain.org/reports/Ito2013) | Ito lab adult brain lineage clone image set | Kei Ito lab, Institute of Molecular and Cellular Biosciences, University of Tokyo | Ito et al., 2013, *Curr. Biol.* | 96 |
-| [Yu2013](https://virtualflybrain.org/reports/Yu2013) | Lee lab adult brain lineage clone image set | Tzumin Lee lab, Janelia Research Campus | Yu et al., 2013, *Curr. Biol.* | 95 |
-| [Xie2018](https://virtualflybrain.org/reports/Xie2018) | Split GAL4 lines for dopaminergic neurons, Xie2018 | Mark Wu lab, Johns Hopkins University School of Medicine | Xie et al., 2018, *Cell Rep.* | 78 |
-| [Matsuo2016](https://virtualflybrain.org/reports/Matsuo2016) | AMMC local and projection neurons (Matsuo2016) | Kamikouchi lab, Nagoya University, with the Ito lab, University of Tokyo | Matsuo et al., 2016, *J. Comp. Neurol.* | 41 |
-| [HeadMusclesMcKellar2020](https://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Images of proboscis muscles from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 18 |
-| [Nojima2021](https://virtualflybrain.org/reports/Nojima2021) | Split-GAL4 lines from Nojima et al., 2021 | Goodwin lab, Centre for Neural Circuits and Behaviour, University of Oxford | Nojima et al., 2021, *Curr. Biol.* | 15 |
-| [SplitNallasivan2025](https://virtualflybrain.org/reports/SplitNallasivan2025) | Split-GAL4 lines from Nallasivan et al 2025 | Soller lab, University of Birmingham | Nallasivan et al., 2026, *eLife* | 6 |
-| [McKellar2020](https://virtualflybrain.org/reports/McKellar2020) | GAL4 lines from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 5 |
-| [Lillvis2018](https://virtualflybrain.org/reports/Lillvis2018) | Neurons involved in courtship and song (Lillvis2018) | Stern and Dickson labs, Janelia Research Campus | Ding et al., 2019, *Curr. Biol.* | 2 |
+| Dataset | Stage | Contents | Imaging source | Paper | Records |
+|---|---|---|---|---|---|
+| [Lee_Lineage2020](https://virtualflybrain.org/reports/Lee_Lineage2020) | Adult | central brain neurons by lineage, Lee2020 | Tzumin Lee lab, Janelia Research Campus | Lee et al., 2020, *eLife* | 462 |
+| [Cachero2010](https://virtualflybrain.org/reports/Cachero2010) | Adult | Adult Brain fru clones (Cachero2010) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Cachero et al., 2010, *Curr. Biol.* | 119 |
+| [Kohl2013](https://virtualflybrain.org/reports/Kohl2013) | Adult | Third order olfactory neurons involved in pheromone response - backfills (Kohl2013) | Jefferis lab, MRC Laboratory of Molecular Biology, Cambridge | Kohl et al., 2013, *Cell* | 111 |
+| [Ito2013](https://virtualflybrain.org/reports/Ito2013) | Adult | Ito lab adult brain lineage clone image set | Kei Ito lab, Institute of Molecular and Cellular Biosciences, University of Tokyo | Ito et al., 2013, *Curr. Biol.* | 96 |
+| [Yu2013](https://virtualflybrain.org/reports/Yu2013) | Adult | Lee lab adult brain lineage clone image set | Tzumin Lee lab, Janelia Research Campus | Yu et al., 2013, *Curr. Biol.* | 95 |
+| [Xie2018](https://virtualflybrain.org/reports/Xie2018) | Adult | Split GAL4 lines for dopaminergic neurons, Xie2018 | Mark Wu lab, Johns Hopkins University School of Medicine | Xie et al., 2018, *Cell Rep.* | 78 |
+| [Matsuo2016](https://virtualflybrain.org/reports/Matsuo2016) | Adult | AMMC local and projection neurons (Matsuo2016) | Kamikouchi lab, Nagoya University, with the Ito lab, University of Tokyo | Matsuo et al., 2016, *J. Comp. Neurol.* | 41 |
+| [HeadMusclesMcKellar2020](https://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | Adult | Images of proboscis muscles from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 18 |
+| [Nojima2021](https://virtualflybrain.org/reports/Nojima2021) | Adult | Split-GAL4 lines from Nojima et al., 2021 | Goodwin lab, Centre for Neural Circuits and Behaviour, University of Oxford | Nojima et al., 2021, *Curr. Biol.* | 15 |
+| [SplitNallasivan2025](https://virtualflybrain.org/reports/SplitNallasivan2025) | Adult | Split-GAL4 lines from Nallasivan et al 2025 | Soller lab, University of Birmingham | Nallasivan et al., 2026, *eLife* | 6 |
+| [McKellar2020](https://virtualflybrain.org/reports/McKellar2020) | Adult | GAL4 lines from McKellar et al., 2020 | Simpson and Dickson labs, Janelia Research Campus | McKellar et al., 2020, *eLife* | 5 |
+| [Lillvis2018](https://virtualflybrain.org/reports/Lillvis2018) | Adult | Neurons involved in courtship and song (Lillvis2018) | Stern and Dickson labs, Janelia Research Campus | Ding et al., 2019, *Curr. Biol.* | 2 |
 
 Records are the individuals VFB holds from each dataset.
 

--- a/content/en/docs/Data/LM/vdrc/index.md
+++ b/content/en/docs/Data/LM/vdrc/index.md
@@ -23,11 +23,11 @@ under [Janelia FlyLight](/docs/data/lm/flylight/).
 
 ## Datasets
 
-| Dataset | Contents | Records in VFB |
-|---|---|---|
-| [Dickson_VT](https://virtualflybrain.org/reports/Dickson_VT) | Dickson lab VT line collection - VDRC images | 18,016 |
-| [Dickson2017](https://virtualflybrain.org/reports/Dickson2017) | Dickson lab VT lines - FlyLight/Janelia images (2017) | 5,378 |
-| [Hampel2017](https://virtualflybrain.org/reports/Hampel2017) | LexA driver targetting mechanosensory eye bristles (Hampel2017) | 1 |
+| Dataset | Stage | Contents | Records in VFB |
+|---|---|---|---|
+| [Dickson_VT](https://virtualflybrain.org/reports/Dickson_VT) | Adult | Dickson lab VT line collection - VDRC images | 18,016 |
+| [Dickson2017](https://virtualflybrain.org/reports/Dickson2017) | Adult | Dickson lab VT lines - FlyLight/Janelia images (2017) | 5,378 |
+| [Hampel2017](https://virtualflybrain.org/reports/Hampel2017) | Adult | LexA driver targetting mechanosensory eye bristles (Hampel2017) | 1 |
 
 Records are the individuals VFB holds from each dataset. Citations are on each dataset's
 own page on VFB; cite the original study rather than VFB when you use the images.

--- a/content/en/docs/Data/_index.md
+++ b/content/en/docs/Data/_index.md
@@ -33,6 +33,7 @@ which is regenerated against the production knowledge base after every data rele
 | Light microscopy | Driver line expression patterns, split-GAL4 combinations, single-neuron and clonal images from confocal microscopy | [LM data](/docs/data/lm/) |
 | Single-cell transcriptomics | Cell clusters and their gene expression from scRNAseq and snRNAseq studies | [scRNAseq data](/docs/data/scrnaseq/) |
 | Templates and regions | The reference brains and VNCs everything is registered to, and the painted neuropil domains in each | [Templates](/docs/data/templates/) |
+| Datasets by stage | Every dataset grouped by developmental stage (embryo, larva, pupa, adult), with a description of what each stage covers | [Datasets by stage](/docs/data/stages/) |
 
 VFB also hosts the public [CATMAID instances](/hosted/) for several community EM
 datasets, in some cases as the only remaining public copy after the original host went

--- a/content/en/docs/Data/scRNAseq/_index.md
+++ b/content/en/docs/Data/scRNAseq/_index.md
@@ -45,32 +45,32 @@ The same queries are available through
 Gene counts are after the extent filter above, so they are lower than the gene count
 reported by the original study. Ordered by cluster count.
 
-| Dataset | Study | Clusters | Genes |
-|---|---|---|---|
-| [scRNAseq_2022_FCA_MIXED](https://flybase.org/reports/FBlc0004785) | Single-nucleus RNA-seq on cells from 5-days old female and male flies | 497 | 11,079 |
-| [scRNAseq_2022_FCA_MALE](https://flybase.org/reports/FBlc0004307) | Single-nucleus RNA-seq on cells from 5-days old male flies | 422 | 10,978 |
-| [scRNAseq_2022_FCA_FEMALE](https://flybase.org/reports/FBlc0003846) | Single-nucleus RNA-seq on cells from 5-days old female flies | 411 | 8,169 |
-| [scRNAseq_2022_Calderon](https://flybase.org/reports/FBlc0007797) | The continuum of Drosophila embryonic development at single-cell resolution | 274 | 2,166 |
-| [scRNAseq_2023_AFCA_D30_FEMALE](https://flybase.org/reports/FBlc0006424) | Single-nucleus RNA-seq on cells from 30-days old female flies | 179 | 4,987 |
-| [scRNAseq_2023_AFCA_D70_FEMALE](https://flybase.org/reports/FBlc0007348) | Single-nucleus RNA-seq on cells from 70-days old female flies | 176 | 5,458 |
-| [scRNAseq_2023_AFCA_D50_FEMALE](https://flybase.org/reports/FBlc0006888) | Single-nucleus RNA-seq on cells from 50-days old female flies | 175 | 4,595 |
-| [scRNAseq_2023_AFCA_D50_MALE](https://flybase.org/reports/FBlc0007071) | Single-nucleus RNA-seq on cells from 50-days old male flies | 172 | 4,878 |
-| [scRNAseq_2023_AFCA_D30_MALE](https://flybase.org/reports/FBlc0006611) | Single-nucleus RNA-seq on cells from 30-days old male flies | 168 | 4,857 |
-| [scRNAseq_2023_AFCA_D70_MALE](https://flybase.org/reports/FBlc0007532) | Single-nucleus RNA-seq on cells from 70-days old male flies | 161 | 4,835 |
-| [scRNAseq_2023_AFCA_D30](https://flybase.org/reports/FBlc0006423) | Single-nucleus RNA-seq on cells from 30-days old flies | 99 | 5,312 |
-| [scRNAseq_2023_AFCA_D70](https://flybase.org/reports/FBlc0007347) | Single-nucleus RNA-seq on cells from 70-days old flies | 95 | 5,592 |
-| [scRNAseq_2023_AFCA_D50](https://flybase.org/reports/FBlc0006887) | Single-nucleus RNA-seq on cells from 50-days old flies | 95 | 5,015 |
-| [scRNAseq_2021_Ozel](https://flybase.org/reports/FBlc0005659) | Single-cell RNA-seq study of pupal and adult optic lobes | 66 | 4,770 |
-| [scRNAseq_2020_Kurmangaliyev](https://flybase.org/reports/FBlc0006237) | Single-cell RNA-seq study of the pupal optic lobe | 62 | 5,975 |
-| [scRNAseq_2018_Davie](https://flybase.org/reports/FBlc0006090) | Single-cell RNA-seq study of the aging brain | 59 | 6,111 |
-| [scRNAseq_2020_Hormann](https://flybase.org/reports/FBlc0006305) | Single-cell RNA-seq study of visual motion-sensing neurons | 40 | 4,014 |
-| [scRNAseq_2021_Mokashi_CTRL](https://flybase.org/reports/FBlc0005420) | Single-cell RNA-seq study of adult brain without alcohol exposure | 39 | 3,097 |
-| [scRNAseq_2021_Baker_CTRL](https://flybase.org/reports/FBlc0005515) | Single-cell RNA-seq study of adult brain without cocaine exposure | 36 | 3,329 |
-| [scRNAseq_2020_Allen](https://flybase.org/reports/FBlc0005603) | Single-cell RNA-seq study of adult ventral nerve cords | 20 | 3,085 |
-| [scRNAseq_2022_Konstantinides](https://flybase.org/reports/FBlc0006404) | Single-cell RNA-seq study of larval optic lobes | 14 | 5,530 |
-| [scRNAseq_2023_Saavedra](https://flybase.org/reports/FBlc0006361) | Single-cell RNA-seq study of the adult thorax | 11 | 1,726 |
-| [scRNAseq_2019_Avalos](https://flybase.org/reports/FBlc0005362) | Single-cell RNA-seq study of first instar larval brains upon starvation | 10 | 6,463 |
-| [scRNAseq_2021_IngSimmons](https://flybase.org/reports/FBlc0006191) | Single-cell RNA-seq study of gastrulating embryos | 9 | 6,423 |
+| Dataset | Stage | Study | Clusters | Genes |
+|---|---|---|---|---|
+| [scRNAseq_2022_FCA_MIXED](https://flybase.org/reports/FBlc0004785) | Adult | Single-nucleus RNA-seq on cells from 5-days old female and male flies | 497 | 11,079 |
+| [scRNAseq_2022_FCA_MALE](https://flybase.org/reports/FBlc0004307) | Adult | Single-nucleus RNA-seq on cells from 5-days old male flies | 422 | 10,978 |
+| [scRNAseq_2022_FCA_FEMALE](https://flybase.org/reports/FBlc0003846) | Adult | Single-nucleus RNA-seq on cells from 5-days old female flies | 411 | 8,169 |
+| [scRNAseq_2022_Calderon](https://flybase.org/reports/FBlc0007797) | Embryo | The continuum of Drosophila embryonic development at single-cell resolution | 274 | 2,166 |
+| [scRNAseq_2023_AFCA_D30_FEMALE](https://flybase.org/reports/FBlc0006424) | Adult | Single-nucleus RNA-seq on cells from 30-days old female flies | 179 | 4,987 |
+| [scRNAseq_2023_AFCA_D70_FEMALE](https://flybase.org/reports/FBlc0007348) | Adult | Single-nucleus RNA-seq on cells from 70-days old female flies | 176 | 5,458 |
+| [scRNAseq_2023_AFCA_D50_FEMALE](https://flybase.org/reports/FBlc0006888) | Adult | Single-nucleus RNA-seq on cells from 50-days old female flies | 175 | 4,595 |
+| [scRNAseq_2023_AFCA_D50_MALE](https://flybase.org/reports/FBlc0007071) | Adult | Single-nucleus RNA-seq on cells from 50-days old male flies | 172 | 4,878 |
+| [scRNAseq_2023_AFCA_D30_MALE](https://flybase.org/reports/FBlc0006611) | Adult | Single-nucleus RNA-seq on cells from 30-days old male flies | 168 | 4,857 |
+| [scRNAseq_2023_AFCA_D70_MALE](https://flybase.org/reports/FBlc0007532) | Adult | Single-nucleus RNA-seq on cells from 70-days old male flies | 161 | 4,835 |
+| [scRNAseq_2023_AFCA_D30](https://flybase.org/reports/FBlc0006423) | Adult | Single-nucleus RNA-seq on cells from 30-days old flies | 99 | 5,312 |
+| [scRNAseq_2023_AFCA_D70](https://flybase.org/reports/FBlc0007347) | Adult | Single-nucleus RNA-seq on cells from 70-days old flies | 95 | 5,592 |
+| [scRNAseq_2023_AFCA_D50](https://flybase.org/reports/FBlc0006887) | Adult | Single-nucleus RNA-seq on cells from 50-days old flies | 95 | 5,015 |
+| [scRNAseq_2021_Ozel](https://flybase.org/reports/FBlc0005659) | Pupa | Single-cell RNA-seq study of pupal and adult optic lobes | 66 | 4,770 |
+| [scRNAseq_2020_Kurmangaliyev](https://flybase.org/reports/FBlc0006237) | Pupa | Single-cell RNA-seq study of the pupal optic lobe | 62 | 5,975 |
+| [scRNAseq_2018_Davie](https://flybase.org/reports/FBlc0006090) | Adult | Single-cell RNA-seq study of the aging brain | 59 | 6,111 |
+| [scRNAseq_2020_Hormann](https://flybase.org/reports/FBlc0006305) | Adult | Single-cell RNA-seq study of visual motion-sensing neurons | 40 | 4,014 |
+| [scRNAseq_2021_Mokashi_CTRL](https://flybase.org/reports/FBlc0005420) | Adult | Single-cell RNA-seq study of adult brain without alcohol exposure | 39 | 3,097 |
+| [scRNAseq_2021_Baker_CTRL](https://flybase.org/reports/FBlc0005515) | Adult | Single-cell RNA-seq study of adult brain without cocaine exposure | 36 | 3,329 |
+| [scRNAseq_2020_Allen](https://flybase.org/reports/FBlc0005603) | Adult | Single-cell RNA-seq study of adult ventral nerve cords | 20 | 3,085 |
+| [scRNAseq_2022_Konstantinides](https://flybase.org/reports/FBlc0006404) | Larva | Single-cell RNA-seq study of larval optic lobes | 14 | 5,530 |
+| [scRNAseq_2023_Saavedra](https://flybase.org/reports/FBlc0006361) | Adult | Single-cell RNA-seq study of the adult thorax | 11 | 1,726 |
+| [scRNAseq_2019_Avalos](https://flybase.org/reports/FBlc0005362) | L1 larva | Single-cell RNA-seq study of first instar larval brains upon starvation | 10 | 6,463 |
+| [scRNAseq_2021_IngSimmons](https://flybase.org/reports/FBlc0006191) | Embryo | Single-cell RNA-seq study of gastrulating embryos | 9 | 6,423 |
 
 Not every cluster carries an anatomical annotation: many are non-neural or were not
 resolved to a cell type in the source study. Counts here are of what VFB holds, and are

--- a/content/en/docs/Data/stages.md
+++ b/content/en/docs/Data/stages.md
@@ -1,0 +1,359 @@
+---
+title: "Datasets by developmental stage"
+linkTitle: "Datasets by stage"
+weight: 511
+date: 2026-08-31
+description: >
+    Every VFB dataset grouped by the developmental stage of the animal it was collected from.
+---
+
+VFB's datasets are documented by [technique](/docs/data/em/) and by
+[source](/docs/data/lm/) elsewhere on this site, but nothing groups them by the stage of
+the animal they came from. That gap has come up in practice: it is why a question like
+*"how many larval datasets does VFB hold, and which is newest?"* has no direct answer on
+the site today, and can only be approximated by searching dataset names for the word
+"larval" — a search that misses anything not named that way, and catches nothing at all
+for embryo or pupal material.
+
+This page is that missing reference. It lists all 210 dataset entities currently in the
+VFB knowledge base (`DataSet` individuals — the same list `search_terms` returns when
+filtered to `dataset`), grouped by developmental stage, with a link to each dataset's own
+page where a stage-agnostic reader would want to jump straight to the data.
+
+**How this was built.** VFB does not currently record a structured "stage" field on
+dataset entities — this table was compiled by hand from each dataset's name, description
+and publication, cross-checked against a more reliable structured signal where one
+exists: which [template](/docs/data/templates/) a dataset's images are registered to.
+Registration is stage-specific — the L1 CNS template (`Seymour`, VFB\_00050000) only ever
+receives first-instar larval images, the L3 CNS template (`Wood2018`, VFB\_00049000) only
+third-instar images — so a dataset's `AlignedDatasets` membership on those templates is
+firmer evidence than its name. That check changed three classifications from the first,
+label-only pass: the `TrumanWood2018`/`TrumanWood2018public` Truman Larval Flip-Out
+Collection and `SplitMeissner2024` are all registered to the L3 template rather than an
+unspecified larval stage or, in Meissner's case, no stage at all. This is a documentation
+convenience, not a data-model change — nothing here is queryable from the API. A dataset
+missing from a future data release, or one whose stage was misjudged, should be corrected
+here directly; if VFB's data model gains a real structured stage field later, this page
+should be regenerated from it instead of maintained by hand.
+
+## Embryo
+
+Approximately 0–22 hours after egg laying, from fertilisation to hatching. The two
+datasets here are single-cell/single-nucleus transcriptomic surveys of the whole embryo;
+VFB holds no embryonic imaging data at this time.
+
+| Dataset | Short form |
+|---|---|
+| [Single-cell RNA-seq study of gastrulating embryos](https://flybase.org/reports/FBlc0006191) | `FBlc0006191` |
+| [The continuum of Drosophila embryonic development at single-cell resolution](https://flybase.org/reports/FBlc0007797) | `FBlc0007797` |
+
+## Larva
+
+The larval period runs from hatching to pupariation and is divided into three instars —
+L1, L2 and L3 — separated by moults. VFB's larval holdings cluster almost entirely at the
+first and third instars; no dataset here is recorded as L2. Anatomy differs enough
+between instars that a "larval" dataset with no instar stated should not be assumed
+comparable to one that states it, particularly for connectomic data.
+
+### L1 (first instar)
+
+The stage most larval EM connectomics is drawn from: the larval CNS is small enough for
+a first-instar animal to be reconstructed at synaptic resolution in a single study. Most
+entries below are single-paper EM reconstructions built on the `l1em` connectome
+(Ohyama et al. 2015 and the studies that extended it) and registered to the L1 CNS
+template.
+
+| Dataset | Short form |
+|---|---|
+| [Comparative Connectomics Reveals How Partner Identity, Location, and Activity Specify Synaptic Connectivity in Drosophila (Valdes-Aleman et al. 2021)](https://virtualflybrain.org/reports/Valdes_Aleman2021) | `Valdes_Aleman2021` |
+| [EM L1 Andrade et al. 2019](https://virtualflybrain.org/reports/Andrade2019) | `Andrade2019` |
+| [EM L1 Barnes et al., 2022](https://virtualflybrain.org/reports/Barnes2022) | `Barnes2022` |
+| [EM L1 Carreira-Rosario, Arzan Zarin, Clark et al. 2018](https://virtualflybrain.org/reports/CarreiraRosario2018) | `CarreiraRosario2018` |
+| [EM L1 Eschbach et al 2020](https://virtualflybrain.org/reports/Eschbach2020) | `Eschbach2020` |
+| [EM L1 Eschbach et al 2020b](https://virtualflybrain.org/reports/Eschbach2020b) | `Eschbach2020b` |
+| [EM L1 Imambocus et al., 2022](https://virtualflybrain.org/reports/Imambocus2022) | `Imambocus2022` |
+| [EM L1 Jovanic et al. 2019](https://virtualflybrain.org/reports/Jovanic2019) | `Jovanic2019` |
+| [EM L1 Mark et al. 2019](https://virtualflybrain.org/reports/Mark2019) | `Mark2019` |
+| [EM L1 Miroschnikow et al. 2018](https://virtualflybrain.org/reports/Miroschnikow2018) | `Miroschnikow2018` |
+| [EM L1 Tastekin et al 2018](https://virtualflybrain.org/reports/Tastekin2018) | `Tastekin2018` |
+| [EM L1 Winding, Pedigo et al., 2023](https://virtualflybrain.org/reports/WindingPedigo2023) | `WindingPedigo2023` |
+| [EM L1 Zarin, Mark et al. 2019](https://virtualflybrain.org/reports/Zarin2019) | `Zarin2019` |
+| [Eve+ neurons, sensorimotor circuit - EM (Heckscher2015)](https://virtualflybrain.org/reports/Heckscher2015) | `Heckscher2015` |
+| [Full CNS EM, sparse (manually traced) reconstruction (L1 larva)](https://virtualflybrain.org/reports/Ohyama2015) | `Ohyama2015` |
+| [larval hugin neurons - EM (Schlegel2016)](https://virtualflybrain.org/reports/Schlegel2016) | `Schlegel2016` |
+| [Larval MB neurons - EM (Eichler2017)](https://virtualflybrain.org/reports/Eichler2017) | `Eichler2017` |
+| [Larval motor circuit neurons (Zwart2016)](https://virtualflybrain.org/reports/Zwart2016) | `Zwart2016` |
+| [Larval olfactory system neurons - EM (Berck2016)](https://virtualflybrain.org/reports/Berck2016) | `Berck2016` |
+| [Larval peristaltic locomotor system neurons - EM (Fushiki2016)](https://virtualflybrain.org/reports/Fushiki2016) | `Fushiki2016` |
+| [larval sensorimotor decision pathways (Jovanic2016)](https://virtualflybrain.org/reports/Jovanic2016) | `Jovanic2016` |
+| [larval visual circuit neurons (Larderet2017)](https://virtualflybrain.org/reports/Larderet2017) | `Larderet2017` |
+| [Larval wave neurons and circuit partners - EM (Takagi2017)](https://virtualflybrain.org/reports/Takagi2017) | `Takagi2017` |
+| [Nociceptive circuit neurons - EM (Gerhard2017)](https://virtualflybrain.org/reports/Gerhard2017) | `Gerhard2017` |
+| [Nociceptive system neurons - EM (Burgos2017)](https://virtualflybrain.org/reports/Burgos2018) | `Burgos2018` |
+| [Single-cell RNA-seq study of first instar larval brains upon starvation](https://flybase.org/reports/FBlc0005362) | `FBlc0005362` |
+| [Unveiling the sensory and interneuronal pathways of the neuroendocrine connectome in Drosophila (Hueckesfeld et al. 2020)](https://virtualflybrain.org/reports/Hueckesfeld2020) | `Hueckesfeld2020` |
+
+### L3 (third instar)
+
+The last and largest larval instar, imaged shortly before pupariation. VFB's L3 material
+is registered to the Wood2018 L3 CNS template and includes the Truman Larval Flip-Out
+Collection (`TrumanWood2018`, published 2018) — currently the newest of VFB's larval
+datasets by publication year.
+
+| Dataset | Short form |
+|---|---|
+| [L3 Larval CNS Template (Truman2016)](https://virtualflybrain.org/reports/Truman2016) | `Truman2016` |
+| [L3 neuropils (WoodHartenstein2018)](https://virtualflybrain.org/reports/WoodHartenstein2018) | `WoodHartenstein2018` |
+| [Split-GAL4 lines from Meissner et al., 2024](https://virtualflybrain.org/reports/SplitMeissner2024) | `SplitMeissner2024` |
+| [Truman Larval Flip-Out Collection](https://virtualflybrain.org/reports/TrumanWood2018) | `TrumanWood2018` |
+| [Truman Larval Flip-Out Collection](https://virtualflybrain.org/reports/TrumanWood2018public) | `TrumanWood2018public` |
+
+### Larva (instar not stated)
+
+Larval by name, publication or genetic targeting, but without enough evidence in VFB to
+assign a specific instar — none of these are registered to either larval template, most
+likely because they are driver-line metadata without their own aligned images. Treat the
+instar as unknown rather than assuming L1 or L3.
+
+| Dataset | Short form |
+|---|---|
+| [MCFO images of GMR-GAL4 lines from Jovanic et al., 2019](https://virtualflybrain.org/reports/Gen1MCFOJovanic2019) | `Gen1MCFOJovanic2019` |
+| [Single-cell RNA-seq study of larval optic lobes](https://flybase.org/reports/FBlc0006404) | `FBlc0006404` |
+| [Split-GAL4 lines from Jovanic et al., 2019](https://virtualflybrain.org/reports/SplitJovanic2019) | `SplitJovanic2019` |
+| [Split-GAL4 lines from Takagi et al., 2017](https://virtualflybrain.org/reports/SplitTakagi2017) | `SplitTakagi2017` |
+
+## Pupa
+
+Metamorphosis, from pupariation to eclosion. Both datasets here are transcriptomic
+surveys of the optic lobe spanning the pupal-to-adult transition; VFB holds no
+pupal-only imaging data.
+
+| Dataset | Short form |
+|---|---|
+| [Single-cell RNA-seq study of pupal and adult optic lobes](https://flybase.org/reports/FBlc0005659) | `FBlc0005659` |
+| [Single-cell RNA-seq study of the pupal optic lobe](https://flybase.org/reports/FBlc0006237) | `FBlc0006237` |
+
+## Adult
+
+By far VFB's largest holding: 170 of the 210 dataset entities.
+Almost everything here is light-microscopy driver-line and split-GAL4 material from
+FlyLight, VDRC, FlyCircuit and individual labs, plus the per-paper EM connectome
+datasets (FAFB, hemibrain and their derivatives) and the adult-focused Fly Cell Atlas /
+Aging Fly Cell Atlas scRNAseq series. Sex is usually stated for the EM connectomes (FAFB
+and hemibrain are each a single traced female brain; MANC and Male-CNS are male) and
+usually unstated for driver-line collections, which typically pool both sexes.
+
+### Brain
+
+The overwhelming majority of VFB's adult data: everything above that targets or images
+central brain and optic lobe circuitry, without a more specific VNC, leg or whole-body
+grouping below.
+
+| Dataset | Short form |
+|---|---|
+| [Adult Brain fru clones (Cachero2010)](https://virtualflybrain.org/reports/Cachero2010) | `Cachero2010` |
+| [AMMC local and projection neurons (Matsuo2016)](https://virtualflybrain.org/reports/Matsuo2016) | `Matsuo2016` |
+| [BrainName neuropils and tracts - Ito half-brain](https://virtualflybrain.org/reports/BrainName_Ito_half_brain) | `BrainName_Ito_half_brain` |
+| [BrainName neuropils on adult brain JFRC2 (Jenett, Shinomya)](https://virtualflybrain.org/reports/JenettShinomya_BrainName) | `JenettShinomya_BrainName` |
+| [BrainTrap lines (Knowles-Barley2010)](https://virtualflybrain.org/reports/Knowles_Barley2010) | `Knowles_Barley2010` |
+| [central brain neurons by lineage, Lee2020](https://virtualflybrain.org/reports/Lee_Lineage2020) | `Lee_Lineage2020` |
+| [Dickson lab VT line collection - VDRC images](https://virtualflybrain.org/reports/Dickson_VT) | `Dickson_VT` |
+| [Dickson lab VT lines - FlyLight/Janelia images (2017)](https://virtualflybrain.org/reports/Dickson2017) | `Dickson2017` |
+| [EM FAFB Baltruschat et al 2021](https://virtualflybrain.org/reports/Baltruschat2021) | `Baltruschat2021` |
+| [EM FAFB Bates and Schlegel et al 2020](https://virtualflybrain.org/reports/BatesSchlegel2020) | `BatesSchlegel2020` |
+| [EM FAFB Coates et al 2020](https://virtualflybrain.org/reports/Coates2020) | `Coates2020` |
+| [EM FAFB Dolan and Belliart-Guerin et al. 2018](https://virtualflybrain.org/reports/Dolan2018) | `Dolan2018` |
+| [EM FAFB Dolan et al. 2019](https://virtualflybrain.org/reports/FafbDolan2019) | `FafbDolan2019` |
+| [EM FAFB Dombrovski et al 2023](https://virtualflybrain.org/reports/Dombrovski2023) | `Dombrovski2023` |
+| [EM FAFB Engert et al. 2022](https://virtualflybrain.org/reports/Engert2022) | `Engert2022` |
+| [EM FAFB Erginkaya et al 2025](https://virtualflybrain.org/reports/Erginkaya2025) | `Erginkaya2025` |
+| [EM FAFB Felsenberg et al. 2018](https://virtualflybrain.org/reports/Felsenberg2018) | `Felsenberg2018` |
+| [EM FAFB Gorko et al 2024](https://virtualflybrain.org/reports/Gorko2024) | `Gorko2024` |
+| [EM FAFB Hampel and Eichler et al 2020](https://virtualflybrain.org/reports/HampelEichler2020) | `HampelEichler2020` |
+| [EM FAFB Kim et al 2020](https://virtualflybrain.org/reports/Kim2020) | `Kim2020` |
+| [EM FAFB Kind et al. 2021](https://virtualflybrain.org/reports/Kind2021) | `Kind2021` |
+| [EM FAFB Marin et al 2020](https://virtualflybrain.org/reports/Marin2020) | `Marin2020` |
+| [EM FAFB Morimoto et al 2020](https://virtualflybrain.org/reports/Morimoto2020) | `Morimoto2020` |
+| [EM FAFB Otto et al 2020](https://virtualflybrain.org/reports/Otto2020) | `Otto2020` |
+| [EM FAFB Sayin et al 2019](https://virtualflybrain.org/reports/Sayin2019) | `Sayin2019` |
+| [EM FAFB Shiu et al. 2022](https://virtualflybrain.org/reports/Shiu2022) | `Shiu2022` |
+| [EM FAFB Taisz and Galili et al., 2022](https://virtualflybrain.org/reports/TaiszGalili2022) | `TaiszGalili2022` |
+| [EM FAFB Turner-Evans et al 2020](https://virtualflybrain.org/reports/Turner_Evans2020) | `Turner_Evans2020` |
+| [EM FAFB Wang et al 2020a](https://virtualflybrain.org/reports/Wang2020a) | `Wang2020a` |
+| [EM FAFB Wang et al 2020b](https://virtualflybrain.org/reports/Wang2020b) | `Wang2020b` |
+| [EM FAFB Wang et al 2020c](https://virtualflybrain.org/reports/Wang2020c) | `Wang2020c` |
+| [EM FAFB Zhao et al., 2023](https://virtualflybrain.org/reports/Zhao2023) | `Zhao2023` |
+| [EM FAFB Zheng et al 2020 (published 2022)](https://virtualflybrain.org/reports/Zheng2020) | `Zheng2020` |
+| [FlyCircuit 1.0 - single neurons (Chiang2010)](https://virtualflybrain.org/reports/Chiang2010) | `Chiang2010` |
+| [FlyLight - Gen1 GAL4/LexA collection (exported 2019)](https://virtualflybrain.org/reports/FlyLightGen1Set2019) | `FlyLightGen1Set2019` |
+| [FlyLight - GMR GAL4 collection (Jenett2012)](https://virtualflybrain.org/reports/Jenett2012) | `Jenett2012` |
+| [FlyLight split-GAL4 lines for Lateral Horn](https://virtualflybrain.org/reports/FlyLight2019LateralHorn2019) | `FlyLight2019LateralHorn2019` |
+| [FlyLight split-GAL4 lines for Lateral Horn (LateralHorn2019)](https://virtualflybrain.org/reports/LateralHorn2019) | `LateralHorn2019` |
+| [Full brain EM connectome, dense reconstruction (adult female)](https://virtualflybrain.org/reports/Dorkenwald2023) | `Dorkenwald2023` |
+| [Full brain EM, sparse (manually traced) reconstruction (adult female)](https://virtualflybrain.org/reports/Zheng2018) | `Zheng2018` |
+| [GAL4 Split expression patterns from Dolan et al. 2019](https://virtualflybrain.org/reports/Dolan2019) | `Dolan2019` |
+| [Grooming neurons and drivers (Hampel 2015)](https://virtualflybrain.org/reports/FlyLight2019Hampel2015) | `FlyLight2019Hampel2015` |
+| [Grooming neurons and drivers (Hampel 2015)](https://virtualflybrain.org/reports/Hampel2015) | `Hampel2015` |
+| [Images of aSP22 descending neuron from McKellar et al., 2019](https://virtualflybrain.org/reports/McKellar2019) | `McKellar2019` |
+| [Ito lab adult brain lineage clone image set](https://virtualflybrain.org/reports/Ito2013) | `Ito2013` |
+| [JRC 2018 templates & ROIs](https://virtualflybrain.org/reports/JRC2018) | `JRC2018` |
+| [JRC_FlyEM_Hemibrain painted domains](https://virtualflybrain.org/reports/Xu2020roi) | `Xu2020roi` |
+| [Lee lab adult brain lineage clone image set](https://virtualflybrain.org/reports/Yu2013) | `Yu2013` |
+| [LexA driver targetting mechanosensory eye bristles (Hampel2017)](https://virtualflybrain.org/reports/Hampel2017) | `Hampel2017` |
+| [MBONs and split-GAL4 lines that target them (Aso2014)](https://virtualflybrain.org/reports/Aso2014) | `Aso2014` |
+| [MCFO images of GMR-GAL4 lines from Dionne et al., 2018](https://virtualflybrain.org/reports/Gen1MCFODionne2018) | `Gen1MCFODionne2018` |
+| [MCFO images of GMR-GAL4 lines from Jenett et al., 2012](https://virtualflybrain.org/reports/Gen1MCFOJenett2012) | `Gen1MCFOJenett2012` |
+| [MCFO images of GMR-GAL4 lines from Pfeiffer et al., 2010](https://virtualflybrain.org/reports/Gen1MCFOPfeiffer2010) | `Gen1MCFOPfeiffer2010` |
+| [MCFO images of VT-GAL4 lines from Tirian et al., 2017](https://virtualflybrain.org/reports/Gen1MCFOTirian2017) | `Gen1MCFOTirian2017` |
+| [Optic lobe EM connectome, dense reconstruction (adult male)](https://virtualflybrain.org/reports/Nern2024) | `Nern2024` |
+| [Partial brain EM connectome, dense reconstruction (adult female)](https://virtualflybrain.org/reports/Xu2020NeuronsV1point2point1) | `Xu2020NeuronsV1point2point1` |
+| [RNAseq_2020_Davis](https://virtualflybrain.org/reports/PRJNA480794) | `PRJNA480794` |
+| [Single-cell RNA-seq study of adult brain without alcohol exposure](https://flybase.org/reports/FBlc0005420) | `FBlc0005420` |
+| [Single-cell RNA-seq study of adult brain without cocaine exposure](https://flybase.org/reports/FBlc0005515) | `FBlc0005515` |
+| [Single-cell RNA-seq study of the aging brain](https://flybase.org/reports/FBlc0006090) | `FBlc0006090` |
+| [Single-cell RNA-seq study of visual motion-sensing neurons](https://flybase.org/reports/FBlc0006305) | `FBlc0006305` |
+| [Single-nucleus RNA-seq on cells from 30-days old male flies](https://flybase.org/reports/FBlc0006611) | `FBlc0006611` |
+| [Split GAL4 lines for dopaminergic neurons, Xie2018](https://virtualflybrain.org/reports/Xie2018) | `Xie2018` |
+| [split-GAL4 lines for  EB neurons (Robie2017)](https://virtualflybrain.org/reports/Robie2017) | `Robie2017` |
+| [split-GAL4 lines for dopaminergic neurons (AsoRubin2016)](https://virtualflybrain.org/reports/AsoRubin2016) | `AsoRubin2016` |
+| [split-GAL4 lines for dopaminergic neurons (AsoRubin2016)](https://virtualflybrain.org/reports/FlyLight2019AsoRubin2016) | `FlyLight2019AsoRubin2016` |
+| [split-GAL4 lines for EB neurons (Robie2017)](https://virtualflybrain.org/reports/FlyLight2019Robie2017) | `FlyLight2019Robie2017` |
+| [split-GAL4 lines for LC VPNs (Wu2016)](https://virtualflybrain.org/reports/FlyLight2019Wu2016) | `FlyLight2019Wu2016` |
+| [split-GAL4 lines for LC VPNs (Wu2016)](https://virtualflybrain.org/reports/Wu2016) | `Wu2016` |
+| [Split-GAL4 lines from Aso et al., 2014b](https://virtualflybrain.org/reports/SplitAso2014b) | `SplitAso2014b` |
+| [Split-GAL4 lines from Baker et al., 2022](https://virtualflybrain.org/reports/SplitBaker2022) | `SplitBaker2022` |
+| [Split-GAL4 lines from Bogovic et al., 2020](https://virtualflybrain.org/reports/SplitBogovic2020) | `SplitBogovic2020` |
+| [Split-GAL4 lines from Cheong et al., 2023](https://virtualflybrain.org/reports/SplitCheong2023) | `SplitCheong2023` |
+| [Split-GAL4 lines from Cheong et al., 2024](https://virtualflybrain.org/reports/SplitCheong2024) | `SplitCheong2024` |
+| [Split-GAL4 lines from Dag et al., 2019](https://virtualflybrain.org/reports/SplitDag2019) | `SplitDag2019` |
+| [Split-GAL4 lines from Davis et al., 2020](https://virtualflybrain.org/reports/SplitDavis2020) | `SplitDavis2020` |
+| [Split-GAL4 lines from Ehrhardt et al., 2023](https://virtualflybrain.org/reports/SplitEhrhardt2023) | `SplitEhrhardt2023` |
+| [Split-GAL4 lines from Feng et al., 2014](https://virtualflybrain.org/reports/SplitFeng2014) | `SplitFeng2014` |
+| [Split-GAL4 lines from Gao et al., 2019](https://virtualflybrain.org/reports/SplitGao2019) | `SplitGao2019` |
+| [Split-GAL4 lines from Garner et al., 2023](https://virtualflybrain.org/reports/SplitGarner2023) | `SplitGarner2023` |
+| [Split-GAL4 lines from Giraldo et al., 2018](https://virtualflybrain.org/reports/SplitGiraldo2018) | `SplitGiraldo2018` |
+| [Split-GAL4 lines from Hattori et al., 2017](https://virtualflybrain.org/reports/SplitHattori2017) | `SplitHattori2017` |
+| [Split-GAL4 lines from Hulse et al., 2021](https://virtualflybrain.org/reports/SplitHulse2021) | `SplitHulse2021` |
+| [Split-GAL4 lines from Isaacson et al., 2023](https://virtualflybrain.org/reports/SplitIsaacson2023) | `SplitIsaacson2023` |
+| [Split-GAL4 lines from Kind et al., 2021](https://virtualflybrain.org/reports/SplitKind2021) | `SplitKind2021` |
+| [Split-GAL4 lines from Klapoetke et al. 2017](https://virtualflybrain.org/reports/FlyLight2019Klapoetke2017) | `FlyLight2019Klapoetke2017` |
+| [Split-GAL4 lines from Klapoetke et al. 2017](https://virtualflybrain.org/reports/Klapoetke2017) | `Klapoetke2017` |
+| [Split-GAL4 lines from Klapoetke et al., 2022](https://virtualflybrain.org/reports/SplitKlapoetke2022) | `SplitKlapoetke2022` |
+| [Split-GAL4 lines from Lillvis et al., 2022](https://virtualflybrain.org/reports/SplitLillvis2022) | `SplitLillvis2022` |
+| [Split-GAL4 lines from Liu et al., 2019](https://virtualflybrain.org/reports/SplitLiu2019) | `SplitLiu2019` |
+| [Split-GAL4 lines from Longden et al., 2021](https://virtualflybrain.org/reports/SplitLongden2021) | `SplitLongden2021` |
+| [Split-GAL4 lines from Longden et al., 2023](https://virtualflybrain.org/reports/SplitLongden2023) | `SplitLongden2023` |
+| [Split-GAL4 lines from Mais et al., 2021](https://virtualflybrain.org/reports/SplitMais2021) | `SplitMais2021` |
+| [Split-GAL4 lines from Masek et al., 2015](https://virtualflybrain.org/reports/SplitMasek2015) | `SplitMasek2015` |
+| [Split-GAL4 lines from Meissner et al., 2018](https://virtualflybrain.org/reports/SplitMeissner2018) | `SplitMeissner2018` |
+| [Split-GAL4 lines from Minegishi et al., 2023](https://virtualflybrain.org/reports/SplitMinegishi2023) | `SplitMinegishi2023` |
+| [Split-GAL4 lines from Montague et al., 2019](https://virtualflybrain.org/reports/SplitMontague2019) | `SplitMontague2019` |
+| [Split-GAL4 lines from Morimoto et al., 2020](https://virtualflybrain.org/reports/SplitMorimoto2020) | `SplitMorimoto2020` |
+| [Split-GAL4 lines from Nallasivan et al 2025](https://virtualflybrain.org/reports/SplitNallasivan2025) | `SplitNallasivan2025` |
+| [Split-GAL4 lines from Nern et al., 2025](https://virtualflybrain.org/reports/SplitNern2025) | `SplitNern2025` |
+| [Split-GAL4 lines from Nojima et al., 2021](https://virtualflybrain.org/reports/Nojima2021) | `Nojima2021` |
+| [Split-GAL4 lines from Ribeiro et al., 2018](https://virtualflybrain.org/reports/SplitRibeiro2018) | `SplitRibeiro2018` |
+| [Split-GAL4 lines from Rubin et al., 2024](https://virtualflybrain.org/reports/SplitRubin2024) | `SplitRubin2024` |
+| [Split-GAL4 lines from Schlichting et al., 2019](https://virtualflybrain.org/reports/SplitSchlichting2019) | `SplitSchlichting2019` |
+| [Split-GAL4 lines from Schretter et al., 2020](https://virtualflybrain.org/reports/SplitSchretter2020) | `SplitSchretter2020` |
+| [Split-GAL4 lines from Schretter et al., 2024](https://virtualflybrain.org/reports/SplitSchretter2024) | `SplitSchretter2024` |
+| [Split-GAL4 lines from Shao et al., 2017](https://virtualflybrain.org/reports/SplitShao2017) | `SplitShao2017` |
+| [Split-GAL4 lines from Shuai et al., 2023](https://virtualflybrain.org/reports/SplitShuai2023) | `SplitShuai2023` |
+| [Split-GAL4 lines from Sitaraman et al., 2015](https://virtualflybrain.org/reports/SplitSitaraman2015) | `SplitSitaraman2015` |
+| [Split-GAL4 lines from Sterne et al., 2021](https://virtualflybrain.org/reports/SplitSterne2021) | `SplitSterne2021` |
+| [Split-GAL4 lines from Sun et al., 2017](https://virtualflybrain.org/reports/SplitSun2017) | `SplitSun2017` |
+| [Split-GAL4 lines from Takemura et al., 2017](https://virtualflybrain.org/reports/SplitTakemura2017) | `SplitTakemura2017` |
+| [Split-GAL4 lines from Tanaka et al., 2008](https://virtualflybrain.org/reports/SplitTanaka2008) | `SplitTanaka2008` |
+| [Split-GAL4 lines from Triphan et al., 2016](https://virtualflybrain.org/reports/SplitTriphan2016) | `SplitTriphan2016` |
+| [Split-GAL4 lines from Turner-Evans et al., 2017](https://virtualflybrain.org/reports/SplitDavis2017) | `SplitDavis2017` |
+| [Split-GAL4 lines from Turner-Evans et al., 2017](https://virtualflybrain.org/reports/SplitTurner_Evans2017) | `SplitTurner_Evans2017` |
+| [Split-GAL4 lines from Turner-Evans et al., 2020](https://virtualflybrain.org/reports/SplitTurner_Evans2020) | `SplitTurner_Evans2020` |
+| [Split-GAL4 lines from Vijayan et al., 2023](https://virtualflybrain.org/reports/SplitVijayan2023) | `SplitVijayan2023` |
+| [Split-GAL4 lines from Vogt et al., 2014](https://virtualflybrain.org/reports/SplitVogt2014) | `SplitVogt2014` |
+| [Split-GAL4 lines from Vogt et al., 2016](https://virtualflybrain.org/reports/SplitVogt2016) | `SplitVogt2016` |
+| [Split-GAL4 lines from Wang et al., 2020a](https://virtualflybrain.org/reports/SplitWang2020a) | `SplitWang2020a` |
+| [Split-GAL4 lines from Wang et al., 2020b](https://virtualflybrain.org/reports/SplitWang2020b) | `SplitWang2020b` |
+| [Split-GAL4 lines from Wang et al., 2020c](https://virtualflybrain.org/reports/SplitWang2020c) | `SplitWang2020c` |
+| [Split-GAL4 lines from Wolff et al., 2025](https://virtualflybrain.org/reports/SplitWolff2025) | `SplitWolff2025` |
+| [Split-GAL4 lines from Xie et al., 2021](https://virtualflybrain.org/reports/SplitXie2021) | `SplitXie2021` |
+| [Split-GAL4 lines from Yamagata et al., 2015](https://virtualflybrain.org/reports/SplitYamagata2015) | `SplitYamagata2015` |
+| [Split-GAL4 lines from Yoo et al., 2023](https://virtualflybrain.org/reports/SplitYoo2023) | `SplitYoo2023` |
+| [Split-GAL4 lines from Zhao et al., 2023](https://virtualflybrain.org/reports/SplitZhao2023) | `SplitZhao2023` |
+| [Split-GAL4 lines from Zhao et al., 2025](https://virtualflybrain.org/reports/SplitZhao2025) | `SplitZhao2025` |
+| [Splits targetting CX neurons, Wolff2018](https://virtualflybrain.org/reports/FlyLight2019Wolff2018) | `FlyLight2019Wolff2018` |
+| [Splits targetting CX neurons, Wolff2018](https://virtualflybrain.org/reports/Wolff2018) | `Wolff2018` |
+| [Splits targetting the visual motion pathway, Strother2017](https://virtualflybrain.org/reports/FlyLight2019Strother2017) | `FlyLight2019Strother2017` |
+| [Splits targetting the visual motion pathway, Strother2017](https://virtualflybrain.org/reports/Strother2017) | `Strother2017` |
+| [Third order olfactory neurons involved in pheromone response - backfills (Kohl2013)](https://virtualflybrain.org/reports/Kohl2013) | `Kohl2013` |
+
+### VNC (ventral nerve cord)
+
+Datasets specific to the adult ventral nerve cord — MANC and FANC on the EM side, the
+Court VNC/VNS templates and neuropils, and the handful of driver-line and scRNAseq sets
+built around VNC circuits (walking, courtship song, neck motor control).
+
+| Dataset | Short form |
+|---|---|
+| [Adult VNC neuropils (Court2020)](https://virtualflybrain.org/reports/Court2020) | `Court2020` |
+| [Adult VNS neuropils (Court2017)](https://virtualflybrain.org/reports/Court2017) | `Court2017` |
+| [Full VNC EM connectome, dense reconstruction (adult male)](https://virtualflybrain.org/reports/Takemura2023) | `Takemura2023` |
+| [Full VNS EM, sparse reconstruction (adult female)](https://virtualflybrain.org/reports/Maniates_Selvin2020) | `Maniates_Selvin2020` |
+| [Single-cell RNA-seq study of adult ventral nerve cords](https://flybase.org/reports/FBlc0005603) | `FBlc0005603` |
+| [Split-GAL4 lines from Bidaye et al., 2014](https://virtualflybrain.org/reports/SplitBidaye2014) | `SplitBidaye2014` |
+| [Split-GAL4 lines from Bidaye et al., 2020](https://virtualflybrain.org/reports/SplitBidaye2020) | `SplitBidaye2020` |
+| [Split-GAL4 lines from Gorko et al., 2024](https://virtualflybrain.org/reports/SplitGorko2024) | `SplitGorko2024` |
+| [Split-GAL4 lines from Lillvis et al., 2024](https://virtualflybrain.org/reports/SplitLillvis2024) | `SplitLillvis2024` |
+
+### Leg, head and thorax
+
+Peripheral and body-wall datasets that are neither brain nor VNC proper: leg
+proprioception and imaging, proboscis motor neurons, and thoracic scRNAseq.
+
+| Dataset | Short form |
+|---|---|
+| [Biomechanical origins of proprioceptive maps in the Drosophila leg](https://virtualflybrain.org/reports/Mamiya2022) | `Mamiya2022` |
+| [GAL4 lines from McKellar et al., 2020](https://virtualflybrain.org/reports/McKellar2020) | `McKellar2020` |
+| [Images of proboscis muscles from McKellar et al., 2020](https://virtualflybrain.org/reports/HeadMusclesMcKellar2020) | `HeadMusclesMcKellar2020` |
+| [Millimeter-scale imaging of a Drosophila leg at single-neuron resolution](https://virtualflybrain.org/reports/Kuan2020) | `Kuan2020` |
+| [Single-cell RNA-seq study of the adult thorax](https://flybase.org/reports/FBlc0006361) | `FBlc0006361` |
+| [Split-GAL4 lines from Tuthill et al., 2013](https://virtualflybrain.org/reports/SplitTuthill2013) | `SplitTuthill2013` |
+
+### Full CNS and whole body
+
+Resources that deliberately span more than one region: whole-CNS connectomes (BANC,
+Male-CNS), descending-neuron driver-line sets that by design run from the brain into the
+VNC, and the Fly Cell Atlas / Aging Fly Cell Atlas scRNAseq series, which sample the
+whole animal rather than the nervous system alone.
+
+| Dataset | Short form |
+|---|---|
+| [Full CNS EM connectome, dense reconstruction (adult female)](https://virtualflybrain.org/reports/Bates2025) | `Bates2025` |
+| [Full CNS EM connectome, dense reconstruction (adult male)](https://virtualflybrain.org/reports/Berg2025) | `Berg2025` |
+| [Neurons involved in courtship and song (Lillvis2018)](https://virtualflybrain.org/reports/Lillvis2018) | `Lillvis2018` |
+| [Single-nucleus RNA-seq on cells from 30-days old female flies](https://flybase.org/reports/FBlc0006424) | `FBlc0006424` |
+| [Single-nucleus RNA-seq on cells from 30-days old flies](https://flybase.org/reports/FBlc0006423) | `FBlc0006423` |
+| [Single-nucleus RNA-seq on cells from 5-days old female and male flies](https://flybase.org/reports/FBlc0004785) | `FBlc0004785` |
+| [Single-nucleus RNA-seq on cells from 5-days old female flies](https://flybase.org/reports/FBlc0003846) | `FBlc0003846` |
+| [Single-nucleus RNA-seq on cells from 5-days old male flies](https://flybase.org/reports/FBlc0004307) | `FBlc0004307` |
+| [Single-nucleus RNA-seq on cells from 50-days old female flies](https://flybase.org/reports/FBlc0006888) | `FBlc0006888` |
+| [Single-nucleus RNA-seq on cells from 50-days old flies](https://flybase.org/reports/FBlc0006887) | `FBlc0006887` |
+| [Single-nucleus RNA-seq on cells from 50-days old male flies](https://flybase.org/reports/FBlc0007071) | `FBlc0007071` |
+| [Single-nucleus RNA-seq on cells from 70-days old female flies](https://flybase.org/reports/FBlc0007348) | `FBlc0007348` |
+| [Single-nucleus RNA-seq on cells from 70-days old flies](https://flybase.org/reports/FBlc0007347) | `FBlc0007347` |
+| [Single-nucleus RNA-seq on cells from 70-days old male flies](https://flybase.org/reports/FBlc0007532) | `FBlc0007532` |
+| [split-GAL4 lines for descending neurons (Namiki2018)](https://virtualflybrain.org/reports/FlyLight2019Namiki2018) | `FlyLight2019Namiki2018` |
+| [split-GAL4 lines for descending neurons (Namiki2018)](https://virtualflybrain.org/reports/Namiki2018) | `Namiki2018` |
+| [Split-GAL4 lines from Feng et al., 2020](https://virtualflybrain.org/reports/SplitFeng2020) | `SplitFeng2020` |
+| [Split-GAL4 lines from Liang et al., 2017](https://virtualflybrain.org/reports/SplitLiang2017) | `SplitLiang2017` |
+| [Split-GAL4 lines from Namiki et al., 2022](https://virtualflybrain.org/reports/SplitNamiki2022) | `SplitNamiki2022` |
+| [Split-GAL4 lines from Reyn et al., 2017](https://virtualflybrain.org/reports/SplitReyn2017) | `SplitReyn2017` |
+| [Split-GAL4 lines from Zung et al., 2025](https://virtualflybrain.org/reports/SplitZung2025) | `SplitZung2025` |
+
+## Stage-agnostic resources
+
+A small number of dataset entities in VFB's knowledge base are reference resources
+rather than material from an animal at a particular stage — reused across stages by
+design. None fall in this bucket at the time of writing (VFB's templates and neuropil
+domain sets are all stage-specific and appear above under their own stage), but the
+category is kept here for anything added later that should not be forced into a stage
+it does not have.


### PR DESCRIPTION
Add a Stage column to the EM, LM (FlyLight/VDRC/FlyCircuit/labs/BrainTrap) and scRNAseq dataset tables, and a new page (`docs/data/stages/`) that groups all 210 VFB dataset entities by developmental stage (embryo, L1/L3/instar-unspecified larva, pupa, adult — the last split by brain/VNC/leg,head,thorax/full CNS & whole body), each with a short description and a link to its report page, plus a description of what each stage term covers.

VFB has no structured stage field on DataSet entities, so this was compiled by hand from each dataset's name, description and publication, then cross-checked against which developmental-stage template a dataset's images are aligned to (`AlignedDatasets` on the L1 and L3 CNS templates) — firmer evidence than name alone. That check reclassified `TrumanWood2018`, `TrumanWood2018public` and `SplitMeissner2024` from "larva, instar unspecified" (or, for `SplitMeissner2024`, no stage at all) to L3 larva.

Motivated by a NeuroFly 2026 workshop question ("is TrumanWood2018 the newest of 12 larval datasets?") that could only be answered by searching dataset names for "larval" — a method that misses anything not named that way and catches nothing for embryo or pupal data.

This page is a documentation-only stopgap: nothing here is queryable via the API, so it should be regenerated from a real data-model field if VFB ever adds one.
