### PR TITLE
Add news article for the FlyWire connectome render video

### DIFF
--- a/content/en/blog/news/flywire_connectome_render_video.md
+++ b/content/en/blog/news/flywire_connectome_render_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: The FlyWire connectome"
+linkTitle: "FlyWire Princeton connectome render video"
+date: 2024-10-02
+description: >
+    A silent visualisation from FlyWire Princeton of the whole adult fly brain connectome, marking the publication of the FlyWire Consortium's Nature 2024 papers.
+---
+
+FlyWire Princeton has released a silent visualisation, "The FlyWire Connectome," rendering the neuron-by-neuron, synapse-by-synapse wiring diagram of the adult fruit fly brain built by the FlyWire Consortium, to mark the publication of its flagship paper and a suite of related papers in a special issue of *Nature* in October 2024.
+
+{{< youtube id="J2xTkMsZchs" autoplay="true" >}}
+
+FlyWire is a Princeton-led effort, comprising members from more than 146 labs across 122 institutions, with major contributions from teams at the University of Cambridge and the University of Vermont; Sebastian Seung and Mala Murthy of the Princeton Neuroscience Institute are co-senior authors on the flagship paper. Where earlier connectomes covered the 302-neuron *C. elegans* and the roughly 3,000-neuron larval fly brain, this dataset maps the adult fly brain's nearly 140,000 neurons and tens of millions of synapses — orders of magnitude more complex, and, at the time, the only full brain connectome for an adult animal of this scale. As Seung put it, "any brain that we truly understand tells us something about all brains."
+
+This FlyWire connectome is integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["The FlyWire Connectome"](https://www.youtube.com/watch?v=J2xTkMsZchs), render by Tyler Sloan, edited by Amy Sterling, © FlyWire Princeton. Score: "Clear Skies" by Scott Buckley (CC-BY 4.0). See also [Princeton's news article](https://www.princeton.edu/news/2024/10/02/mapping-entire-fly-brain-step-toward-understanding-diseases-human-brain) and the [Nature paper](https://www.nature.com/articles/s41586-024-07558-y).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for FlyWire Princeton's visualisation of the adult fly brain connectome.

- Dated 2024-10-02 to match the video's premiere date, coinciding with the FlyWire Consortium's Nature 2024 papers
- Notes the consortium's scale (146 labs, 122 institutions), Seung/Murthy as co-senior authors, and the ~140,000-neuron/tens-of-millions-of-synapse scale of the dataset
- Credits render/edit/score attributions from the video description and links to Princeton's news article and the Nature paper