### PR TITLE
Add news article for Cardona's 'The Brain: What For?' seminar video

### DIFF
--- a/content/en/blog/news/cardona_brain_what_for_seminar_video.md
+++ b/content/en/blog/news/cardona_brain_what_for_seminar_video.md
@@ -1,0 +1,21 @@
+---
+title: "Video: \"The Brain: What For?\" — Albert Cardona's seminar for non-scientists"
+linkTitle: "Cardona \"Brain: What For?\" seminar video"
+date: 2024-01-17
+description: >
+    Albert Cardona's MRC LMB seminar for non-scientists, using the Drosophila larva to ask what a brain actually contributes when so much behaviour turns out not to need one.
+---
+
+The MRC Laboratory of Molecular Biology has published a recording of "The Brain: What For?", a seminar for non-scientists given by Professor Albert Cardona as part of the Cambridge Biomedical Campus's virtual tour series. Cardona, a program leader at the LMB working on fly connectomics within the Medical Research Council's Molecular Connectomics initiative, asks a deceptively simple question: what does a brain actually contribute to an animal's life, given how much behaviour turns out not to depend on one at all?
+
+{{< youtube id="mcZwH5MYkFU" autoplay="true" >}}
+
+Cardona builds his case around the *Drosophila* larva, a roughly 3,000-neuron brain sitting atop a nerve cord that, on its own, already produces most of the animal's basic repertoire — crawling, turning, exploring, avoiding harmful temperatures. Using the GAL4/GAL80 genetic toolkit to silence neural activity in the brain lobes specifically while leaving the nerve cord untouched, his lab showed that a larva with its brain switched off still crawls, turns and explores in a way indistinguishable from a normal animal. It is only when the animal is given a task with a goal — finding the source of an attractive odour gradient — that the difference shows: brain-inactivated larvae wander normally but completely fail to track the gradient, while intact controls climb steadily towards it.
+
+He connects this to modelling work from Barbara Webb's group in Edinburgh, in which a larva built from nothing but springs, a motor neuron, a stretch receptor and one inhibitory connection to the neighbouring segment reproduces realistic peristaltic crawling and exploration with no brain at all — illustrating how much of the work is done by the body and nerve cord's own biomechanics and local circuitry, with the brain issuing only coarse, high-level commands. He illustrates this "command neuron" idea with the moonwalker neuron pair, which triggers backward crawling in the larva and, unchanged, backward walking in the adult fly, regardless of whether the body plan has legs or not.
+
+Cardona then turns to how his lab reconstructs these circuits from electron microscopy: densely imaging an entire nervous system volume, tracing individual neurons and their synapses (originally 13 years of work, now achievable in around two months), and — because each neuron is individually identifiable and stereotyped across animals — building genetic driver lines that target single, named neurons for further experiments. Mapping the larva's full set of descending neurons this way let his team predict, from wiring alone, which neurons drive forward crawling, backward crawling, turning and head movements, simply from where along the nerve cord their synapses concentrate — before running a single behavioural experiment.
+
+He closes by connecting this fundamental work back to human health: roughly 60% of the fly genome is shared with humans, including much of the machinery for how neurons connect and circuits integrate different senses, so understanding these basic organisational principles in a tractable system informs how researchers think about circuits we cannot yet map directly, such as the human brain.
+
+Video: ["The Brain: What For? — Albert Cardona — Seminar for Non-Scientists"](https://www.youtube.com/watch?v=mcZwH5MYkFU), © MRC Laboratory of Molecular Biology.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for Albert Cardona's MRC LMB seminar-for-non-scientists.

- Dated 2024-01-17 to match the video's original YouTube publish date
- Summarises the actual talk: brain-silenced larvae crawling normally but failing at goal-directed odour tracking, the Webb-lab (Edinburgh) brainless biomechanical crawling model, the moonwalker command neuron, EM-based descending neuron mapping, and the human-health rationale, drawn from the video transcript
- Credits MRC Laboratory of Molecular Biology