### PR TITLE
Add news article for HHMI's fly connectomics history video

### DIFF
--- a/content/en/blog/news/janelia_connectomics_history_video.md
+++ b/content/en/blog/news/janelia_connectomics_history_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: The history of fruit fly connectomics at Janelia"
+linkTitle: "HHMI Janelia connectomics history video"
+date: 2026-09-03
+description: >
+    An HHMI video tracing the nearly 20-year story behind Janelia's complete fruit fly connectome, from the 2008 project launch through FIB-SEM imaging, machine-learning-assisted tracing, and the 2025 completion.
+---
+
+HHMI has released "The History of Fruit Fly Connectomics at Janelia," a video tracing the almost 20-year effort by Janelia Research Campus scientists to build a complete wiring diagram — a connectome — of the fruit fly *Drosophila*'s brain and ventral nerve cord.
+
+{{< youtube id="2uMQG5LHWwc" autoplay="true" >}}
+
+The project began in 2008, when the fly's more than 100,000 neurons made it hundreds of times larger than any organism previously mapped at this level of detail. Getting there required nearly a decade of work refining Focused Ion Beam Scanning Electron Microscopy (FIB-SEM) to sustain the continuous, long-term imaging a specimen this size demands, followed by machine-learning-based methods, developed in collaboration with Google, to automate tracing of individual neurons through the resulting data. Along the way, the team published the "Hemibrain" ("Henry") partial brain volume in 2020, before completing and annotating the full connectome of the entire fly brain and ventral nerve cord in 2025.
+
+These datasets — and the connectomics pipeline behind them — underpin much of the connectivity data now integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["The History of Fruit Fly Connectomics at Janelia"](https://www.youtube.com/watch?v=2uMQG5LHWwc), © Howard Hughes Medical Institute (HHMI). See also HHMI's [full story](https://www.hhmi.org/news/scientists-complete-full-map-fruit-fly-brain-connectome).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for HHMI's retrospective video on the ~20-year Janelia fly connectome project.

- Dated 2026-09-03 to match the video's original YouTube publish date
- Covers the 2008 project start, the FIB-SEM imaging development, ML-assisted tracing with Google, the 2020 Hemibrain volume, and 2025 full completion, per HHMI's own transcript/summary
- Links to HHMI's full news story alongside the video
- Credits HHMI/Janelia Research Campus