### PR TITLE
Add news article for the Cardona lab larval brain eFIB-SEM video

### DIFF
--- a/content/en/blog/news/cardona_larval_brain_efib_sem_video.md
+++ b/content/en/blog/news/cardona_larval_brain_efib_sem_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: A fly-through of an eFIB-SEM larval brain volume"
+linkTitle: "Cardona lab eFIB-SEM larval brain video"
+date: 2026-05-07
+description: >
+    A brief fly-through of an enhanced FIB-SEM volume of the fruit fly larval brain, imaged at 8x8x8 nanometre resolution in Albert Cardona's lab at the MRC LMB.
+---
+
+Professor Albert Cardona has released a short, silent fly-through of an enhanced FIB-SEM (eFIB-SEM) volume of the fruit fly larval brain, acquired in his lab at the MRC Laboratory of Molecular Biology. The volume was imaged at 8x8x8 nanometre resolution.
+
+{{< youtube id="p4MH4-I-P5I" autoplay="true" >}}
+
+This isotropic, nanometre-scale resolution is the level of detail needed to trace synaptic connections between neurons throughout a volume, the basis for reconstructing connectomes such as the existing larval brain connectome already available on VFB.
+
+Larval connectomics data of this kind is among the resources integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["eFIB-SEM volume of a fruit fly larval brain"](https://www.youtube.com/watch?v=p4MH4-I-P5I), © Prof. Albert Cardona, MRC Laboratory of Molecular Biology.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for Prof. Albert Cardona's fly-through of an eFIB-SEM larval brain volume.

- Dated 2026-05-07 to match the video's original YouTube publish date
- Notes the 8x8x8nm imaging resolution and the MRC LMB as the source lab
- Credits Prof. Albert Cardona