### PR TITLE
Add news article advertising the VFB self-led online workshop

### DIFF
--- a/content/en/blog/news/self_led_workshop_launch.md
+++ b/content/en/blog/news/self_led_workshop_launch.md
@@ -1,0 +1,17 @@
+---
+title: "VFB Self-led Learning Sessions: a free online workshop, open to everyone"
+linkTitle: "Self-led workshop launch"
+date: 2026-09-06
+description: >
+    Our self-led online workshop, originally built for NeuroFly 2026, is a free set of sessions on finding, connecting and examining neurons across all the connectomes on VFB — open to anyone, any time.
+---
+
+{{< youtube id="XJGzoSSihaI" autoplay="true" >}}
+
+We built the [VFB Self-led Learning Sessions](https://workshop.virtualflybrain.org) for NeuroFly 2026, but they were never meant for conference attendees only — they're a free, self-paced online workshop open to anyone who wants to learn to work with Drosophila connectomics and related data on Virtual Fly Brain.
+
+The workshop is a set of seven sessions covering how to find, connect and examine neurons across all the connectomes available on VFB, alongside imaging and transcriptomic data. We designed it as a self-led, online resource rather than a single in-person session specifically to remove space constraints and open it up to anyone, whether or not they could attend NeuroFly in person. Work through it in your own time, at your own pace, whenever suits you.
+
+There are multiple routes through the material — Python, R, a chat interface, our [MCP tool](/docs/tutorials/vfb-mcp-guide/), or the 3D browser — with little to no setup required. Sessions are designed to be worked through in order, and once you've finished, you can apply what you've learned to your own neurons, regions and genes.
+
+Start the workshop at [workshop.virtualflybrain.org](https://workshop.virtualflybrain.org).


### PR DESCRIPTION
Adds a news article, dated today, promoting the VFB Self-led Learning Sessions at workshop.virtualflybrain.org.

- Video placed above the text as requested
- Frames the workshop as originally built for NeuroFly 2026 but open to everyone, any time, self-paced
- Summarises the seven sessions and the available routes through them (Python, R, chat, MCP tool, 3D browser)