### PR TITLE
Add news article for HHMI's optic lobe motion-circuit video

### DIFF
--- a/content/en/blog/news/hhmi_optic_lobe_motion_circuit_video.md
+++ b/content/en/blog/news/hhmi_optic_lobe_motion_circuit_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: A motion-detection circuit in the fly eye and optic lobe"
+linkTitle: "HHMI optic lobe motion circuit video"
+date: 2025-03-01
+description: >
+    A silent HHMI visualisation picking out a simple neural circuit for motion detection and hazard evasion among the dense mass of neurons in the fruit fly eye and optic lobe.
+---
+
+HHMI has released a short, silent visualisation that picks a single, simple neural circuit out of the dense mass of neurons in the fruit fly eye and optic lobe — the part of the brain that processes visual information — described by HHMI as like finding a needle in a haystack. The neurons shown form a basic circuit involved in motion detection and hazard evasion.
+
+{{< youtube id="cyWdrbK3di4" autoplay="true" >}}
+
+By first showing the surrounding sea of optic lobe neurons and then isolating the connections that make up this one circuit, the video illustrates how a specific, tractable pathway for detecting motion can be picked out of the eye and optic lobe's much larger, densely wired neuropil — the kind of circuit that lets a fly detect and respond to an approaching hazard.
+
+This kind of optic lobe connectivity is among the data integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Fly Neural Circuit"](https://www.youtube.com/watch?v=cyWdrbK3di4), © Howard Hughes Medical Institute (HHMI).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI's silent visualisation of a motion-detection/hazard-evasion circuit in the fly eye and optic lobe.

- Dated 2025-03-01 to match the video's original YouTube publish date
- Describes the video's needle-in-a-haystack framing of isolating one circuit from the surrounding optic lobe neuropil
- Credits HHMI as producer