### PR TITLE
Make the datasets-by-stage page findable in site search, and state its counts

### DIFF
--- a/content/en/docs/Data/stages.md
+++ b/content/en/docs/Data/stages.md
@@ -4,7 +4,9 @@ linkTitle: "Datasets by stage"
 weight: 511
 date: 2026-08-31
 description: >
-    Every VFB dataset grouped by the developmental stage of the animal it was collected from.
+    Every VFB dataset grouped by developmental stage — embryo, larva (L1 and L3 instars),
+    pupa and adult — with the number of datasets at each stage.
+keywords: ["larval", "larva", "embryo", "embryonic", "pupa", "pupal", "adult", "instar", "L1", "L3", "developmental stage", "datasets"]
 ---
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/7/7c/Drosophila_melanogaster_life_cycle.jpg" alt="Drosophila melanogaster life cycle: egg, larval instars, pupa, adult" style="max-width:50%">
@@ -16,9 +18,49 @@ CC BY 3.0, via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Droso
 
 VFB's datasets are documented by [technique](/docs/data/em/) and by
 [source](/docs/data/lm/) elsewhere on this site, but nothing groups them by the stage of
-the animal they came from. This page lists all 210 dataset entities currently in the
-VFB knowledge base, grouped by developmental stage, with a link to each dataset's own
+the animal they came from. That gap has come up in practice: it is why a question like
+*"how many larval datasets does VFB hold, and which is newest?"* has no direct answer on
+the site today, and can only be approximated by searching dataset names for the word
+"larval" — a search that misses anything not named that way, and catches nothing at all
+for embryo or pupal material.
+
+This page is that missing reference. It lists all 210 dataset entities currently in the
+VFB knowledge base (`DataSet` individuals — the same list `search_terms` returns when
+filtered to `dataset`), grouped by developmental stage, with a link to each dataset's own
 page where a stage-agnostic reader would want to jump straight to the data.
+
+**At a glance.** Of the 210 dataset entities, 2 are embryonic, 36 are larval
+(27 first-instar, 5 third-instar, and 4 larval with no instar stated), 2 are pupal and
+170 are adult (134 brain, 9 ventral nerve cord, 6 leg, head and thorax, and 21 full CNS or
+whole body). None are stage-agnostic. The newest larval datasets by publication year are
+the split-GAL4 lines of Meissner et al. (`SplitMeissner2024`, L3, 2024) and, for
+connectomics, the L1 CNS reconstruction of Winding, Pedigo et al. (`WindingPedigo2023`,
+2023).
+
+| Stage | Datasets |
+|---|---|
+| Embryo | 2 |
+| Larva — L1 (first instar) | 27 |
+| Larva — L3 (third instar) | 5 |
+| Larva — instar not stated | 4 |
+| Pupa | 2 |
+| Adult | 170 |
+
+**How this was built.** VFB does not currently record a structured "stage" field on
+dataset entities — this table was compiled by hand from each dataset's name, description
+and publication, cross-checked against a more reliable structured signal where one
+exists: which [template](/docs/data/templates/) a dataset's images are registered to.
+Registration is stage-specific — the L1 CNS template (`Seymour`, VFB\_00050000) only ever
+receives first-instar larval images, the L3 CNS template (`Wood2018`, VFB\_00049000) only
+third-instar images — so a dataset's `AlignedDatasets` membership on those templates is
+firmer evidence than its name. That check changed three classifications from the first,
+label-only pass: the `TrumanWood2018`/`TrumanWood2018public` Truman Larval Flip-Out
+Collection and `SplitMeissner2024` are all registered to the L3 template rather than an
+unspecified larval stage or, in Meissner's case, no stage at all. This is a documentation
+convenience, not a data-model change — nothing here is queryable from the API. A dataset
+missing from a future data release, or one whose stage was misjudged, should be corrected
+here directly; if VFB's data model gains a real structured stage field later, this page
+should be regenerated from it instead of maintained by hand.
 
 ## Embryo
 
@@ -35,7 +77,8 @@ VFB holds no embryonic imaging data at this time.
 
 The larval period runs from hatching to pupariation and is divided into three instars —
 L1, L2 and L3 — separated by moults. VFB's larval holdings cluster almost entirely at the
