### PR TITLE
Add news article for HHMI Janelia's male CNS connectome video

### DIFF
--- a/content/en/blog/news/janelia_male_cns_connectome_video.md
+++ b/content/en/blog/news/janelia_male_cns_connectome_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: The male fly CNS connectome, visualised"
+linkTitle: "HHMI Janelia male CNS connectome video"
+date: 2026-09-03
+description: >
+    A silent HHMI Janelia visualisation of the complete male fly central nervous system connectome, produced to illustrate comparisons between male and female brains.
+---
+
+HHMI's Janelia Research Campus has released a short visualisation of the complete male fly central nervous system (CNS) connectome. The data was acquired and analysed by the FlyEM Project Team at Janelia, the Cambridge Connectomics Group, and Google Research; the video itself was produced by Philip Hubbard of Janelia. It has no narration or audio — the connectome speaks for itself.
+
+{{< youtube id="XqrmATUvHac" autoplay="true" >}}
+
+As Janelia's description puts it, having a complete male CNS connectome alongside the existing female one lets researchers directly compare male and female brains and wiring, and start to understand the circuit basis of complex social behaviours — such as mating and aggression — that differ between the sexes.
+
+This male CNS connectome is among the datasets integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Male Fly Brain Connectome"](https://youtu.be/XqrmATUvHac), © HHMI Janelia Research Campus.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI Janelia's silent visualisation of the complete male fly CNS connectome.

- Dated 2026-09-03 to match the video's original YouTube publish date
- Notes the FlyEM Project Team (Janelia), Cambridge Connectomics Group, and Google Research as the data credits, and Philip Hubbard (Janelia) as the video's producer
- Explains the male/female brain comparison motivation from Janelia's own description
- Notes the connectome's integration into VFB alongside our other connectomics resources