### PR TITLE
Fix video clipping on recently added news articles' YouTube embeds

### DIFF
--- a/content/en/blog/news/banc_connectome_tour_video.md
+++ b/content/en/blog/news/banc_connectome_tour_video.md
@@ -8,7 +8,7 @@ description: >
 
 FlyWire Princeton has released a narrated tour of the brain and nerve cord connectome, BANC — described as the most extensive connectome produced to date — exploring what it reveals about the organisation of sensory-motor circuits across a whole central nervous system. The video was made by Tyler Sloan of Quorumetrix Studio and narrated by Alexander S. Bates, accompanying the connectome's description in Bates, Phelps, Him, Yang et al., *Nature*, 2026.
 
-{{< youtube id="k-HQA3eoEgQ" autoplay="true" >}}
+{{< youtube id="k-HQA3eoEgQ" autoplay="true" mute="true" class="video-embed" >}}
 
 BANC connects a full brain reconstruction (central brain and optic lobes) to a ventral nerve cord reconstruction — the insect analogue of the mammalian spinal cord — via the neurons that carry information between the two. Within the nerve cord, the tour highlights repeated sensory-motor control loops for individual body parts, such as the leg circuits linking sensory input, intrinsic interneurons and motor output, and then shows how long-range neck-spanning neurons, such as the walking command neuron DNg100, coordinate these separate local loops into a single, unified behaviour.
 
@@ -16,6 +16,6 @@ BANC is among the connectomes integrated into Virtual Fly Brain alongside our ot
 
 **Part 2** continues the tour with a concrete example of these long-range circuits at work: when a fly senses adverse vibration — picked up via Johnston's organ neurons in the antenna — a threat-response descending neuron activates motor neurons that make the fly brace, while a second neuron simultaneously inhibits DNg100 to stop it walking, together producing a "stop and brace" reaction. The team used this same approach, tracing neck-spanning neurons and embedding them in connectivity space with UMAP, to demarcate large groups of neurons they believe organise many different behaviour classes by combining and recombining low-level sensory-motor modules through higher-order, long-range projections. They liken the resulting picture to subsumption architecture, an influential idea from autonomous robotics, and suggest the fly nervous system is organised along similar lines.
 
