### PR TITLE
Add news article for HHMI Janelia's full male CNS connectome video

### DIFF
--- a/content/en/blog/news/janelia_full_male_cns_connectome_video.md
+++ b/content/en/blog/news/janelia_full_male_cns_connectome_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: The first complete map of a male fly's entire central nervous system"
+linkTitle: "HHMI Janelia full male CNS connectome video"
+date: 2026-09-03
+description: >
+    A silent HHMI Janelia visualisation of the newly completed male fly connectome — the first map of an entire central nervous system, covering the brain, both optic lobes, and the ventral nerve cord.
+---
+
+HHMI's Janelia Research Campus has released a short visualisation marking the completion of the male fly central nervous system (CNS) connectome — the first map of an entire insect CNS, comprising every neuron in the brain, both optic lobes, and the ventral nerve cord. The data was acquired and analysed by the FlyEM Project Team at Janelia, the Cambridge Connectomics Group, and Google Research; the video was produced by Philip Hubbard of Janelia. As with Janelia's related release on comparing male and female brains, this video carries no narration or audio.
+
+{{< youtube id="jeh9czULwH0" autoplay="true" >}}
+
+Where earlier connectomes covered the brain or the ventral nerve cord separately, this dataset connects the two together with the optic lobes into a single, complete wiring diagram of the male fly's entire nervous system — from sensory input in the eyes, through central brain processing, down to the motor circuits in the nerve cord that drive behaviour.
+
+This full male CNS connectome is among the datasets integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Complete Male Fly Central Nervous System Connectome"](https://www.youtube.com/watch?v=jeh9czULwH0), © HHMI Janelia Research Campus.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI Janelia's video announcing the first complete map of an entire male fly CNS.

- Dated 2026-09-03 to match the video's original YouTube publish date
- Notes this connectome covers the brain, both optic lobes, and the ventral nerve cord together — distinct from the companion male/female-comparison video covered in a previous article
- Notes the FlyEM Project Team (Janelia), Cambridge Connectomics Group, and Google Research as data credits, and Philip Hubbard (Janelia) as the video's producer