### PR TITLE
Add news article for the BANC connectome tour video

### DIFF
--- a/content/en/blog/news/banc_connectome_tour_video.md
+++ b/content/en/blog/news/banc_connectome_tour_video.md
@@ -3,7 +3,7 @@ title: "Video: A tour of the brain and nerve cord connectome (BANC)"
 linkTitle: "BANC connectome tour video"
 date: 2026-07-01
 description: >
-    A narrated tour of BANC, the most extensive fly connectome to date, showing how sensory-motor circuits linking the brain and ventral nerve cord coordinate behaviour across the whole central nervous system.
+    A two-part narrated tour of BANC, the most extensive fly connectome to date, showing how sensory-motor circuits linking the brain and ventral nerve cord coordinate behaviour across the whole central nervous system.
 ---
 
 FlyWire Princeton has released a narrated tour of the brain and nerve cord connectome, BANC — described as the most extensive connectome produced to date — exploring what it reveals about the organisation of sensory-motor circuits across a whole central nervous system. The video was made by Tyler Sloan of Quorumetrix Studio and narrated by Alexander S. Bates, accompanying the connectome's description in Bates, Phelps, Him, Yang et al., *Nature*, 2026.
@@ -14,4 +14,8 @@ BANC connects a full brain reconstruction (central brain and optic lobes) to a v
 
 BANC is among the connectomes integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively. The project involved a large international collaboration, including the University of Edinburgh, and can be browsed directly at [codex.flywire.ai](https://codex.flywire.ai/?dataset=banc).
 
-Video: ["BANC: A Tour of the Brain and Nerve Cord Connectome"](https://www.youtube.com/watch?v=k-HQA3eoEgQ), by Tyler Sloan (Quorumetrix Studio), narrated by Alexander S. Bates, © FlyWire Princeton. Paper: [Bates, Phelps, Him, Yang et al., Nature (2026)](https://rdcu.be/fncjS). Data: [doi.org/10.7910/DVN/7WTH1N](https://doi.org/10.7910/DVN/7WTH1N).
+**Part 2** continues the tour with a concrete example of these long-range circuits at work: when a fly senses adverse vibration — picked up via Johnston's organ neurons in the antenna — a threat-response descending neuron activates motor neurons that make the fly brace, while a second neuron simultaneously inhibits DNg100 to stop it walking, together producing a "stop and brace" reaction. The team used this same approach, tracing neck-spanning neurons and embedding them in connectivity space with UMAP, to demarcate large groups of neurons they believe organise many different behaviour classes by combining and recombining low-level sensory-motor modules through higher-order, long-range projections. They liken the resulting picture to subsumption architecture, an influential idea from autonomous robotics, and suggest the fly nervous system is organised along similar lines.
+
+{{< youtube id="TBCcwWMRcww" autoplay="true" >}}
+
+Video 1: ["BANC: A Tour of the Brain and Nerve Cord Connectome"](https://www.youtube.com/watch?v=k-HQA3eoEgQ). Video 2: [Part 2](https://www.youtube.com/watch?v=TBCcwWMRcww). Both by Tyler Sloan (Quorumetrix Studio), narrated by Alexander S. Bates, © FlyWire Princeton. Paper: [Bates, Phelps, Him, Yang et al., Nature (2026)](https://rdcu.be/fncjS). Data: [doi.org/10.7910/DVN/7WTH1N](https://doi.org/10.7910/DVN/7WTH1N).

--- a/content/en/blog/news/banc_connectome_tour_video.md
+++ b/content/en/blog/news/banc_connectome_tour_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: A tour of the brain and nerve cord connectome (BANC)"
+linkTitle: "BANC connectome tour video"
+date: 2026-07-01
+description: >
+    A narrated tour of BANC, the most extensive fly connectome to date, showing how sensory-motor circuits linking the brain and ventral nerve cord coordinate behaviour across the whole central nervous system.
+---
+
+FlyWire Princeton has released a narrated tour of the brain and nerve cord connectome, BANC — described as the most extensive connectome produced to date — exploring what it reveals about the organisation of sensory-motor circuits across a whole central nervous system. The video was made by Tyler Sloan of Quorumetrix Studio and narrated by Alexander S. Bates, accompanying the connectome's description in Bates, Phelps, Him, Yang et al., *Nature*, 2026.
+
+{{< youtube id="k-HQA3eoEgQ" autoplay="true" >}}
+
+BANC connects a full brain reconstruction (central brain and optic lobes) to a ventral nerve cord reconstruction — the insect analogue of the mammalian spinal cord — via the neurons that carry information between the two. Within the nerve cord, the tour highlights repeated sensory-motor control loops for individual body parts, such as the leg circuits linking sensory input, intrinsic interneurons and motor output, and then shows how long-range neck-spanning neurons, such as the walking command neuron DNg100, coordinate these separate local loops into a single, unified behaviour.
+
+BANC is among the connectomes integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively. The project involved a large international collaboration, including the University of Edinburgh, and can be browsed directly at [codex.flywire.ai](https://codex.flywire.ai/?dataset=banc).
+
+Video: ["BANC: A Tour of the Brain and Nerve Cord Connectome"](https://www.youtube.com/watch?v=k-HQA3eoEgQ), by Tyler Sloan (Quorumetrix Studio), narrated by Alexander S. Bates, © FlyWire Princeton. Paper: [Bates, Phelps, Him, Yang et al., Nature (2026)](https://rdcu.be/fncjS). Data: [doi.org/10.7910/DVN/7WTH1N](https://doi.org/10.7910/DVN/7WTH1N).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for FlyWire Princeton's narrated tour of BANC, the brain and nerve cord connectome.

- Dated 2026-07-01 to match the video's premiere date
- Summarises the tour's content: brain/VNC connection, leg sensory-motor loops, and long-range coordinating neurons like DNg100, drawn from the actual video transcript
- Notes VFB's own integration of BANC and links to the Nature paper, dataset DOI, and codex.flywire.ai browser
- Credits Tyler Sloan/Quorumetrix Studio and narrator Alexander S. Bates