### PR TITLE
Add news article for HHMI's giant fiber escape-behaviour video

### DIFF
--- a/content/en/blog/news/janelia_giant_fiber_escape_video.md
+++ b/content/en/blog/news/janelia_giant_fiber_escape_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: How the fly brain chooses between two escape takeoffs"
+linkTitle: "HHMI Janelia giant fiber escape video"
+date: 2017-09-06
+description: >
+    An HHMI video on research from the Card lab at Janelia showing how a fly's giant fiber descending neurons integrate looming visual features to choose between a long and a short escape takeoff.
+---
+
+HHMI has released a video summarising research from the Card lab at Janelia Research Campus on how the brain of *Drosophila melanogaster* recombines separately processed visual features to choose an escape manoeuvre. The fly brain detects features of the visual world — shape, orientation, colour, motion — in parallel, but that information must then be recombined to guide behaviour; this study asks how that recombination determines which of two escape takeoffs a fly performs when a predator looms into view.
+
+{{< youtube id="ucF3ofIBj-I" autoplay="true" >}}
+
+A fly's long takeoff — extending its wings before jumping and beginning to flap — is more stable, while its short takeoff is a bare jump with folded wings that leaves the fly tumbling and needing to right itself in the air; both happen faster than an eye blink. Earlier work from the same lab had shown that a short takeoff occurs when a single pair of large descending neurons, the giant fibers, fire before the other descending neurons that drive a long takeoff. Here, the authors recorded giant fiber activity intracellularly while presenting looming stimuli that simulate an approaching predator, and used genetic tools to silence candidate feature-encoding neurons.
+
+Rather than a single type of looming-sensitive neuron feeding the giant fibers, they found two: one encoding the looming stimulus's angular velocity, and another encoding its angular size. Their model is that these two signals are summed in the giant fibers — a slow-looming predator mostly drives the size-encoding channel, which excites the giant fibers but not always to spiking threshold, favouring a long takeoff; a fast-looming predator drives both channels together, pushing the giant fibers over threshold earlier and biasing the fly towards the faster, short takeoff.
+
+Video: ["Combining Visual Features to Guide an Escape"](https://www.youtube.com/watch?v=ucF3ofIBj-I), © Howard Hughes Medical Institute (HHMI).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI's video on Card lab (Janelia) research into how giant fiber descending neurons drive fly escape takeoff choice.

- Dated 2017-09-06 to match the video's original YouTube publish date
- Summarises the paper's finding: looming angular velocity and angular size are encoded by separate neurons whose signals sum in the giant fibers to bias long vs. short takeoff
- Credits HHMI as producer