### PR TITLE
Add backdated news article for the Columbia SCAPE larval proprioception video

### DIFF
--- a/content/en/blog/news/zuckerman_scape_larva_video.md
+++ b/content/en/blog/news/zuckerman_scape_larva_video.md
@@ -1,0 +1,17 @@
+---
+title: "Video: SCAPE microscopy catches proprioceptive neurons firing in a crawling fly larva"
+linkTitle: "Columbia SCAPE larval proprioception video"
+date: 2019-03-07
+description: >
+    A Columbia Zuckerman Institute video on SCAPE, a high-speed 3D microscope that recorded proprioceptive sensory neurons firing inside a freely crawling fruit fly larva.
+---
+
+Columbia University's Zuckerman Institute has released a video on SCAPE (swept confocally aligned planar excitation) microscopy, a high-speed 3D imaging technique developed at Columbia and used by the Hillman and Grueber labs to record individual proprioceptive neurons moving, stretching and firing inside free-roaming fruit fly larvae as they crawled. SCAPE forms 3D images by scanning a sample with a moving sheet of laser light through a single, stationary objective lens, reaching imaging speeds up to 500 times faster than conventional point-by-point scanning microscopes — fast enough to follow an unrestrained, crawling larva rather than requiring it to be immobilised or slowed down.
+
+{{< youtube id="9xHZkMxfB0o" autoplay="true" mute="true" class="video-embed" >}}
+
+The underlying study, led by biomedical engineer Elizabeth Hillman and neuroscientist Wesley Grueber, used SCAPE to simultaneously track a larva's changing 3D body shape and the activity of its proprioceptors — sensory neurons along the body wall that report the body's position and movement back to the brain — while it crawled unconstrained. [Vaadia et al. (2019)](https://doi.org/10.1016/j.cub.2019.01.060) found that different proprioceptor subtypes fire in a consistent sequence tied to specific phases of each crawl cycle, some as a body segment stretches and others as it compresses, together providing continuous coverage of the body's changing shape throughout crawling and other movements — evidence against the earlier assumption that these neurons simply act as redundant backups for one another.
+
+Virtual Fly Brain integrates structural connectomics and neuroanatomy data across the fly nervous system, including the larval stage; this kind of live functional imaging is a complementary approach, showing how identified circuits actually fire as the animal moves rather than only how they are wired.
+
+Video: ["High-speed, 3D SCAPE Microscope Captures Stunning, Live Videos of Fruit Fly Nerve Cells in Action"](https://www.youtube.com/watch?v=9xHZkMxfB0o), © Columbia University's Zuckerman Institute. Study: Vaadia RD, Li W, Voleti V, Singhania A, Hillman EMC, Grueber WB, "Characterization of Proprioceptive System Dynamics in Behaving *Drosophila* Larvae Using High-Speed Volumetric Microscopy," *Current Biology* 29(6):935–944.e4 (2019), [doi:10.1016/j.cub.2019.01.060](https://doi.org/10.1016/j.cub.2019.01.060) (open access, CC BY 4.0).


### PR DESCRIPTION
Adds a backdated news post for Columbia's Zuckerman Institute video on SCAPE microscopy recording proprioceptive neuron activity in freely crawling fly larvae, following the established pattern for the other backdated video posts (Wellcome, HHMI, Cardona lab, Lo lab).

Licence checks:
- Video: YouTube oEmbed confirms `9xHZkMxfB0o` is embeddable.
- Zuckerman Institute article: no explicit reuse licence, so paraphrased rather than quoted.
- Paper (Vaadia et al. 2019, *Current Biology*, DOI 10.1016/j.cub.2019.01.060): confirmed via Crossref as CC BY 4.0 (open access) for the version of record.

The closing paragraph deliberately avoids claiming this specific dataset is "integrated into VFB" — it's functional imaging, not a structural reconstruction — and instead connects it to VFB's actual scope (structural connectomics, including larval) without overstating overlap.

## Test plan
- [ ] Confirm the video embed plays and isn't clipped
- [ ] Confirm the DOI link resolves
- [ ] Spot-check the summary against the paper/press release for accuracy
