### PR TITLE
Update latest-release badge to v26.09.02

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "VFB Latest"
-linkTitle: "Latest (Release: v4 2026.06.22)"
+linkTitle: "Latest (Release: v26.09.02)"
 menu:
   main:
     weight: 30


### PR DESCRIPTION
The nav badge in `content/en/blog/_index.md` still read "v4 2026.06.22" after the v26.09.02 / v2026-09-01 data release. Bumps it to match the current Docker-VFB-Neo4j-ProductionDB tag.
