### PR TITLE
Add a Tools section with quick starts for the analysis toolchain

### DIFF
--- a/content/en/docs/Concepts/bridging.md
+++ b/content/en/docs/Concepts/bridging.md
@@ -44,7 +44,7 @@ flybrains.report()   # what is actually available, Python and R downloads alike
 
 If you already hold these registrations from the R side, `flybrains` will find and register
 them rather than duplicating the download. Using the Jefferis lab or VFB transforms needs
-[CMTK](/docs/tutorials/apis/cmtk/) installed; the FANC and BANC transforms need
+[CMTK](/docs/tools/cmtk/) installed; the FANC and BANC transforms need
 [elastix](https://elastix.lumc.nl/index.php).
 
 The package ships metadata and surface meshes for 31 light-level templates and connectome

--- a/content/en/docs/Concepts/registration.md
+++ b/content/en/docs/Concepts/registration.md
@@ -36,7 +36,7 @@ The transformation is found in stages of increasing freedom:
    structures into correspondence.
 
 The non-rigid step is what actually does the work, and it is why registration is expensive
-and imperfect. Two toolkits dominate fly registration. [**CMTK**](/docs/tutorials/apis/cmtk/) is the more common; the
+and imperfect. Two toolkits dominate fly registration. [**CMTK**](/docs/tools/cmtk/) is the more common; the
 paper usually cited for it describes a parallel implementation of non-rigid registration,
 demonstrated on clinical and other biomedical problems rather than on flies
 ([Rohlfing and Maurer, 2003](https://doi.org/10.1109/TITB.2003.808506)) — it was

--- a/content/en/docs/Tools/_index.md
+++ b/content/en/docs/Tools/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Tools"
+linkTitle: "Tools"
+weight: 650
+description: >
+  Software you install and run against VFB data — what each tool is for, how to install it,
+  a minimal example, and where its own documentation lives.
+---
+
+The pages here cover the software people most often use with VFB data: clients for getting data
+out, libraries for analysing and plotting neurons, and the registration toolkits that move data
+between template spaces. Each page is a quick start — what the tool is for, how to install it,
+enough code to confirm it works — and then points at the project's own documentation, which is
+always the authoritative source.
+
+Three neighbouring sections cover different things. [VFB APIs](/docs/apis/) documents the
+endpoints VFB itself serves, rather than third-party software that talks to them.
+[Tutorials](/docs/tutorials/) has the worked examples: longer, with real analyses and output.
+[Resources](/docs/resources/) lists external sites and databases to browse rather than install.
+Where a tool has a worked tutorial as well, its page here links to it.
+
+Most of this toolchain is maintained by the wider *Drosophila* connectomics community rather
+than by VFB, and it splits along language lines: [navis](/docs/tools/navis/) and its ecosystem
+in Python, [natverse](/docs/tools/natverse/) in R. The two overlap heavily in what they can do,
+so the practical question is usually which language the rest of your analysis is in.

--- a/content/en/docs/Tools/cmtk.md
+++ b/content/en/docs/Tools/cmtk.md
@@ -1,7 +1,7 @@
 ---
 title: "Installing CMTK"
-weight: 432
-series: ["API"]
+weight: 654
+aliases: ["/docs/tutorials/apis/cmtk/"]
 date: 2026-09-09
 description: >
   The simplest way to get a local copy of CMTK, for using navis-flybrains / nat.flybrains
@@ -118,5 +118,6 @@ Any of the above should leave the individual tools (`registration`, `warp`, `mat
 registration --version
 ```
 
-navis-flybrains and the natverse look for those tools rather than the `cmtk` launcher, so it is
-the `lib/cmtk/bin` directory that has to be on `PATH` — which is what the script sets up.
+[flybrains](/docs/tools/navis-flybrains/) and the [natverse](/docs/tools/natverse/) look for
+those tools rather than the `cmtk` launcher, so it is the `lib/cmtk/bin` directory that has to
+be on `PATH` — which is what the script sets up.

--- a/content/en/docs/Tools/elastix.md
+++ b/content/en/docs/Tools/elastix.md
@@ -1,0 +1,46 @@
+---
+title: "elastix"
+linkTitle: "elastix"
+weight: 659
+description: >
+  The registration toolbox behind the FANC and BANC transforms — what to install, and the
+  detail that catches people out.
+---
+
+Most of the bridging transforms VFB and the Jefferis lab publish are
+[CMTK](/docs/tools/cmtk/) registrations. The FANC and BANC transforms are not: they are
+elastix, so moving data into or out of those spaces needs elastix installed as well.
+
+If you are not working with FANC or BANC, you do not need this.
+
+## What to install
+
+navis looks for a **`transformix` executable** on your `PATH` and uses the elastix `lib`
+directory that sits beside it. It is therefore the precompiled command-line binaries you want,
+from the [elastix releases](https://github.com/SuperElastix/elastix/releases), unpacked
+somewhere on your `PATH`.
+
+The Python package `itk-elastix` and the SimpleElastix bindings are a different interface to
+the same algorithms. They are useful in their own right, but installing them does not give
+navis the `transformix` binary it looks for.
+
+## The library-path catch
+
+elastix needs its own `lib` directory on the dynamic library search path — `LD_LIBRARY_PATH`
+on Linux, `DYLD_LIBRARY_PATH` on macOS — or the binaries fail to start. navis sets this up
+itself when it imports, so transforms run from inside a Python session generally work once the
+binaries are unpacked. Running `transformix` directly from a shell may need the variable set by
+hand; the release archives ship a script for this.
+
+Note that macOS strips `DYLD_*` variables from protected processes under SIP, which is a
+recurring source of confusion when the same setup works in one context and not another.
+
+## Where next
+
+Which spaces need elastix, and how a route between two spaces is chosen, is covered on the
+[bridging registrations](/docs/concepts/bridging/) page.
+[flybrains](/docs/tools/navis-flybrains/) is what actually invokes it from Python.
+
+Documentation and manual: [elastix.dev](https://elastix.dev/) and the
+[project wiki](https://github.com/SuperElastix/elastix/wiki).
+Source: [SuperElastix/elastix](https://github.com/SuperElastix/elastix).

--- a/content/en/docs/Tools/natverse.md
+++ b/content/en/docs/Tools/natverse.md
@@ -1,0 +1,47 @@
+---
+title: "natverse"
+linkTitle: "natverse"
+weight: 657
+description: >
+  The R toolchain — nat and its companion packages for importing, transforming, comparing
+  and plotting neurons.
+---
+
+The natverse is a collection of interoperable R packages for working with 3D neuroanatomical
+data. It covers much the same ground as [navis](/docs/tools/navis/) and its ecosystem does in
+Python, so which you reach for is usually decided by what the rest of your analysis is written
+in rather than by capability.
+
+The pieces you are most likely to want:
+
+`nat` is the core — reading, manipulating and plotting neurons and surfaces.
+`nat.templatebrains` and `nat.flybrains` provide the template spaces and the bridging and
+mirroring registrations between them, the R counterpart to
+[flybrains](/docs/tools/navis-flybrains/). `nat.nblast` implements
+[NBLAST](/docs/tools/nblast/). `neuprintr` queries [neuPrint](/docs/tools/neuprint/), and
+`elmr` supports EM–light-microscopy comparison.
+
+## Install
+
+```r
+install.packages('natmanager')
+natmanager::install('core')      # nat and the essentials
+natmanager::install('natverse')  # everything
+```
+
+## Transforms need CMTK
+
+The VFB and Jefferis lab registrations that `nat.flybrains` uses are CMTK transforms, so
+applying them needs [CMTK installed](/docs/tools/cmtk/) and its tools on your `PATH`. `nat`
+locates them with `cmtk.bindir()`; if that returns nothing, CMTK is either not installed or not
+where R can find it.
+
+VFB publishes the same transform set to both ecosystems, so a route computed here and one
+computed in Python agree — see [bridging registrations](/docs/concepts/bridging/) for what
+those routes are and what chaining them costs in accuracy.
+
+## Where next
+
+Full documentation: [natverse.org](https://natverse.org/), which links the reference manuals
+for each constituent package. The natverse paper is
+[Bates et al. (2020)](https://doi.org/10.7554/eLife.53350).

--- a/content/en/docs/Tools/navis-flybrains.md
+++ b/content/en/docs/Tools/navis-flybrains.md
@@ -52,7 +52,7 @@ The Jefferis lab and VFB transform collections are CMTK registrations, so using 
 [CMTK installed](/docs/tools/cmtk/) and on your `PATH`. The Janelia H5 transforms do not. If a
 transform route fails with CMTK missing, that is what it is telling you.
 
-The FANC and BANC transforms need [elastix](https://elastix.lumc.nl/index.php) instead.
+The FANC and BANC transforms need [elastix](/docs/tools/elastix/) instead.
 
 ## Where next
 

--- a/content/en/docs/Tools/navis-flybrains.md
+++ b/content/en/docs/Tools/navis-flybrains.md
@@ -1,0 +1,65 @@
+---
+title: "flybrains"
+linkTitle: "flybrains"
+weight: 653
+description: >
+  Template brains and bridging transforms for navis — move neurons and points between
+  Drosophila template spaces.
+---
+
+`flybrains` supplies `navis` with the *Drosophila* template brains and the transforms between
+them. Once it is imported, `navis.xform_brain` can move neurons, meshes or raw points between
+template spaces — FAFB to JRC2018F, hemibrain to JRC2018F, and so on — by finding a route
+through the registered transforms.
+
+VFB publishes its own bridging and mirroring transforms through this package, so the transform
+that moves a neuron inside VFB is the same one you get in your own analysis. The
+[bridging registrations](/docs/concepts/bridging/) page explains what those transforms are and
+how routes between spaces are chosen; this page is about installing and using them.
+
+## Install
+
+```sh
+pip3 install flybrains
+```
+
+The package itself is small: the transforms are downloaded separately, on request.
+
+## Quick start
+
+```python
+import navis
+import flybrains
+import numpy as np
+
+# One-off downloads -- pick the collections you need
+flybrains.download_jefferislab_transforms()   # CMTK, Jefferis lab
+flybrains.download_jrc_transforms()           # H5, Janelia brain
+flybrains.download_vfb_transforms()           # CMTK, VirtualFlyBrain.org
+flybrains.register_transforms()
+
+points = np.array([[429536, 205240, 38400]])
+navis.xform_brain(points, source='FAFB', target='JRC2018F')
+# array([[241.53969657, 100.99399233,  35.96977733]])
+```
+
+`flybrains.report()` lists what is actually available to you, across both the Python and R
+downloads — worth running when a transform you expected is not found.
+
+## CMTK is required for some transforms
+
+The Jefferis lab and VFB transform collections are CMTK registrations, so using them needs
+[CMTK installed](/docs/tools/cmtk/) and on your `PATH`. The Janelia H5 transforms do not. If a
+transform route fails with CMTK missing, that is what it is telling you.
+
+The FANC and BANC transforms need [elastix](https://elastix.lumc.nl/index.php) instead.
+
+## Where next
+
+Full documentation and the list of supported spaces:
+[navis-org/navis-flybrains](https://github.com/navis-org/navis-flybrains). The navis
+[transforms tutorial](https://navis-org.github.io/navis/stable/generated/gallery/6_misc/tutorial_misc_01_transforms/)
+covers applying them in practice.
+
+On the R side, [nat.templatebrains and nat.flybrains](/docs/tools/natverse/) provide the
+equivalent, drawing on the same transform collections.

--- a/content/en/docs/Tools/navis.md
+++ b/content/en/docs/Tools/navis.md
@@ -1,0 +1,51 @@
+---
+title: "navis"
+linkTitle: "navis"
+weight: 652
+description: >
+  The core Python library for reading, analysing, transforming and plotting neurons.
+---
+
+`navis` is the workhorse of the Python side of this toolchain. It represents neurons as
+skeletons, meshes or dotprops, and provides the operations you then want to perform on them:
+pruning and resampling, morphometrics, NBLAST similarity, plotting in 2D and 3D, and
+transformation between template spaces.
+
+Most of the other Python tools here produce or consume `navis` objects — `pymaid` returns
+CATMAID skeletons as `navis` neurons, `neuprint-python` does the same for neuPrint bodies, and
+[flybrains](/docs/tools/navis-flybrains/) plugs template-space transforms into
+`navis.xform_brain`. Learning `navis` first therefore pays off across the rest.
+
+## Install
+
+```sh
+pip3 install "navis[all]"
+```
+
+The `[all]` extra pulls in the optional dependencies, including those for 3D plotting. A plain
+`pip3 install navis` works if you only need the core.
+
+## Quick start
+
+```python
+import navis
+
+# navis ships example neurons: olfactory projection neurons from the hemibrain
+n = navis.example_neurons(1, kind='skeleton')
+n
+```
+
+That prints a summary — node count, cable length, soma, units — and confirms the install is
+working. `navis.example_neurons(5)` returns a `NeuronList`, the container used whenever you
+work on more than one neuron at a time.
+
+## Where next
+
+Three tutorials here go further: [exploring neurons in navis](/docs/tutorials/apis/navis/)
+covers the data types and how to manipulate them,
+[plotting](/docs/tutorials/apis/plotting/) covers visualisation, and
+[NBLAST](/docs/tutorials/apis/nblast/) covers morphological comparison. See also the
+[NBLAST](/docs/tools/nblast/) page here.
+
+Full documentation: [navis-org.github.io/navis](https://navis-org.github.io/navis/).
+Source: [navis-org/navis](https://github.com/navis-org/navis).

--- a/content/en/docs/Tools/nblast.md
+++ b/content/en/docs/Tools/nblast.md
@@ -1,0 +1,50 @@
+---
+title: "Running NBLAST"
+linkTitle: "NBLAST"
+weight: 658
+description: >
+  Scoring morphological similarity yourself, in navis or nat.nblast, rather than using
+  VFB's precomputed scores.
+---
+
+VFB precomputes NBLAST scores and exposes them through the "find similar" queries on the
+website, so you do not need to run NBLAST yourself to use them — the
+[NBLAST concept page](/docs/concepts/nblast/) explains what is covered and how to tell whether
+a given neuron has scores. This page is for when you want to score your own neurons, or score
+against a set VFB does not cover.
+
+NBLAST works on **dotprops**: neurons resampled into points with associated tangent vectors.
+Scoring is therefore a two-step business — convert, then compare — and both the resampling
+distance and the neighbourhood size affect the result. Neurons must also be in the same
+template space before the comparison means anything, which is where
+[flybrains](/docs/tools/navis-flybrains/) or `nat.flybrains` come in.
+
+## In Python, with navis
+
+```python
+import navis
+
+nl = navis.example_neurons(5)
+
+# Convert to dotprops first; resample and k affect the scores
+dps = navis.make_dotprops(nl, resample=1, k=5)
+
+scores = navis.nblast_allbyall(dps)
+```
+
+`navis.nblast()` compares one set against another where you do not want the all-by-all matrix.
+Scores are conventionally normalised against a self-self comparison, so a perfect match scores
+1.
+
+## In R, with nat.nblast
+
+`nat.nblast` is part of the [natverse](/docs/tools/natverse/) and installs with it.
+
+## Where next
+
+The [NBLAST tutorial](/docs/tutorials/apis/nblast/) works through a real comparison end to end,
+including preparing the dotprops and interpreting the resulting scores. For what the scores
+mean and how VFB uses them, see [NBLAST](/docs/concepts/nblast/).
+
+The method is described in
+[Costa et al. (2016)](https://doi.org/10.1016/j.neuron.2016.06.012).

--- a/content/en/docs/Tools/neuprint.md
+++ b/content/en/docs/Tools/neuprint.md
@@ -1,0 +1,59 @@
+---
+title: "neuPrint clients"
+linkTitle: "neuPrint clients"
+weight: 656
+description: >
+  neuprint-python and neuprintr — query the hemibrain, MANC and other connectomes hosted
+  at neuPrint.
+---
+
+[neuPrint](https://neuprint.janelia.org) is Janelia's connectome database, hosting the
+hemibrain, MANC, optic-lobe and male-CNS datasets. Both language ecosystems have a client for
+it: `neuprint-python` and, on the R side, `neuprintr`.
+
+Either needs an authentication token, which you get by logging in to neuPrint and copying it
+from your account page. The datasets themselves are public; the token identifies you to the
+server.
+
+## neuprint-python
+
+```sh
+pip3 install neuprint-python
+```
+
+```python
+import neuprint as neu
+
+client = neu.Client('https://neuprint.janelia.org',
+                    dataset='hemibrain:v1.1',
+                    token={your_token})
+```
+
+Most functions accept `neu.NeuronCriteria`, a filter over body IDs, types, instance names and
+regions of interest, which is how you select the neurons a query applies to.
+
+## neuprintr
+
+`neuprintr` is part of the [natverse](/docs/tools/natverse/) and is installed with it:
+
+```r
+install.packages('natmanager')
+natmanager::install('natverse')
+```
+
+## Which neurons am I looking at
+
+Body IDs are local to a neuPrint dataset. VFB assigns its own persistent identifiers to the
+same neurons and records the cross-references, so [VFB_connect](/docs/tools/vfb-connect/) can
+map between a neuPrint body ID and everything else VFB holds for that neuron — including
+imagery and its classification in the anatomy ontology.
+
+## Where next
+
+The [neuPrint tutorial](/docs/tutorials/apis/neuprint/) covers fetching neurons, synaptic
+partners and paths through the connectome, and plotting the resulting graphs. VFB's own
+connectivity data is described under [Data](/docs/data/).
+
+Full documentation:
+[neuprint-python](https://connectome-neuprint.github.io/neuprint-python/docs/) and
+[neuprintr](https://natverse.org/neuprintr/).

--- a/content/en/docs/Tools/pymaid.md
+++ b/content/en/docs/Tools/pymaid.md
@@ -1,0 +1,53 @@
+---
+title: "pymaid"
+linkTitle: "pymaid"
+weight: 655
+description: >
+  Python client for CATMAID, including the FAFB and other EM datasets VFB hosts.
+---
+
+`pymaid` talks to CATMAID servers and returns neurons as `navis` objects, so skeletons you pull
+from CATMAID drop straight into the rest of the Python toolchain. VFB hosts the public CATMAID
+instances for several connectomics datasets — see [what is
+available](https://catmaid.virtualflybrain.org/) — and those are open for read-only access
+without a token.
+
+## Install
+
+```sh
+pip3 install python-catmaid
+```
+
+Note the package name. There is an unrelated `pymaid` package on PyPI; installing that one will
+not give you this library.
+
+## Quick start
+
+VFB's CATMAID servers are public, so connecting needs no API token:
+
+```python
+import pymaid
+import navis
+
+# Connect to the VFB CATMAID server hosting the FAFB data
+rm = pymaid.connect_catmaid(server="https://fafb.catmaid.virtualflybrain.org/",
+                            api_token=None, max_threads=10)
+
+print(f'Server is running CATMAID version {rm.catmaid_version}')
+```
+
+With a connection established, `pymaid.get_neuron(16)` fetches a skeleton by its ID, returning
+a `CatmaidNeuron` that `navis` can plot, prune and compare like any other neuron.
+
+Skeleton IDs are local to each CATMAID instance and are not unique between them, which is why
+VFB gives every image its own persistent identifier. [VFB_connect](/docs/tools/vfb-connect/)
+can map between the two.
+
+## Where next
+
+The [pymaid tutorial](/docs/tutorials/apis/pymaid/) works through retrieving neurons, filtering
+them by name and lineage, and plotting the results.
+
+Full documentation: [pymaid.readthedocs.io](https://pymaid.readthedocs.io/).
+Source: [navis-org/pymaid](https://github.com/navis-org/pymaid).
+CATMAID itself: [catmaid.readthedocs.io](https://catmaid.readthedocs.io/en/stable/).

--- a/content/en/docs/Tools/vfb-connect.md
+++ b/content/en/docs/Tools/vfb-connect.md
@@ -1,0 +1,50 @@
+---
+title: "VFB_connect"
+linkTitle: "VFB_connect"
+weight: 651
+description: >
+  VFB's own Python client — query VFB's terms, images, connectivity and cross-references
+  from code.
+---
+
+`VFB_connect` is the Python client for the databases behind Virtual Fly Brain. A single object
+wraps connections and canned queries across all of VFB's open databases, so you can look up
+anatomy terms, resolve IDs between VFB and external resources such as CATMAID and neuPrint,
+retrieve connectivity, and download images without writing queries against each service
+yourself.
+
+If you are working with VFB data from Python, start here: most of the other tools on these
+pages consume data that `VFB_connect` can hand them.
+
+## Install
+
+```sh
+pip install vfb_connect
+```
+
+## Quick start
+
+```python
+from vfb_connect import vfb
+
+# Metadata for a class -- here, Kenyon cell
+vfb.term('FBbt_00003686')
+
+# Everything VFB knows in a named region
+vfb.get_terms_by_region('fan-shaped body')
+```
+
+Terms are addressed by their identifiers in CURIE form — `FBbt_00003686` above is a
+[Drosophila Anatomy Ontology](https://www.ebi.ac.uk/ols4/ontologies/fbbt) class, and VFB's own
+individuals use `VFB_` identifiers. Any report page on the website shows the identifier for
+what you are looking at, so the website is a convenient way to find the term you want before
+querying it from code.
+
+## Where next
+
+The [VFB connect API overview](/docs/tutorials/apis/vfb_api_overview/) tutorial covers the
+query surface in depth — term info, mapping between VFB and external IDs, connectivity and
+similarity queries. For the endpoints underneath it, see [VFB APIs](/docs/apis/).
+
+Full documentation: [vfb_connect.readthedocs.io](https://vfb_connect.readthedocs.io/en/stable/).
+Source: [VirtualFlyBrain/VFB_connect](https://github.com/VirtualFlyBrain/VFB_connect).

--- a/content/en/docs/Tutorials/APIs/_index.md
+++ b/content/en/docs/Tutorials/APIs/_index.md
@@ -9,4 +9,5 @@ description: >
 ---
 Worked examples for reaching VFB from code — `VFB_connect` for VFB's own data, and the wider Python
 and R toolchain (navis, pymaid, neuprint, natverse) for analysis and for data held elsewhere. For
-endpoint reference rather than worked examples, see [APIs](/docs/apis/).
+endpoint reference rather than worked examples, see [APIs](/docs/apis/); for installing
+these tools in the first place, and quick starts for each, see [Tools](/docs/tools/).


### PR DESCRIPTION
Adds a `Tools` section (weight 650, after VFB APIs) with a page per tool: what it is for, how to install it, enough code to confirm it works, then links to the project's own documentation and to our worked tutorial where one exists.

Covered: VFB_connect, navis, flybrains, CMTK, pymaid, the neuPrint clients (neuprint-python and neuprintr), the natverse, NBLAST and elastix.

### Why a separate section

There was scope to overlap three existing sections, so the index sets out the split: [VFB APIs](/docs/apis/) documents the endpoints VFB itself serves, [Tutorials](/docs/tutorials/) holds the worked examples, and [Resources](/docs/resources/) lists sites to browse rather than software to install. Each Tools page links to its tutorial rather than restating it, and `Tutorials/APIs` now links back.

Someone arriving with "how do I get VFB data into Python" previously had nowhere short to land: the tutorials assume the tools are already installed, and Resources lists data sites.

### On accuracy

Install commands and examples are taken from each project's own documentation or from our existing tutorials rather than written from memory. Two details are worth calling out because they are the kind that waste an afternoon:

- the pymaid page notes the PyPI name is `python-catmaid`, since installing `pymaid` gets you an unrelated package;
- the elastix page notes that navis looks for a `transformix` executable on `PATH` and the `lib` directory beside it, so it is the precompiled binaries that are needed rather than `itk-elastix` or the SimpleElastix bindings. That was checked against navis's own `transforms/elastix.py`.

### CMTK moves here

The CMTK page moves from `Tutorials/APIs`, where it sat awkwardly — it is an install guide, not a worked example. It carries an `aliases` entry so the URL it was published under keeps working, and the two Concepts links are repointed.

### Verified with a local build

`hugo` builds clean, all nine pages render, the CMTK alias redirect is generated, and every internal `/docs/` link in the new section resolves against a page that exists.

### One thing not fixed here

While checking that redirect I found that 13 existing pages use `alias:` in their front matter, where Hugo's key is `aliases:`. Those redirects are therefore not generated, and URLs including `/docs/tutorials/1_datatypes/`, `/docs/tutorials/0_vfb_api_overview/` and `/docs/tutorials/4_nblast/` currently 404. I used the correct key on the page I moved but left the other 13 alone to keep this diff reviewable — happy to follow up separately.
