### PR TITLE
Add news article for HHMI's full adult fly brain EM video

### DIFF
--- a/content/en/blog/news/janelia_full_adult_fly_brain_em_video.md
+++ b/content/en/blog/news/janelia_full_adult_fly_brain_em_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: The first complete EM images of an adult fly brain"
+linkTitle: "HHMI Janelia full adult fly brain EM video"
+date: 2018-07-19
+description: >
+    An HHMI video on Janelia's first nanoscale, whole-brain electron microscopy dataset of the adult fruit fly brain — the imaging effort behind the FAFB dataset.
+---
+
+HHMI has released a video on work from Janelia Research Campus in which scientists used high-speed transmission electron microscopy to image the entire brain of an adult female fruit fly at nanoscale resolution — the first time this had been done for a whole adult fly brain.
+
+{{< youtube id="-s8QUpx_Zo4" autoplay="true" >}}
+
+The fly brain, about the size of a poppy seed and containing roughly 100,000 neurons, was imaged across more than 7,000 thin tissue slices, producing 212 million individual images that were captured and stitched together into a single volume. The resulting dataset lets researchers trace the path of any one neuron to any other throughout the whole brain. Davi Bock's team, who led the imaging effort, had already used the dataset to discover a new brain-spanning neuron in a memory centre of the brain, and at the time of release more than 20 lab groups were using the freely available dataset to trace neurons and map connections.
+
+This dataset — since widely known as FAFB, the Full Adult Fly Brain EM volume — underpins much of the connectomics data now integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Complete Fly Brain Imaged at Nanoscale Resolution"](https://www.youtube.com/watch?v=-s8QUpx_Zo4), © Howard Hughes Medical Institute (HHMI). See also Janelia's [news article](https://www.janelia.org/news/complete-fly-brain-imaged-at-nanoscale-resolution).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI's video on Janelia's first complete nanoscale EM imaging of an adult fly brain (the FAFB dataset).

- Dated 2018-07-19 to match the video's original YouTube publish date
- Summarises the imaging effort: 7,000+ slices, 212 million images stitched together, and Davi Bock's team's early brain-spanning neuron discovery
- Links to Janelia's own news article alongside the video
- Credits HHMI/Janelia Research Campus