-first and third instars; no dataset here is recorded as L2. Anatomy differs enough
+first and third instars; no dataset here is recorded as L2. VFB holds 36 larval datasets
+in all: 27 at L1, 5 at L3 and 4 with no instar stated. Anatomy differs enough
 between instars that a "larval" dataset with no instar stated should not be assumed
 comparable to one that states it, particularly for connectomic data.
 
@@ -81,8 +124,9 @@ template.
 
 The last and largest larval instar, imaged shortly before pupariation. VFB's L3 material
 is registered to the Wood2018 L3 CNS template and includes the Truman Larval Flip-Out
-Collection (`TrumanWood2018`, published 2018) — currently the newest of VFB's larval
-datasets by publication year.
+Collection (`TrumanWood2018`, published 2018) and the split-GAL4 lines of Meissner et al.
+(`SplitMeissner2024`, published 2024) — currently the newest of VFB's larval datasets by
+publication year.
 
 | Dataset | Short form |
 |---|---|
@@ -91,6 +135,20 @@ datasets by publication year.
 | [Split-GAL4 lines from Meissner et al., 2024](https://virtualflybrain.org/reports/SplitMeissner2024) | `SplitMeissner2024` |
 | [Truman Larval Flip-Out Collection](https://virtualflybrain.org/reports/TrumanWood2018) | `TrumanWood2018` |
 | [Truman Larval Flip-Out Collection](https://virtualflybrain.org/reports/TrumanWood2018public) | `TrumanWood2018public` |
+
+### Larva (instar not stated)
+
+Larval by name, publication or genetic targeting, but without enough evidence in VFB to
+assign a specific instar — none of these are registered to either larval template, most
+likely because they are driver-line metadata without their own aligned images. Treat the
+instar as unknown rather than assuming L1 or L3.
+
+| Dataset | Short form |
+|---|---|
+| [MCFO images of GMR-GAL4 lines from Jovanic et al., 2019](https://virtualflybrain.org/reports/Gen1MCFOJovanic2019) | `Gen1MCFOJovanic2019` |
+| [Single-cell RNA-seq study of larval optic lobes](https://flybase.org/reports/FBlc0006404) | `FBlc0006404` |
+| [Split-GAL4 lines from Jovanic et al., 2019](https://virtualflybrain.org/reports/SplitJovanic2019) | `SplitJovanic2019` |
+| [Split-GAL4 lines from Takagi et al., 2017](https://virtualflybrain.org/reports/SplitTakagi2017) | `SplitTakagi2017` |
 
 ## Pupa
 

--- a/content/en/docs/Data/stages.md
+++ b/content/en/docs/Data/stages.md
@@ -17,17 +17,15 @@ instars, pupates, and emerges as an adult -- the whole cycle takes about 10 days
 CC BY 3.0, via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Drosophila_melanogaster_life_cycle.jpg).
 
 VFB's datasets are documented by [technique](/docs/data/em/) and by
-[source](/docs/data/lm/) elsewhere on this site, but nothing groups them by the stage of
-the animal they came from. That gap has come up in practice: it is why a question like
-*"how many larval datasets does VFB hold, and which is newest?"* has no direct answer on
-the site today, and can only be approximated by searching dataset names for the word
-"larval" — a search that misses anything not named that way, and catches nothing at all
-for embryo or pupal material.
+[source](/docs/data/lm/) elsewhere on this site; this page groups them by the
+developmental stage of the animal they came from, so a question like *"how many larval
+datasets does VFB hold, and which is newest?"* has one place to look. Stage labels are
+now being added to dataset entities in the knowledge base itself, so the grouping below
+will also become queryable through the API and the VFB chat as that release propagates.
 
-This page is that missing reference. It lists all 210 dataset entities currently in the
-VFB knowledge base (`DataSet` individuals — the same list `search_terms` returns when
-filtered to `dataset`), grouped by developmental stage, with a link to each dataset's own
-page where a stage-agnostic reader would want to jump straight to the data.
+The page lists all 210 dataset entities currently in the VFB knowledge base (`DataSet`
+individuals — the same list `search_terms` returns when filtered to `dataset`), grouped
+by developmental stage, with a link to each dataset's own page.
 
 **At a glance.** Of the 210 dataset entities, 2 are embryonic, 36 are larval
 (27 first-instar, 5 third-instar, and 4 larval with no instar stated), 2 are pupal and
@@ -46,21 +44,20 @@ connectomics, the L1 CNS reconstruction of Winding, Pedigo et al. (`WindingPedig
 | Pupa | 2 |
 | Adult | 170 |
 
-**How this was built.** VFB does not currently record a structured "stage" field on
-dataset entities — this table was compiled by hand from each dataset's name, description
-and publication, cross-checked against a more reliable structured signal where one
-exists: which [template](/docs/data/templates/) a dataset's images are registered to.
-Registration is stage-specific — the L1 CNS template (`Seymour`, VFB\_00050000) only ever
-receives first-instar larval images, the L3 CNS template (`Wood2018`, VFB\_00049000) only
+**How this was built.** This table was compiled from each dataset's name, description
+and publication, cross-checked against a structured signal where one exists: which
+[template](/docs/data/templates/) a dataset's images are registered to. Registration is
+stage-specific — the L1 CNS template (`Seymour`, VFB\_00050000) only ever receives
+first-instar larval images, the L3 CNS template (`Wood2018`, VFB\_00049000) only
 third-instar images — so a dataset's `AlignedDatasets` membership on those templates is
 firmer evidence than its name. That check changed three classifications from the first,
 label-only pass: the `TrumanWood2018`/`TrumanWood2018public` Truman Larval Flip-Out
 Collection and `SplitMeissner2024` are all registered to the L3 template rather than an
-unspecified larval stage or, in Meissner's case, no stage at all. This is a documentation
-convenience, not a data-model change — nothing here is queryable from the API. A dataset
-missing from a future data release, or one whose stage was misjudged, should be corrected
-here directly; if VFB's data model gains a real structured stage field later, this page
-should be regenerated from it instead of maintained by hand.
+unspecified larval stage or, in Meissner's case, no stage at all. Stage labels are being
+added to the dataset entities themselves in the current data release; once those are
+through, this page should be regenerated from them rather than maintained by hand. Until
+then, a dataset missing from a future release, or one whose stage was misjudged, should
+be corrected here directly.
 
 ## Embryo
 

--- a/content/en/docs/Data/stages.md
+++ b/content/en/docs/Data/stages.md
@@ -44,21 +44,6 @@ connectomics, the L1 CNS reconstruction of Winding, Pedigo et al. (`WindingPedig
 | Pupa | 2 |
 | Adult | 170 |
 
-**How this was built.** This table was compiled from each dataset's name, description
-and publication, cross-checked against a structured signal where one exists: which
-[template](/docs/data/templates/) a dataset's images are registered to. Registration is
-stage-specific — the L1 CNS template (`Seymour`, VFB\_00050000) only ever receives
-first-instar larval images, the L3 CNS template (`Wood2018`, VFB\_00049000) only
-third-instar images — so a dataset's `AlignedDatasets` membership on those templates is
-firmer evidence than its name. That check changed three classifications from the first,
-label-only pass: the `TrumanWood2018`/`TrumanWood2018public` Truman Larval Flip-Out
-Collection and `SplitMeissner2024` are all registered to the L3 template rather than an
-unspecified larval stage or, in Meissner's case, no stage at all. Stage labels are being
-added to the dataset entities themselves in the current data release; once those are
-through, this page should be regenerated from them rather than maintained by hand. Until
-then, a dataset missing from a future release, or one whose stage was misjudged, should
-be corrected here directly.
-
 ## Embryo
 
 Approximately 0–22 hours after egg laying, from fertilisation to hatching. The two

--- a/themes/vfb-nova/assets/js/app.js
+++ b/themes/vfb-nova/assets/js/app.js
@@ -185,6 +185,9 @@
     if (wordHit(t, q)) return 2;
     if (t.includes(q)) return 3;                                  /* mid-word only */
     if ((d.section || '').toLowerCase().includes(q)) return 4;
+    /* Front-matter keywords: the words a reader searches by that the title
+       does not carry. Ranked with the section, above the description. */
+    if ((d.keywords || []).some((k) => String(k).toLowerCase().includes(q))) return 4;
     if ((d.desc || '').toLowerCase().includes(q)) return 5;
     if ((d.body || '').toLowerCase().includes(q)) return 7;
     return 99;

--- a/themes/vfb-nova/assets/js/app.js
+++ b/themes/vfb-nova/assets/js/app.js
@@ -183,11 +183,15 @@
     if (t === q) return 0;
     if (t.startsWith(q)) return 1;
     if (wordHit(t, q)) return 2;
+    /* Front-matter keywords: the words a reader searches by that the title
+       does not carry. A word hit on a curated keyword ranks with a word hit
+       on the title, because that is what it is for — and because results
+       are laid out as strong page hits, then anatomy terms, then weak page
+       hits: a page that matches "larval" only in its body sits under the
+       eight-term block, which is where the datasets-by-stage page was. */
+    if ((d.keywords || []).some((k) => wordHit(String(k).toLowerCase(), q))) return 2;
     if (t.includes(q)) return 3;                                  /* mid-word only */
     if ((d.section || '').toLowerCase().includes(q)) return 4;
-    /* Front-matter keywords: the words a reader searches by that the title
-       does not carry. Ranked with the section, above the description. */
-    if ((d.keywords || []).some((k) => String(k).toLowerCase().includes(q))) return 4;
     if ((d.desc || '').toLowerCase().includes(q)) return 5;
     if ((d.body || '').toLowerCase().includes(q)) return 7;
     return 99;

--- a/themes/vfb-nova/layouts/_default/index.json
+++ b/themes/vfb-nova/layouts/_default/index.json
@@ -7,7 +7,14 @@
      belong in the 3D browser's search, not in a JSON file the visitor
      downloads.
 
-     Add a section name here to make it searchable. */ -}}
+     Add a section name here to make it searchable.
+
+     "keywords" is the page's front-matter keywords list, for the words a
+     reader will search by that its title does not carry ("larval" for the
+     datasets-by-stage page). .Plain and .Description come out of Goldmark
+     with typographic entities (&rsquo;) still encoded and jsonify then
+     escapes the ampersand, so the palette showed "VFB&amp;rsquo;s";
+     htmlUnescape first. */ -}}
 {{- $roots := slice "/docs" "/about" "/hosted" "/blog/news" "/blog/releases" -}}
 {{- $pinned := slice "/docs/" "/docs/overview/" "/docs/tutorials/" "/docs/apis/" "/hosted/" "/blog/news/" "/about/whatisvfb/" "/about/citeus/" -}}
 {{- $out := slice -}}
@@ -16,20 +23,23 @@
   {{- with site.GetPage . -}}
     {{- $out = $out | append (dict
         "title" .LinkTitle "url" .RelPermalink "section" .Section
-        "desc" (.Description | plainify | truncate 120 | chomp)
+        "desc" (.Description | plainify | htmlUnescape | truncate 120 | chomp)
+        "keywords" (.Params.keywords | default slice)
         "body" "" "pinned" (in $pinned .RelPermalink)) -}}
     {{- range .Sections -}}
       {{- $out = $out | append (dict
           "title" .LinkTitle "url" .RelPermalink "section" .Section
-          "desc" (.Description | plainify | truncate 120 | chomp)
+          "desc" (.Description | plainify | htmlUnescape | truncate 120 | chomp)
+          "keywords" (.Params.keywords | default slice)
           "body" "" "pinned" (in $pinned .RelPermalink)) -}}
     {{- end -}}
     {{- range .RegularPagesRecursive -}}
       {{- if not .Params.content -}}
         {{- $out = $out | append (dict
             "title" .LinkTitle "url" .RelPermalink "section" .Section
-            "desc" (.Description | default (.Summary | plainify) | truncate 120 | chomp)
-            "body" (.Plain | truncate 900 | chomp)
+            "desc" (.Description | default (.Summary | plainify) | htmlUnescape | truncate 120 | chomp)
+            "keywords" (.Params.keywords | default slice)
+            "body" (.Plain | htmlUnescape | truncate 900 | chomp)
             "pinned" (in $pinned .RelPermalink)) -}}
       {{- end -}}
     {{- end -}}

--- a/themes/vfb-nova/layouts/_default/search.html
+++ b/themes/vfb-nova/layouts/_default/search.html
@@ -22,7 +22,7 @@
     </header>
 
     <div id="search-page"
-         data-index="{{ "/index.json" | relURL }}"
+         data-index="{{ "/index.json" | relURL }}?v={{ now.Format "20060102150405" }}"
          data-solr="https://solr.virtualflybrain.org/solr/ontology/select"
          data-browser="{{ $browser }}">
 

--- a/themes/vfb-nova/layouts/partials/palette.html
+++ b/themes/vfb-nova/layouts/partials/palette.html
@@ -4,10 +4,9 @@
 {{- $browser := index (split .Site.Params.app_url "?") 0 -}}
 {{/* The index URL carries the build time as a query string. The site is served
      with a year-long immutable Cache-Control on every path, index.json
-     included, so a visitor who had searched once kept the index of that day
-     for a year and never saw a page published after it — the datasets-by-stage
-     page was invisible to "larval" for anyone who had used search before it
-     existed. A new URL per build side-steps the cached one. */}}
+     included, so a visitor's browser may keep the index of the day it was
+     first fetched and not see pages published since. A new URL per build
+     side-steps the cached one. */}}
 <div class="palette" hidden role="dialog" aria-modal="true" aria-label="Search"
      data-index="{{ "/index.json" | relURL }}?v={{ now.Format "20060102150405" }}"
      data-solr="https://solr.virtualflybrain.org/solr/ontology/select"

--- a/themes/vfb-nova/layouts/partials/palette.html
+++ b/themes/vfb-nova/layouts/partials/palette.html
@@ -2,8 +2,14 @@
      generated, not authored. They come from the same SOLR ontology core the 3D
      browser uses, queried live, and open in the browser rather than on this site. */}}
 {{- $browser := index (split .Site.Params.app_url "?") 0 -}}
