### PR TITLE
Fix NeuroFly 2026 YouTube ID and video-embed clipping across the site

### DIFF
--- a/content/en/about/geppetto.md
+++ b/content/en/about/geppetto.md
@@ -13,7 +13,7 @@ cascade:
 
 [Geppetto](https://geppetto.org) is an open source project that VFB is an active developer of in partnership with [MetaCell](https://www.metacell.us/)
 
-{{< youtube id="OmwXCGPBhNo" autoplay="true" >}}
+{{< youtube id="OmwXCGPBhNo" autoplay="true" mute="true" class="video-embed" >}}
 
 For full details on the project see [Geppetto.org](https://geppetto.org)
 

--- a/content/en/blog/news/neurofly2026.md
+++ b/content/en/blog/news/neurofly2026.md
@@ -56,4 +56,4 @@ So you can easily spot us if you have any questions:
 </div>
 
 
-{{< youtube id="LP0B2THlWoJJNk5w" autoplay="true" >}}
+{{< youtube id="XJGzoSSihaI" autoplay="true" mute="true" class="video-embed" >}}

--- a/content/en/blog/news/wellcome_fruit_fly_brain_video.md
+++ b/content/en/blog/news/wellcome_fruit_fly_brain_video.md
@@ -8,7 +8,7 @@ description: >
 
 Wellcome, the biomedical research funder, has published a recording of a Wellcome Guest Lecture given by Greg Jefferis, neuroscientist and Joint Head of the Division of Neurobiology at the MRC Laboratory of Molecular Biology, and a Principal Investigator on Virtual Fly Brain. Jefferis led one of the teams behind the project that reconstructed a full connectome — a complete map of every neuron and its connections — of the fruit fly *Drosophila melanogaster*'s brain, using artificial intelligence to help do it at scale.
 
-{{< youtube id="-x0WAkQgOJk" autoplay="true" >}}
+{{< youtube id="-x0WAkQgOJk" autoplay="true" mute="true" class="video-embed" >}}
 
 Jefferis opens by making the case for the fly: the human brain has around 86–100 billion neurons and the mouse brain roughly a thousandfold fewer, but the fly brain has only around 100,000–139,000 — a "countable number" that nonetheless supports a rich repertoire of behaviour, illustrated with high-speed footage of a fly evading an oncoming swat. He then traces the history of connectomics back to Sydney Brenner's effort at the LMB in the 1970s to map the 302-neuron nervous system of the nematode worm *C. elegans* by hand from electron microscope sections, a project not repeated at any larger scale for the next 20 years.
 

--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -41,7 +41,7 @@ it, whatever that study happened to call it.
 
 ## A tour of the site
 
-{{< youtube id="z2Cre6avnpk" >}}
+{{< youtube id="z2Cre6avnpk" class="video-embed" >}}
 
 The walkthrough above covers the main interface. Note that it predates some later changes to the
 site, so a few details will differ from what you see now.

--- a/content/en/docs/Resources/_index.md
+++ b/content/en/docs/Resources/_index.md
@@ -30,7 +30,7 @@ Connectome explorer provided by Janelia Research Campus. Hosts the hemibrain, MA
 ### [CATMAID](https://catmaid.org)
 The Collaborative Annotation Toolkit for Massive Amounts of Image Data (CATMAID) is a web companion to the TrakEM2 software (Cardona, 2006) for management, registration and analysis of large-scale ssTEM datasets.
 
-{{< youtube id="CZpaTCuSQao" autoplay="true" title="A video introduction to catmaid software for connectomics from lead developer Tom Kazimiers hosted by the NEUBIAS Academy" >}}
+{{< youtube id="CZpaTCuSQao" autoplay="true" mute="true" class="video-embed" title="A video introduction to catmaid software for connectomics from lead developer Tom Kazimiers hosted by the NEUBIAS Academy" >}}
 
 [CATMAID documentation](https://catmaid.readthedocs.io/en/stable/)
 

--- a/content/en/docs/past workshops/Connectome/introVideo.md
+++ b/content/en/docs/past workshops/Connectome/introVideo.md
@@ -11,4 +11,4 @@ description: >
   Introduction session from the Virtual Fly Brain "Hacking the connectome" workshop that was run in collaboration with the Drosophila Connectomics Group based at the Dept of Zoology, University of Cambridge.
 ---
 
-{{< youtube id="FfhAgQLxx0Q" autoplay="true" >}}
+{{< youtube id="FfhAgQLxx0Q" autoplay="true" mute="true" class="video-embed" >}}


### PR DESCRIPTION
The NeuroFly 2026 post's `{{< youtube >}}` embed had a malformed id (`LP0B2THlWoJJNk5w`, 16 chars — not a valid 11-char YouTube ID), so nothing played. Corrected to `XJGzoSSihaI`.

Every `{{< youtube >}}` embed on the site was clipped at the bottom (captions/controls cut off) because the shortcode's default markup conflicts with `prose.css`'s generic `.prose iframe` margin rule. `prose.css` already ships a `.video-embed` class built to avoid exactly this, just never wired up — added `class="video-embed"` to all six embeds site-wide.

Added `mute="true"` explicitly to the autoplaying embeds.

**Note:** the live site's current rendered output for these embeds is just `?autoplay=1` — missing all the other querystring params (`controls`/`end`/`loop`/`mute`/`start`) that a local build against the pinned Hugo v0.164.0 produces. Worth checking after this deploys whether `mute=1` actually shows up in the rendered `src` — if not, the live builder may not be running v0.164.0.

## Test plan
- [ ] Confirm the NeuroFly 2026 post plays the correct video
- [ ] Confirm none of the six embeds clip captions/controls at the bottom
- [ ] Confirm autoplaying embeds are muted (check rendered iframe src for `mute=1`)
