### PR TITLE
Add news article for the Lo lab 'Building a fly brain' video

### DIFF
--- a/content/en/blog/news/lo_lab_building_a_fly_brain_video.md
+++ b/content/en/blog/news/lo_lab_building_a_fly_brain_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: Building a fly brain, neuron by neuron"
+linkTitle: "Lo lab \"Building a fly brain\" video"
+date: 2014-09-11
+description: >
+    A visualisation from the Lo lab at National Tsing Hua University building a fly brain from FlyCircuit data by placing around 18,000 individually reconstructed neurons into position one by one.
+---
+
+The Chung-Chuan Lo laboratory at National Tsing Hua University's Brain Research Center, Taiwan, has produced "Building a fly brain (HD)," a visualisation that assembles a fruit fly brain by placing roughly 18,000 individually reconstructed neurons into their positions one at a time — about 20% of the estimated total neurons in a fly brain. Every neuron shown was constructed from data in the [FlyCircuit database](http://www.flycircuit.tw/), accompanying Chiang et al.'s "Three-Dimensional Reconstruction of Brain-wide Wiring Networks in *Drosophila* at Single-Cell Resolution" (*Current Biology*, 2011).
+
+{{< youtube id="F4lc9cY4fMM" autoplay="true" >}}
+
+Watching individual, single-cell-resolution reconstructions accumulate neuron by neuron into a complete brain gives an intuitive sense of the sheer density and diversity of cell types packed into this tiny structure — long before whole-brain electron microscopy connectomes existed, single-neuron light-level reconstruction projects like FlyCircuit were already mapping the fly brain's morphology at scale.
+
+FlyCircuit's single-neuron reconstructions are among the resources integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Building a fly brain (HD)"](https://www.youtube.com/watch?v=F4lc9cY4fMM), © Chung-Chuan Lo laboratory, National Tsing Hua University. Music: "The Simple Complex" by UncleBibby (CC BY 4.0).


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for the Chung-Chuan Lo laboratory's FlyCircuit-based fly brain visualisation.

- Dated 2014-09-11 to match the video's original YouTube publish date
- Notes the ~18,000 single-neuron FlyCircuit reconstructions and the accompanying Chiang et al. 2011 Current Biology paper
- Credits the Lo lab, National Tsing Hua University Brain Research Center, and the CC-BY music