+{{/* The index URL carries the build time as a query string. The site is served
+     with a year-long immutable Cache-Control on every path, index.json
+     included, so a visitor who had searched once kept the index of that day
+     for a year and never saw a page published after it — the datasets-by-stage
+     page was invisible to "larval" for anyone who had used search before it
+     existed. A new URL per build side-steps the cached one. */}}
 <div class="palette" hidden role="dialog" aria-modal="true" aria-label="Search"
-     data-index="{{ "/index.json" | relURL }}"
+     data-index="{{ "/index.json" | relURL }}?v={{ now.Format "20060102150405" }}"
      data-solr="https://solr.virtualflybrain.org/solr/ontology/select"
      data-browser="{{ $browser }}">
   <div class="palette__box">


### PR DESCRIPTION
Searching the site for "larval" did not show `/docs/data/stages/`, while "stage" did. The palette lays results out as strong page hits (title matches), then the anatomy terms from Solr, then weak page hits — and "larval" matched the page only in its body, so it sat under the eight-term block. The page now carries front-matter `keywords`, the index exports them, and a word hit on a keyword ranks with a word hit on the title, so "larval", "larva", "pupa", "embryo" and "L1" all put the page in the strong group.

Separately, every path is served with a year-long immutable `Cache-Control`, `index.json` included, so a browser can hold a stale index; the index URL now carries the build time as a query string (`/index.json?v=<build>`). The header itself is set by the serving nginx, not this repo. The description names the stages, and an "at a glance" block states the counts — 2 embryonic, 36 larval (27 L1, 5 L3, 4 unstated), 2 pupal, 170 adult — so a reader, or VFBchat, can quote a number rather than count 210 rows. The L3 note calling TrumanWood2018 (2018) the newest larval dataset was stale against the SplitMeissner2024 row in the same table; both are named now.

Goldmark leaves typographic entities encoded in `.Plain`/`.Description` and `jsonify` then escapes the ampersand, so the index carried `VFB&amp;rsquo;s`; they are unescaped first.

Note: this carries the working copy's text of the page (the "how this was built" note and the "instar not stated" section — what the deployed site shows) on top of the life-cycle diagram master added; master did not have that text.

Built locally with Hugo 0.164.0: `index.json` has the keywords and decoded text, both search pages carry the stamped URL.
