### PR TITLE
Add news article for Wellcome's fruit fly connectome video with Greg Jefferis

### DIFF
--- a/content/en/blog/news/wellcome_fruit_fly_brain_video.md
+++ b/content/en/blog/news/wellcome_fruit_fly_brain_video.md
@@ -1,0 +1,21 @@
+---
+title: "Video: Inside the fruit fly brain, and what it might mean for human health"
+linkTitle: "Wellcome video with Greg Jefferis"
+date: 2025-05-15
+description: >
+    A Wellcome Guest Lecture with Greg Jefferis on why his team mapped the fruit fly brain's connectome using AI, and what connectomes could mean for understanding human health.
+---
+
+Wellcome, the biomedical research funder, has published a recording of a Wellcome Guest Lecture given by Greg Jefferis, neuroscientist and Joint Head of the Division of Neurobiology at the MRC Laboratory of Molecular Biology, and a Principal Investigator on Virtual Fly Brain. Jefferis led one of the teams behind the project that reconstructed a full connectome — a complete map of every neuron and its connections — of the fruit fly *Drosophila melanogaster*'s brain, using artificial intelligence to help do it at scale.
+
+{{< youtube id="-x0WAkQgOJk" autoplay="true" >}}
+
+Jefferis opens by making the case for the fly: the human brain has around 86–100 billion neurons and the mouse brain roughly a thousandfold fewer, but the fly brain has only around 100,000–139,000 — a "countable number" that nonetheless supports a rich repertoire of behaviour, illustrated with high-speed footage of a fly evading an oncoming swat. He then traces the history of connectomics back to Sydney Brenner's effort at the LMB in the 1970s to map the 302-neuron nervous system of the nematode worm *C. elegans* by hand from electron microscope sections, a project not repeated at any larger scale for the next 20 years.
+
+He explains how modern electron microscopy and AI-assisted segmentation made it possible to reconstruct a whole fly brain: automated tracing still leaves errors that needed roughly 3 million manual edits (about 30 person-years of proofreading) to fix, after which every neuron was labelled and grouped into around 8,000 cell types, and validated by comparing them against an earlier partial connectome from Janelia. Using the mushroom body memory circuit as a worked example, he shows how tracing wiring — including, with a Janelia collaborator's help, whether individual connections are excitatory or inhibitory — let his team read out how a fly converts a learned association into a steering decision.
+
+Current work covers a full male brain-and-nerve-cord connectome, comparisons between male and female brains that reveal sexually dimorphic circuits behind courtship and male-male aggression, and a project extending the approach to the mosquito *Aedes aegypti* to understand how it locates human targets. Looking ahead, Jefferis discusses the cost and technical hurdles of scaling connectomics to mouse and eventually human brains — proofreading, not imaging, being the main bottleneck — and what a reference human connectome could mean for understanding brain disease.
+
+The connectome discussed is integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Inside the fruit fly brain and what it might mean for human health, with Greg Jefferis"](https://www.youtube.com/watch?v=-x0WAkQgOJk), © Wellcome.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` embedding and summarising Wellcome's Guest Lecture video with Greg Jefferis on the fly brain connectome project.

- Dated 2025-05-15 to match the video's original YouTube publish date
- Summarises the talk (fly vs. mouse vs. human neuron counts, the C. elegans/Sydney Brenner origin of connectomics, AI-assisted reconstruction and proofreading, the mushroom body learning-circuit example, sexually dimorphic circuits, the mosquito extension, and future scaling) based on the actual video transcript
- Notes the connectome's integration into VFB alongside our other connectomics resources