### PR TITLE
Add news article for the Lo lab fly brain simulation video

### DIFF
--- a/content/en/blog/news/lo_lab_fly_brain_simulation_video.md
+++ b/content/en/blog/news/lo_lab_fly_brain_simulation_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: Simulating a fruit fly brain with FlySim"
+linkTitle: "Lo lab fly brain simulation video"
+date: 2017-04-05
+description: >
+    A simulation of fruit fly brain activity from the Lo lab at National Tsing Hua University, run with their FlySim simulator on circuits and parameters derived from the FlyCircuit database.
+---
+
+The Chung-Chuan Lo laboratory at National Tsing Hua University, Taiwan, has released a video of a fruit fly brain simulation run with FlySim, a simulator developed in the Lo lab. The model's circuits and parameters were derived from data in the [FlyCircuit database](http://www.flycircuit.tw/) — the same single-neuron reconstruction resource behind the lab's earlier "Building a fly brain" visualisation.
+
+{{< youtube id="m8cmKREXpcw" autoplay="true" >}}
+
+Where reconstructing a brain from FlyCircuit data shows its physical structure, this simulation goes a step further, using that structural data to parameterise a running model of brain-wide neural activity — work described in detail in the lab's associated paper in *Frontiers in Neuroinformatics* (2018), [available here](https://www.frontiersin.org/articles/10.3389/fninf.2018.00099/full).
+
+FlyCircuit's single-neuron reconstructions, which underpin this model, are among the resources integrated into Virtual Fly Brain alongside our other connectomics resources, letting anyone query, browse and analyse it interactively.
+
+Video: ["Fruit fly brain simulation"](https://www.youtube.com/watch?v=m8cmKREXpcw), © Chung-Chuan Lo laboratory, National Tsing Hua University.


### PR DESCRIPTION
Adds a backdated news article to `content/en/blog/news/` for the Chung-Chuan Lo laboratory's FlySim fruit fly brain simulation.

- Dated 2017-04-05 to match the video's original YouTube publish date
- Notes FlySim as the simulator, FlyCircuit as the data source for circuits/parameters, and links the 2018 Frontiers in Neuroinformatics paper
- Credits the Lo lab, National Tsing Hua University — companion piece to the earlier 'Building a fly brain' article