-{{< youtube id="TBCcwWMRcww" autoplay="true" >}}
+{{< youtube id="TBCcwWMRcww" autoplay="true" mute="true" class="video-embed" >}}
 
 Video 1: ["BANC: A Tour of the Brain and Nerve Cord Connectome"](https://www.youtube.com/watch?v=k-HQA3eoEgQ). Video 2: [Part 2](https://www.youtube.com/watch?v=TBCcwWMRcww). Both by Tyler Sloan (Quorumetrix Studio), narrated by Alexander S. Bates, © FlyWire Princeton. Paper: [Bates, Phelps, Him, Yang et al., Nature (2026)](https://rdcu.be/fncjS). Data: [doi.org/10.7910/DVN/7WTH1N](https://doi.org/10.7910/DVN/7WTH1N).

--- a/content/en/blog/news/cardona_brain_what_for_seminar_video.md
+++ b/content/en/blog/news/cardona_brain_what_for_seminar_video.md
@@ -8,7 +8,7 @@ description: >
 
 The MRC Laboratory of Molecular Biology has published a recording of "The Brain: What For?", a seminar for non-scientists given by Professor Albert Cardona as part of the Cambridge Biomedical Campus's virtual tour series. Cardona, a program leader at the LMB working on fly connectomics within the Medical Research Council's Molecular Connectomics initiative, asks a deceptively simple question: what does a brain actually contribute to an animal's life, given how much behaviour turns out not to depend on one at all?
 
-{{< youtube id="mcZwH5MYkFU" autoplay="true" >}}
+{{< youtube id="mcZwH5MYkFU" autoplay="true" mute="true" class="video-embed" >}}
 
 Cardona builds his case around the *Drosophila* larva, a roughly 3,000-neuron brain sitting atop a nerve cord that, on its own, already produces most of the animal's basic repertoire — crawling, turning, exploring, avoiding harmful temperatures. Using the GAL4/GAL80 genetic toolkit to silence neural activity in the brain lobes specifically while leaving the nerve cord untouched, his lab showed that a larva with its brain switched off still crawls, turns and explores in a way indistinguishable from a normal animal. It is only when the animal is given a task with a goal — finding the source of an attractive odour gradient — that the difference shows: brain-inactivated larvae wander normally but completely fail to track the gradient, while intact controls climb steadily towards it.
 

--- a/content/en/blog/news/cardona_larval_brain_efib_sem_video.md
+++ b/content/en/blog/news/cardona_larval_brain_efib_sem_video.md
@@ -8,7 +8,7 @@ description: >
 
 Professor Albert Cardona has released a short, silent fly-through of an enhanced FIB-SEM (eFIB-SEM) volume of the fruit fly larval brain, acquired in his lab at the MRC Laboratory of Molecular Biology. The volume was imaged at 8x8x8 nanometre resolution.
 
-{{< youtube id="p4MH4-I-P5I" autoplay="true" >}}
+{{< youtube id="p4MH4-I-P5I" autoplay="true" mute="true" class="video-embed" >}}
 
 This isotropic, nanometre-scale resolution is the level of detail needed to trace synaptic connections between neurons throughout a volume, the basis for reconstructing connectomes such as the existing larval brain connectome already available on VFB.
 

--- a/content/en/blog/news/flywire_connectome_render_video.md
+++ b/content/en/blog/news/flywire_connectome_render_video.md
@@ -8,7 +8,7 @@ description: >
 
 FlyWire Princeton has released a silent visualisation, "The FlyWire Connectome," rendering the neuron-by-neuron, synapse-by-synapse wiring diagram of the adult fruit fly brain built by the FlyWire Consortium, to mark the publication of its flagship paper and a suite of related papers in a special issue of *Nature* in October 2024.
 
-{{< youtube id="J2xTkMsZchs" autoplay="true" >}}
+{{< youtube id="J2xTkMsZchs" autoplay="true" mute="true" class="video-embed" >}}
 
 FlyWire is a Princeton-led effort, comprising members from more than 146 labs across 122 institutions, with major contributions from teams at the University of Cambridge and the University of Vermont; Sebastian Seung and Mala Murthy of the Princeton Neuroscience Institute are co-senior authors on the flagship paper. Where earlier connectomes covered the 302-neuron *C. elegans* and the roughly 3,000-neuron larval fly brain, this dataset maps the adult fly brain's nearly 140,000 neurons and tens of millions of synapses — orders of magnitude more complex, and, at the time, the only full brain connectome for an adult animal of this scale. As Seung put it, "any brain that we truly understand tells us something about all brains."
 

--- a/content/en/blog/news/hhmi_optic_lobe_motion_circuit_video.md
+++ b/content/en/blog/news/hhmi_optic_lobe_motion_circuit_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI has released a short, silent visualisation that picks a single, simple neural circuit out of the dense mass of neurons in the fruit fly eye and optic lobe — the part of the brain that processes visual information — described by HHMI as like finding a needle in a haystack. The neurons shown form a basic circuit involved in motion detection and hazard evasion.
 
-{{< youtube id="cyWdrbK3di4" autoplay="true" >}}
+{{< youtube id="cyWdrbK3di4" autoplay="true" mute="true" class="video-embed" >}}
 
 By first showing the surrounding sea of optic lobe neurons and then isolating the connections that make up this one circuit, the video illustrates how a specific, tractable pathway for detecting motion can be picked out of the eye and optic lobe's much larger, densely wired neuropil — the kind of circuit that lets a fly detect and respond to an approaching hazard.
 

--- a/content/en/blog/news/hhmi_vnc_confocal_map_video.md
+++ b/content/en/blog/news/hhmi_vnc_confocal_map_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI has released a short, silent video showing confocal microscopy images of fruit fly neurons, captured and combined by researchers at Janelia Research Campus, being pieced together like a puzzle to build a rough map of the ventral nerve cord (VNC) — the insect equivalent of a spinal cord, which coordinates walking, flying and reflexes.
 
-{{< youtube id="8nZTq0fJUFc" autoplay="true" >}}
+{{< youtube id="8nZTq0fJUFc" autoplay="true" mute="true" class="video-embed" >}}
 
 Each individually imaged neuron is dazzling on its own; the video's point is how, layered together, these confocal images start to reveal the overall structure and organisation of the VNC as a coordinating hub for locomotion and reflex behaviour, complementing the electron-microscopy-based VNC connectomes.
 

--- a/content/en/blog/news/janelia_connectomics_history_video.md
+++ b/content/en/blog/news/janelia_connectomics_history_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI has released "The History of Fruit Fly Connectomics at Janelia," a video tracing the almost 20-year effort by Janelia Research Campus scientists to build a complete wiring diagram — a connectome — of the fruit fly *Drosophila*'s brain and ventral nerve cord.
 
-{{< youtube id="2uMQG5LHWwc" autoplay="true" >}}
+{{< youtube id="2uMQG5LHWwc" autoplay="true" mute="true" class="video-embed" >}}
 
 The project began in 2008, when the fly's more than 100,000 neurons made it hundreds of times larger than any organism previously mapped at this level of detail. Getting there required nearly a decade of work refining Focused Ion Beam Scanning Electron Microscopy (FIB-SEM) to sustain the continuous, long-term imaging a specimen this size demands, followed by machine-learning-based methods, developed in collaboration with Google, to automate tracing of individual neurons through the resulting data. Along the way, the team published the "Hemibrain" ("Henry") partial brain volume in 2020, before completing and annotating the full connectome of the entire fly brain and ventral nerve cord in 2025.
 

--- a/content/en/blog/news/janelia_full_adult_fly_brain_em_video.md
+++ b/content/en/blog/news/janelia_full_adult_fly_brain_em_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI has released a video on work from Janelia Research Campus in which scientists used high-speed transmission electron microscopy to image the entire brain of an adult female fruit fly at nanoscale resolution — the first time this had been done for a whole adult fly brain.
 
-{{< youtube id="-s8QUpx_Zo4" autoplay="true" >}}
+{{< youtube id="-s8QUpx_Zo4" autoplay="true" mute="true" class="video-embed" >}}
 
 The fly brain, about the size of a poppy seed and containing roughly 100,000 neurons, was imaged across more than 7,000 thin tissue slices, producing 212 million individual images that were captured and stitched together into a single volume. The resulting dataset lets researchers trace the path of any one neuron to any other throughout the whole brain. Davi Bock's team, who led the imaging effort, had already used the dataset to discover a new brain-spanning neuron in a memory centre of the brain, and at the time of release more than 20 lab groups were using the freely available dataset to trace neurons and map connections.
 

--- a/content/en/blog/news/janelia_full_male_cns_connectome_video.md
+++ b/content/en/blog/news/janelia_full_male_cns_connectome_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI's Janelia Research Campus has released a short visualisation marking the completion of the male fly central nervous system (CNS) connectome — the first map of an entire insect CNS, comprising every neuron in the brain, both optic lobes, and the ventral nerve cord. The data was acquired and analysed by the FlyEM Project Team at Janelia, the Cambridge Connectomics Group, and Google Research; the video was produced by Philip Hubbard of Janelia. As with Janelia's related release on comparing male and female brains, this video carries no narration or audio.
 
-{{< youtube id="jeh9czULwH0" autoplay="true" >}}
+{{< youtube id="jeh9czULwH0" autoplay="true" mute="true" class="video-embed" >}}
 
 Where earlier connectomes covered the brain or the ventral nerve cord separately, this dataset connects the two together with the optic lobes into a single, complete wiring diagram of the male fly's entire nervous system — from sensory input in the eyes, through central brain processing, down to the motor circuits in the nerve cord that drive behaviour.
 

--- a/content/en/blog/news/janelia_giant_fiber_escape_video.md
+++ b/content/en/blog/news/janelia_giant_fiber_escape_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI has released a video summarising research from the Card lab at Janelia Research Campus on how the brain of *Drosophila melanogaster* recombines separately processed visual features to choose an escape manoeuvre. The fly brain detects features of the visual world — shape, orientation, colour, motion — in parallel, but that information must then be recombined to guide behaviour; this study asks how that recombination determines which of two escape takeoffs a fly performs when a predator looms into view.
 
-{{< youtube id="ucF3ofIBj-I" autoplay="true" >}}
+{{< youtube id="ucF3ofIBj-I" autoplay="true" mute="true" class="video-embed" >}}
 
 A fly's long takeoff — extending its wings before jumping and beginning to flap — is more stable, while its short takeoff is a bare jump with folded wings that leaves the fly tumbling and needing to right itself in the air; both happen faster than an eye blink. Earlier work from the same lab had shown that a short takeoff occurs when a single pair of large descending neurons, the giant fibers, fire before the other descending neurons that drive a long takeoff. Here, the authors recorded giant fiber activity intracellularly while presenting looming stimuli that simulate an approaching predator, and used genetic tools to silence candidate feature-encoding neurons.
 

--- a/content/en/blog/news/janelia_male_cns_connectome_video.md
+++ b/content/en/blog/news/janelia_male_cns_connectome_video.md
@@ -8,7 +8,7 @@ description: >
 
 HHMI's Janelia Research Campus has released a short visualisation of the complete male fly central nervous system (CNS) connectome. The data was acquired and analysed by the FlyEM Project Team at Janelia, the Cambridge Connectomics Group, and Google Research; the video itself was produced by Philip Hubbard of Janelia. It has no narration or audio — the connectome speaks for itself.
 
-{{< youtube id="XqrmATUvHac" autoplay="true" >}}
+{{< youtube id="XqrmATUvHac" autoplay="true" mute="true" class="video-embed" >}}
 
 As Janelia's description puts it, having a complete male CNS connectome alongside the existing female one lets researchers directly compare male and female brains and wiring, and start to understand the circuit basis of complex social behaviours — such as mating and aggression — that differ between the sexes.
 

--- a/content/en/blog/news/self_led_workshop_launch.md
+++ b/content/en/blog/news/self_led_workshop_launch.md
@@ -6,7 +6,7 @@ description: >
     Our self-led online workshop, originally built for NeuroFly 2026, is a free set of sessions on finding, connecting and examining neurons across all the connectomes on VFB — open to anyone, any time.
 ---
 
-{{< youtube id="XJGzoSSihaI" autoplay="true" >}}
+{{< youtube id="XJGzoSSihaI" autoplay="true" mute="true" class="video-embed" >}}
 
 We built the [VFB Self-led Learning Sessions](https://workshop.virtualflybrain.org) for NeuroFly 2026, but they were never meant for conference attendees only — they're a free, self-paced online workshop open to anyone who wants to learn to work with Drosophila connectomics and related data on Virtual Fly Brain.
 


### PR DESCRIPTION
Fixes the recurring video-clipping bug (see https://virtualflybrain.org/blog/2017/09/06/video-how-the-fly-brain-chooses-between-two-escape-takeoffs/) on the 12 news articles added in the last batch of PRs.

Root cause: those articles' `{{< youtube >}}` calls only passed `id` and `autoplay`, unlike every other video embed on the site (e.g. `neurofly2026.md`, `geppetto.md`), which also pass `mute="true" class="video-embed"`. Without `class="video-embed"`, Hugo's internal shortcode's absolutely-positioned iframe falls through to the generic `.prose iframe` rule instead of the dedicated `.video-embed` rule — and `.prose iframe`'s `margin`/`border` shift the iframe inside its zero-height, `overflow:hidden` wrapper, clipping the bottom of the video.

Fix: add `mute="true" class="video-embed"` to all 12 affected shortcode calls, matching the established site-wide convention. No content changes.