### PR TITLE
Add an Installing CMTK page, with a no-root macOS route

### DIFF
--- a/content/en/docs/Concepts/bridging.md
+++ b/content/en/docs/Concepts/bridging.md
@@ -44,7 +44,7 @@ flybrains.report()   # what is actually available, Python and R downloads alike
 
 If you already hold these registrations from the R side, `flybrains` will find and register
 them rather than duplicating the download. Using the Jefferis lab or VFB transforms needs
-[CMTK](https://www.nitrc.org/projects/cmtk/) installed; the FANC and BANC transforms need
+[CMTK](/docs/tutorials/apis/cmtk/) installed; the FANC and BANC transforms need
 [elastix](https://elastix.lumc.nl/index.php).
 
 The package ships metadata and surface meshes for 31 light-level templates and connectome

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -36,7 +36,7 @@ The transformation is found in stages of increasing freedom:
    structures into correspondence.
 
 The non-rigid step is what actually does the work, and it is why registration is expensive
-and imperfect. Two toolkits dominate fly registration. **CMTK** is the more common; the
+and imperfect. Two toolkits dominate fly registration. [**CMTK**](/docs/tutorials/apis/cmtk/) is the more common; the
 paper usually cited for it describes a parallel implementation of non-rigid registration,
 demonstrated on clinical and other biomedical problems rather than on flies
 ([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506)) — it was

--- a/content/en/docs/Tutorials/APIs/cmtk.md
+++ b/content/en/docs/Tutorials/APIs/cmtk.md
@@ -1,0 +1,74 @@
+---
+title: "Installing CMTK"
+weight: 432
+series: ["API"]
+date: 2026-09-09
+description: >
+  The simplest way to get a local copy of CMTK, for using navis-flybrains / nat.flybrains
+  bridging transforms outside VFB, or for registering your own data.
+---
+
+VFB's [registration](/docs/concepts/registration/) and [bridging](/docs/concepts/bridging/)
+pages describe how [**CMTK**](https://www.nitrc.org/projects/cmtk/) is used to align data to
+common template spaces. You do not need a local copy to use VFB itself — registration already
+happened before data was loaded. You need one if you want to run
+[navis-flybrains](https://github.com/navis-org/navis-flybrains) or
+[nat.flybrains](https://natverse.org/nat.flybrains/index.html) transforms yourself, or register
+your own images.
+
+This page covers the least-effort route to a working CMTK for each platform.
+
+## macOS
+
+Download and run the Apple Silicon installer package from the actively-maintained
+[jefferis/cmtk](https://github.com/jefferis/cmtk) mirror (the same one the natverse project
+builds against):
+
+[**cmtk-3.4.0-dev-macos-arm64-gcd.pkg**](https://github.com/jefferis/cmtk/releases/download/natdev-latest/cmtk-3.4.0-dev-macos-arm64-gcd.pkg)
+
+Double-click it and step through the installer. It places the `cmtk` launcher at
+`/usr/local/bin/cmtk` and the individual tools under `/usr/local/lib/cmtk/bin`.
+`/usr/local/bin` is on the default macOS `PATH`, so no further setup is needed — open a new
+Terminal and confirm with:
+
+```sh
+cmtk --version
+```
+
+Intel Macs are not covered by that build. Use the older, contributed
+[`CMTK-3.4.0-contrib-MacOSX.zip`](https://www.nitrc.org/frs/?group_id=212) from NITRC instead,
+or build from source.
+
+## Windows
+
+We recommend [**MADI3D**](https://madi3d.org) ([GitHub](https://github.com/sandorbx/MADI3D)),
+which installs CMTK for you rather than asking you to do it by hand. From its CMTK setup dialog,
+choose **Automatic setup**: it enables WSL if needed, creates its own isolated
+`MADI3D-CMTK` Ubuntu distribution (your existing WSL distributions, if any, are left untouched),
+and installs the `cmtk` package inside it. The same automatic route also works if you are on
+native Ubuntu/Debian Linux.
+
+If you would rather do it by hand: install [WSL](https://learn.microsoft.com/windows/wsl/install)
+(`wsl --install`, from an administrator PowerShell), then inside the Ubuntu shell it opens:
+
+```sh
+sudo apt update && sudo apt install -y cmtk
+```
+
+## Linux
+
+CMTK is packaged for Ubuntu/Debian directly:
+
+```sh
+sudo apt update && sudo apt install -y cmtk
+```
+
+## Verifying the install
+
+Any of the above should leave `cmtk` and the individual tools (`registration`, `warp`, `mat2dof`,
+`dof2mat`, `reformatx`, `describe`, ...) on your `PATH`:
+
+```sh
+cmtk --version
+registration --version
+```

--- a/content/en/docs/Tutorials/APIs/cmtk.md
+++ b/content/en/docs/Tutorials/APIs/cmtk.md
@@ -16,44 +16,65 @@ happened before data was loaded. You need one if you want to run
 [nat.flybrains](https://natverse.org/nat.flybrains/index.html) transforms yourself, or register
 your own images.
 
-This page covers the least-effort route to a working CMTK for each platform.
+## macOS (Apple Silicon)
 
-## macOS
-
-Download and run the Apple Silicon installer package from the actively-maintained
-[jefferis/cmtk](https://github.com/jefferis/cmtk) mirror (the same one the natverse project
-builds against):
-
-[**cmtk-3.4.0-dev-macos-arm64-gcd.pkg**](https://github.com/jefferis/cmtk/releases/download/natdev-latest/cmtk-3.4.0-dev-macos-arm64-gcd.pkg)
-
-Double-click it and step through the installer. It places the `cmtk` launcher at
-`/usr/local/bin/cmtk` and the individual tools under `/usr/local/lib/cmtk/bin`.
-`/usr/local/bin` is on the default macOS `PATH`, so no further setup is needed — open a new
-Terminal and confirm with:
+Paste this into a terminal. It installs CMTK under your home directory, so it needs no
+administrator rights and touches nothing outside its own folder — which matters on managed
+or institutional Macs, where you may have no admin rights at all.
 
 ```sh
-cmtk --version
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${CMTK_PREFIX:-$HOME/.local/opt/cmtk}"
+ARCHIVE="cmtk-3.4.0-dev-macos-arm64-gcd.tar.gz"
+URL="https://github.com/jefferis/cmtk/releases/download/natdev-latest/${ARCHIVE}"
+SHA256="4160852416b6cba9a55c7e7d0497e4d7153262a3a5265cafb39d1bb850649d6c"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+  echo "This installs the Apple Silicon build; you are on $(uname -s)/$(uname -m)." >&2
+  exit 1
+fi
+
+case "$PREFIX" in
+  *" "*) echo "CMTK's launcher cannot handle a space in its path; pick another." >&2; exit 1 ;;
+esac
+
+if [ -e "$PREFIX" ] && [ ! -x "$PREFIX/bin/cmtk" ]; then
+  echo "$PREFIX exists and is not a CMTK install; set CMTK_PREFIX elsewhere." >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading ${ARCHIVE} (about 50 MB)..."
+curl -fSL --progress-bar -o "$tmp/$ARCHIVE" "$URL"
+
+echo "Verifying checksum..."
+echo "${SHA256}  ${tmp}/${ARCHIVE}" | shasum -a 256 -c - >/dev/null
+
+mkdir -p "$tmp/stage"
+tar -xzf "$tmp/$ARCHIVE" -C "$tmp/stage" --strip-components=2
+rm -rf "$PREFIX"; mkdir -p "$(dirname "$PREFIX")"; mv "$tmp/stage" "$PREFIX"
+
+echo "CMTK $("$PREFIX/lib/cmtk/bin/registration" --version) installed in $PREFIX"
+echo "Add it to your PATH with:"
+echo "  echo 'export PATH=\"${PREFIX}/lib/cmtk/bin:${PREFIX}/bin:\$PATH\"' >> ~/.zshrc"
 ```
 
-Intel Macs are not covered by that build. Use the older, contributed
+Then run the `export PATH` line it prints, open a new terminal, and check with
+`registration --version`.
+
+Two things the script is guarding against. It verifies the download against a published
+SHA-256 before unpacking anything, and it refuses to install to a path containing a space:
+CMTK's own launcher expands its tool path unquoted, so it cannot dispatch a tool from, say,
+`~/Library/Application Support/...`. If the checksum check fails, upstream has most likely
+reissued the build — the tag it comes from is a rolling one — so check this page for an
+updated hash rather than skipping the verification.
+
+Intel Macs are not covered by that build. Use the contributed
 [`CMTK-3.4.0-contrib-MacOSX.zip`](https://www.nitrc.org/frs/?group_id=212) from NITRC instead,
 or build from source.
-
-## Windows
-
-We recommend [**MADI3D**](https://madi3d.org) ([GitHub](https://github.com/sandorbx/MADI3D)),
-which installs CMTK for you rather than asking you to do it by hand. From its CMTK setup dialog,
-choose **Automatic setup**: it enables WSL if needed, creates its own isolated
-`MADI3D-CMTK` Ubuntu distribution (your existing WSL distributions, if any, are left untouched),
-and installs the `cmtk` package inside it. The same automatic route also works if you are on
-native Ubuntu/Debian Linux.
-
-If you would rather do it by hand: install [WSL](https://learn.microsoft.com/windows/wsl/install)
-(`wsl --install`, from an administrator PowerShell), then inside the Ubuntu shell it opens:
-
-```sh
-sudo apt update && sudo apt install -y cmtk
-```
 
 ## Linux
 
@@ -63,12 +84,39 @@ CMTK is packaged for Ubuntu/Debian directly:
 sudo apt update && sudo apt install -y cmtk
 ```
 
-## Verifying the install
+If you have no `sudo` on the machine, the macOS approach works in spirit here too: the
+[jefferis/cmtk](https://github.com/jefferis/cmtk/releases/tag/natdev-latest) release also
+publishes an x86_64 Linux tarball you can unpack into your home directory.
 
-Any of the above should leave `cmtk` and the individual tools (`registration`, `warp`, `mat2dof`,
+## Windows
+
+We recommend [**MADI3D**](https://madi3d.org)
+([GitHub](https://github.com/sandorbx/MADI3D)), which installs CMTK for you rather than asking
+you to do it by hand. In its CMTK setup dialog, choose **Automatic setup**: it enables WSL if
+needed, creates its own isolated `MADI3D-CMTK` Ubuntu distribution — your existing WSL
+distributions are left untouched — and installs the `cmtk` package inside it.
+
+To do it by hand instead: install [WSL](https://learn.microsoft.com/windows/wsl/install)
+(`wsl --install`, from an administrator PowerShell), then inside the Ubuntu shell it opens run
+the `apt` command from the Linux section above.
+
+## A note on MADI3D
+
+MADI3D manages its own copy of CMTK rather than using one already on your `PATH`, so installing
+it there does not give you CMTK for navis-flybrains or the natverse, and vice versa. Its
+automatic setup currently covers Windows and native Ubuntu/Debian; macOS support is
+[proposed in PR #38](https://github.com/sandorbx/MADI3D/pull/38). Until that is released, the
+script above is the route on macOS. MADI3D also offers "use an existing CMTK installation",
+which will happily point at the install the script creates.
+
+## Verifying
+
+Any of the above should leave the individual tools (`registration`, `warp`, `mat2dof`,
 `dof2mat`, `reformatx`, `describe`, ...) on your `PATH`:
 
 ```sh
-cmtk --version
 registration --version
 ```
+
+navis-flybrains and the natverse look for those tools rather than the `cmtk` launcher, so it is
+the `lib/cmtk/bin` directory that has to be on `PATH` — which is what the script sets up.


### PR DESCRIPTION
Adds a page covering how to get a local copy of CMTK, and links the two existing places that mention it to it.

Readers need CMTK locally only if they want to run [navis-flybrains](https://github.com/navis-org/navis-flybrains) or [nat.flybrains](https://natverse.org/nat.flybrains/index.html) transforms themselves, or register their own images — not to use VFB. The page says so up front, then covers each platform.

### The macOS route

The obvious advice is the NITRC `.pkg`, which installs to `/usr/local` and therefore needs administrator rights. That is a poor default for a good part of our audience: institutional and managed Macs commonly withhold admin rights, and some withhold the privilege-escalation prompt itself, which leaves those readers with no working route at all.

So the page leads with a paste-and-run script that unpacks the same upstream build into the reader's home directory. No administrator rights, nothing outside its own prefix, the download verified against a published SHA-256 before anything is unpacked, and any prefix containing a space refused — CMTK's own launcher expands its tool path unquoted and cannot dispatch a tool from one. It puts `lib/cmtk/bin` on `PATH`, which is what navis-flybrains and the natverse actually look for.

The script pins a hash from a rolling upstream tag, so it will need re-verifying and updating whenever that build is reissued. The page tells readers to expect that and look here for a new hash, rather than skip the check.

Intel Macs are pointed at the NITRC contributed build, since the upstream release has no x86_64 macOS asset.

### Other platforms

Linux is the packaged `apt` install, with a note that the same unpack-into-home approach works for anyone without `sudo`. Windows recommends MADI3D, which sets up an isolated WSL environment and installs CMTK into it.

There is also a short section on what MADI3D does and does not give you, because the distinction is easy to miss: it manages its own copy of CMTK rather than one on `PATH`, so installing it there does not help navis-flybrains, and vice versa. Its automatic setup covers Windows and Ubuntu/Debian today; macOS support is proposed upstream and linked as proposed rather than shipped.

### Also in this PR

`Concepts/registration.md` and `Concepts/bridging.md` both mention CMTK; the latter linked straight out to NITRC. Both now link to the new page instead.
