### PR TITLE
MADI3D's macOS CMTK setup has shipped

### DIFF
--- a/content/en/docs/Tools/cmtk.md
+++ b/content/en/docs/Tools/cmtk.md
@@ -103,11 +103,15 @@ the `apt` command from the Linux section above.
 ## A note on MADI3D
 
 MADI3D manages its own copy of CMTK rather than using one already on your `PATH`, so installing
-it there does not give you CMTK for navis-flybrains or the natverse, and vice versa. Its
-automatic setup currently covers Windows and native Ubuntu/Debian; macOS support is
-[proposed in PR #38](https://github.com/sandorbx/MADI3D/pull/38). Until that is released, the
-script above is the route on macOS. MADI3D also offers "use an existing CMTK installation",
-which will happily point at the install the script creates.
+it there does not give you CMTK for navis-flybrains or the natverse, and vice versa. That is
+why this page is still the route if you want CMTK for your own analysis, whether or not you
+also run MADI3D.
+
+Its automatic setup covers Windows, native Ubuntu/Debian and — since
+[v0.31.2-beta](https://github.com/sandorbx/MADI3D/releases/tag/v0.31.2-beta) — Apple Silicon
+macOS, where it downloads and verifies the same upstream build this page uses and unpacks it
+inside its own storage, needing no administrator rights. MADI3D also offers "use an existing
+CMTK installation", which will happily point at the install the script creates.
 
 ## Verifying
 


### PR DESCRIPTION
The CMTK page said MADI3D's macOS support was "proposed" and that the script here was the route "until that is released". It shipped in [v0.31.2-beta](https://github.com/sandorbx/MADI3D/releases/tag/v0.31.2-beta), so this points at the release rather than the pull request.

It also reframes why the script still matters, which is no longer a matter of waiting: MADI3D keeps its CMTK inside its own storage rather than on `PATH`, so it does not serve navis-flybrains or the natverse whether or not it has shipped. Anyone wanting CMTK for their own analysis still wants this page.

### Intel guidance deliberately unchanged

The released automatic setup is Apple Silicon only, so Intel readers are still pointed at the NITRC contributed build. Two things say so:

- on `sandorbx/MADI3D` `main`, `_macos_architecture()` still raises for `x86_64`, and the setup dialog still reads "Apple Silicon only; Intel Macs should choose an existing CMTK installation";
- `jefferis/cmtk` `natdev-latest` publishes only `cmtk-3.4.0-dev-macos-arm64-gcd.pkg` and `.tar.gz` — there is no x86_64 macOS build for it to fetch.

The v0.31.2-beta notes do have a "macOS Intel" section, but it covers installing the MADI3D application from `MADI3D-macOS-x64.zip`, which was already the case in 0.31.1, rather than CMTK setup. Worth a second pair of eyes: if an Intel path does exist, this section should change too.

Verified with a local `hugo` build.
