### PR TITLE
Add news article for HHMI's VNC confocal-mapping video

### DIFF
--- a/content/en/blog/news/hhmi_vnc_confocal_map_video.md
+++ b/content/en/blog/news/hhmi_vnc_confocal_map_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: Piecing together a confocal map of the fly ventral nerve cord"
+linkTitle: "HHMI VNC confocal map video"
+date: 2025-06-23
+description: >
+    A silent HHMI video showing confocal microscopy images of fruit fly neurons combined, piece by piece, into a rough map of the ventral nerve cord — the insect equivalent of a spinal cord.
+---
+
+HHMI has released a short, silent video showing confocal microscopy images of fruit fly neurons, captured and combined by researchers at Janelia Research Campus, being pieced together like a puzzle to build a rough map of the ventral nerve cord (VNC) — the insect equivalent of a spinal cord, which coordinates walking, flying and reflexes.
+
+{{< youtube id="8nZTq0fJUFc" autoplay="true" >}}
+
+Each individually imaged neuron is dazzling on its own; the video's point is how, layered together, these confocal images start to reveal the overall structure and organisation of the VNC as a coordinating hub for locomotion and reflex behaviour, complementing the electron-microscopy-based VNC connectomes.
+
+This kind of ventral nerve cord data is among the resources integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Piecing Together the Fly Nerve Cord"](https://www.youtube.com/watch?v=8nZTq0fJUFc), © Howard Hughes Medical Institute (HHMI).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI's silent video of Janelia confocal microscopy images of fly neurons being pieced together into a rough map of the ventral nerve cord (VNC).

- Dated 2025-06-23 to match the video's original YouTube publish date
- Explains the VNC's role as the insect equivalent of a spinal cord, coordinating walking, flying and reflex
- Credits HHMI/Janelia Research Campus